### PR TITLE
fix: Respect output format in all commands

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,8 +18,8 @@ require (
 	github.com/maxatome/go-testdeep v1.14.0
 	github.com/maxatome/tdhttpmock v1.0.0
 	github.com/ovh/go-ovh v1.9.0
-	github.com/spf13/cobra v1.9.1
-	github.com/spf13/pflag v1.0.6
+	github.com/spf13/cobra v1.10.1
+	github.com/spf13/pflag v1.0.9
 	golang.org/x/exp v0.0.0-20220909182711-5c715a9e8561
 	golang.org/x/sync v0.16.0
 	gopkg.in/ini.v1 v1.67.0

--- a/go.sum
+++ b/go.sum
@@ -127,8 +127,12 @@ github.com/shopspring/decimal v1.3.1 h1:2Usl1nmF/WZucqkFZhnfFYxxxu8LG21F6nPQBE5g
 github.com/shopspring/decimal v1.3.1/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
 github.com/spf13/cobra v1.9.1 h1:CXSaggrXdbHK9CF+8ywj8Amf7PBRmPCOJugH954Nnlo=
 github.com/spf13/cobra v1.9.1/go.mod h1:nDyEzZ8ogv936Cinf6g1RU9MRY64Ir93oCnqb9wxYW0=
+github.com/spf13/cobra v1.10.1 h1:lJeBwCfmrnXthfAupyUTzJ/J4Nc1RsHC/mSRU2dll/s=
+github.com/spf13/cobra v1.10.1/go.mod h1:7SmJGaTHFVBY0jW4NXGluQoLvhqFQM+6XSKD+P4XaB0=
 github.com/spf13/pflag v1.0.6 h1:jFzHGLGAlb3ruxLB8MhbI6A8+AQX/2eW4qeyNZXNp2o=
 github.com/spf13/pflag v1.0.6/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=
+github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/ugorji/go/codec v1.2.7 h1:YPXUKf7fYbp/y8xloBqZOw2qaVggbfwMlI8WM3wZUJ0=

--- a/internal/cmd/account_test.go
+++ b/internal/cmd/account_test.go
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: 2025 OVH SAS <opensource@ovh.net>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd_test
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/jarcoal/httpmock"
+	"github.com/maxatome/go-testdeep/td"
+	"github.com/maxatome/tdhttpmock"
+	"github.com/ovh/ovhcloud-cli/internal/cmd"
+)
+
+func (ms *MockSuite) TestOauth2ClientCreateCmd(assert, require *td.T) {
+	httpmock.RegisterMatcherResponder(http.MethodPost,
+		"https://eu.api.ovh.com/1.0/me/api/oauth2/client",
+		tdhttpmock.JSONBody(td.JSON(`
+			{
+				"callbackUrls": [
+					"https://example.com/callback"
+				],
+				"description": "Test OAuth2 client",
+				"flow": "AUTHORIZATION_CODE",
+				"name": "test-client"
+			}`),
+		),
+		httpmock.NewStringResponder(200, `{"clientId": "client-12345", "clientSecret": "sicrette"}`),
+	)
+
+	out, err := cmd.Execute("account", "api", "oauth2", "client", "create", "--name", "test-client",
+		"--flow", "AUTHORIZATION_CODE", "--callback-urls", "https://example.com/callback",
+		"--description", "Test OAuth2 client", "--json")
+	require.CmpNoError(err)
+	assert.Cmp(json.RawMessage(out), td.JSON(`
+		{
+			"message": "✅ OAuth2 client created successfully (client ID: client-12345, client secret: sicrette)",
+			"details": {
+				"clientId": "client-12345",
+				"clientSecret": "sicrette"
+			}
+		}`),
+	)
+}

--- a/internal/cmd/cloud_rancher_test.go
+++ b/internal/cmd/cloud_rancher_test.go
@@ -5,6 +5,7 @@
 package cmd_test
 
 import (
+	"encoding/json"
 	"net/http"
 
 	"github.com/jarcoal/httpmock"
@@ -29,7 +30,69 @@ func (ms *MockSuite) TestCloudRancherCreateCmd(assert, require *td.T) {
 	)
 
 	out, err := cmd.Execute("cloud", "rancher", "create", "--cloud-project", "fakeProjectID", "--name", "test-rancher", "--plan", "OVHCLOUD_EDITION", "--version", "2.11.3")
-
 	require.CmpNoError(err)
 	assert.String(out, `✅ Rancher test-rancher created successfully (id: rancher-12345)`)
+}
+
+func (ms *MockSuite) TestCloudRancherCreateCmdJSONFormat(assert, require *td.T) {
+	httpmock.RegisterMatcherResponder(http.MethodPost,
+		"https://eu.api.ovh.com/v2/publicCloud/project/fakeProjectID/rancher",
+		tdhttpmock.JSONBody(td.JSON(`
+			{
+				"targetSpec": {
+					"name": "test-rancher",
+					"plan": "OVHCLOUD_EDITION",
+					"version": "2.11.3"
+				}
+			}`),
+		),
+		httpmock.NewStringResponder(200, `{"id": "rancher-12345"}`),
+	)
+
+	out, err := cmd.Execute("cloud", "rancher", "create", "--cloud-project", "fakeProjectID", "--name", "test-rancher", "--plan", "OVHCLOUD_EDITION", "--version", "2.11.3", "--json")
+	require.CmpNoError(err)
+	assert.Cmp(json.RawMessage(out), td.JSON(`{"details":{"id": "rancher-12345"}, "message": "✅ Rancher test-rancher created successfully (id: rancher-12345)"}`))
+}
+
+func (ms *MockSuite) TestCloudRancherCreateCmdYAMLFormat(assert, require *td.T) {
+	httpmock.RegisterMatcherResponder(http.MethodPost,
+		"https://eu.api.ovh.com/v2/publicCloud/project/fakeProjectID/rancher",
+		tdhttpmock.JSONBody(td.JSON(`
+			{
+				"targetSpec": {
+					"name": "test-rancher",
+					"plan": "OVHCLOUD_EDITION",
+					"version": "2.11.3"
+				}
+			}`),
+		),
+		httpmock.NewStringResponder(200, `{"id": "rancher-12345"}`),
+	)
+
+	out, err := cmd.Execute("cloud", "rancher", "create", "--cloud-project", "fakeProjectID", "--name", "test-rancher", "--plan", "OVHCLOUD_EDITION", "--version", "2.11.3", "--yaml")
+	require.CmpNoError(err)
+	assert.String(out, `details:
+  id: rancher-12345
+message: '✅ Rancher test-rancher created successfully (id: rancher-12345)'
+`)
+}
+
+func (ms *MockSuite) TestCloudRancherCreateCmdCustomFormat(assert, require *td.T) {
+	httpmock.RegisterMatcherResponder(http.MethodPost,
+		"https://eu.api.ovh.com/v2/publicCloud/project/fakeProjectID/rancher",
+		tdhttpmock.JSONBody(td.JSON(`
+			{
+				"targetSpec": {
+					"name": "test-rancher",
+					"plan": "OVHCLOUD_EDITION",
+					"version": "2.11.3"
+				}
+			}`),
+		),
+		httpmock.NewStringResponder(200, `{"id": "rancher-12345"}`),
+	)
+
+	out, err := cmd.Execute("cloud", "rancher", "create", "--cloud-project", "fakeProjectID", "--name", "test-rancher", "--plan", "OVHCLOUD_EDITION", "--version", "2.11.3", "--format", "[details.id]")
+	require.CmpNoError(err)
+	assert.String(out, `["rancher-12345"]`)
 }

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -72,10 +72,6 @@ func PostExecute() {
 	flags.OutputFormatConfig = display.OutputFormat{}
 	flags.ParametersViaEditor = false
 	flags.ParametersFile = ""
-
-	// Reinit root command to mark persistent flags as not parsed
-	rootCmd.ResetFlags()
-	initRootCmd()
 }
 
 func initRootCmd() {
@@ -91,7 +87,7 @@ func initRootCmd() {
 
 	rootCmd.PersistentPreRun = func(cmd *cobra.Command, args []string) {
 		if http.Client == nil {
-			display.ExitError("API client is not initialized, please run `ovhcloud login` to authenticate")
+			display.OutputError(&flags.OutputFormatConfig, "API client is not initialized, please run `ovhcloud login` to authenticate")
 			os.Exit(1) // Force os.Exit even in WASM mode
 		}
 	}

--- a/internal/display/common.go
+++ b/internal/display/common.go
@@ -14,3 +14,10 @@ type OutputFormat struct {
 	JsonOutput, YamlOutput, InteractiveOutput bool
 	CustomFormat                              string
 }
+
+type OutputMessage struct {
+	Message string `json:"message,omitempty"`
+	Error   bool   `json:"error,omitempty"`
+	Warning bool   `json:"warning,omitempty"`
+	Details any    `json:"details,omitempty"`
+}

--- a/internal/display/display_wasm.go
+++ b/internal/display/display_wasm.go
@@ -20,7 +20,7 @@ import (
 func renderCustomFormat(value any, format string) {
 	ev, err := gval.Full(filters.AdditionalEvaluators...).NewEvaluable(format)
 	if err != nil {
-		ExitError("invalid format given: %s", err)
+		exitError("invalid format given: %s", err)
 		return
 	}
 
@@ -29,13 +29,13 @@ func renderCustomFormat(value any, format string) {
 		for _, val := range value.([]map[string]any) {
 			out, err := ev(context.Background(), val)
 			if err != nil {
-				ExitError("couldn't extract data according to given format: %s", err)
+				exitError("couldn't extract data according to given format: %s", err)
 				return
 			}
 
 			outBytes, err := json.Marshal(out)
 			if err != nil {
-				ExitError("error marshalling result")
+				exitError("error marshalling result")
 				return
 			}
 			ResultString = string(outBytes)
@@ -43,13 +43,13 @@ func renderCustomFormat(value any, format string) {
 	default:
 		out, err := ev(context.Background(), value)
 		if err != nil {
-			ExitError("couldn't extract data according to given format: %s", err)
+			exitError("couldn't extract data according to given format: %s", err)
 			return
 		}
 
 		outBytes, err := json.Marshal(out)
 		if err != nil {
-			ExitError("error marshalling result")
+			exitError("error marshalling result")
 			return
 		}
 		ResultString = string(outBytes)
@@ -63,7 +63,7 @@ func RenderTable(values []map[string]any, columnsToDisplay []string, outputForma
 	}
 
 	if err := prettyPrintJSON(values); err != nil {
-		ExitError("error displaying JSON results: %s", err)
+		exitError("error displaying JSON results: %s", err)
 		return
 	}
 }
@@ -72,12 +72,12 @@ func RenderConfigTable(cfg *ini.File) {
 	// TODO: untested
 	output := map[string]any{}
 	if err := cfg.MapTo(&output); err != nil {
-		ExitError("failed to extract config to map: %s", err)
+		exitError("failed to extract config to map: %s", err)
 		return
 	}
 
 	if err := prettyPrintJSON(output); err != nil {
-		ExitError("error displaying JSON results: %s", err)
+		exitError("error displaying JSON results: %s", err)
 		return
 	}
 }
@@ -100,19 +100,27 @@ func OutputObject(value map[string]any, serviceName, templateContent string, out
 	}
 
 	if err := prettyPrintJSON(value); err != nil {
-		ExitError("error displaying JSON results: %s", err)
+		exitError("error displaying JSON results: %s", err)
 		return
 	}
 }
 
-func ExitError(message string, params ...any) {
+func exitError(message string, params ...any) {
 	ResultError = fmt.Errorf("🛑 "+message+"\n", params...)
 }
 
-func ExitWarning(message string, params ...any) {
-	ResultError = fmt.Errorf("🟠 "+message+"\n", params...)
+func outputf(message string, params ...any) {
+	ResultString = fmt.Sprintf(message, params...)
 }
 
-func Outputf(message string, params ...any) {
-	ResultString = fmt.Sprintf(message, params...)
+func OutputInfo(outputFormat *OutputFormat, details any, message string, params ...any) {
+	outputf(message, params...)
+}
+
+func OutputError(outputFormat *OutputFormat, message string, params ...any) {
+	exitError(message, params...)
+}
+
+func OutputWarning(outputFormat *OutputFormat, message string, params ...any) {
+	exitError(message, params...)
 }

--- a/internal/display/login.go
+++ b/internal/display/login.go
@@ -62,7 +62,7 @@ func RunLoginInput(customEndpoint bool) map[string]string {
 	p := tea.NewProgram(mod)
 
 	if _, err := p.Run(); err != nil {
-		ExitError(err.Error())
+		exitError(err.Error())
 	}
 
 	if customEndpoint {

--- a/internal/display/login_picker.go
+++ b/internal/display/login_picker.go
@@ -9,7 +9,6 @@ package display
 import (
 	"fmt"
 	"io"
-	"os"
 	"strings"
 
 	"github.com/charmbracelet/bubbles/list"
@@ -132,8 +131,7 @@ func RunLoginPicker(question string, choices []string) string {
 	}
 
 	if _, err := tea.NewProgram(m).Run(); err != nil {
-		fmt.Println("Error running program:", err)
-		os.Exit(1)
+		exitError("Error running program: %s", err)
 	}
 
 	return m.choice

--- a/internal/editor/editor.go
+++ b/internal/editor/editor.go
@@ -5,14 +5,9 @@
 package editor
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
-	"slices"
-
-	"github.com/ovh/go-ovh/ovh"
-	"github.com/ovh/ovhcloud-cli/internal/openapi"
 )
 
 const defaultEditor = "vi"
@@ -51,49 +46,4 @@ func EditValueWithEditor(value []byte) ([]byte, error) {
 	}
 
 	return b, nil
-}
-
-func EditResource(client *ovh.Client, path, url string, openapiSpec []byte) error {
-	// Fetch resource
-	var object map[string]any
-	if err := client.Get(url, &object); err != nil {
-		return fmt.Errorf("error fetching resource %s: %w", url, err)
-	}
-
-	// Filter editable fields
-	editableBody, err := openapi.FilterEditableFields(
-		openapiSpec,
-		path,
-		"put",
-		object,
-	)
-	if err != nil {
-		return fmt.Errorf("failed to extract writable properties: %w", err)
-	}
-
-	// Format editable body
-	editableOutput, err := json.MarshalIndent(editableBody, "", "  ")
-	if err != nil {
-		return fmt.Errorf("failed to marshal writable body: %w", err)
-	}
-
-	// Edit value
-	updatedBody, err := EditValueWithEditor(editableOutput)
-	if err != nil {
-		return fmt.Errorf("failed to edit properties: %w", err)
-	}
-
-	if slices.Equal(updatedBody, editableOutput) {
-		fmt.Println("\n🟠 Resource not updated, exiting")
-		return nil
-	}
-
-	// Update API call
-	if err := client.Put(url, json.RawMessage(updatedBody), nil); err != nil {
-		return fmt.Errorf("failed to update resource: %w", err)
-	}
-
-	fmt.Println("✅ Resource updated succesfully ...")
-
-	return nil
 }

--- a/internal/services/account/account.go
+++ b/internal/services/account/account.go
@@ -46,13 +46,17 @@ func CreateOAuth2Client(cmd *cobra.Command, args []string) {
 		[]string{"name", "description", "flow"},
 	)
 	if err != nil {
-		display.ExitError("failed to create OAuth2 client: %s", err)
+		display.OutputError(&flags.OutputFormatConfig, "failed to create OAuth2 client: %s", err)
 		return
 	}
 
-	fmt.Println("✅ OAuth2 client created successfully")
-	fmt.Printf("Client ID: %s\n", client["clientId"].(string))
-	fmt.Printf("Client Secret: %s\n", client["clientSecret"].(string))
+	display.OutputInfo(
+		&flags.OutputFormatConfig,
+		client,
+		"✅ OAuth2 client created successfully (client ID: %s, client secret: %s)",
+		client["clientId"],
+		client["clientSecret"],
+	)
 }
 
 func ListOAuth2Clients(_ *cobra.Command, _ []string) {
@@ -68,11 +72,11 @@ func DeleteOauth2Client(_ *cobra.Command, args []string) {
 	endpoint := fmt.Sprintf("/me/api/oauth2/client/%s", url.PathEscape(args[0]))
 
 	if err := httpLib.Client.Delete(endpoint, nil); err != nil {
-		display.ExitError("failed to delete OAuth2 client: %s", err)
+		display.OutputError(&flags.OutputFormatConfig, "failed to delete OAuth2 client: %s", err)
 		return
 	}
 
-	fmt.Printf("✅ OAuth2 client '%s' deleted successfully\n", args[0])
+	display.OutputInfo(&flags.OutputFormatConfig, nil, "✅ OAuth2 client '%s' deleted successfully", args[0])
 }
 
 func EditOauth2Client(cmd *cobra.Command, args []string) {
@@ -83,7 +87,7 @@ func EditOauth2Client(cmd *cobra.Command, args []string) {
 		Oauth2ClientSpec,
 		assets.MeOpenapiSchema,
 	); err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 }

--- a/internal/services/cloud/cloud_container_registry.go
+++ b/internal/services/cloud/cloud_container_registry.go
@@ -41,7 +41,7 @@ var (
 func ListContainerRegistries(_ *cobra.Command, _ []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
@@ -49,14 +49,14 @@ func ListContainerRegistries(_ *cobra.Command, _ []string) {
 	endpoint := fmt.Sprintf("/cloud/project/%s/containerRegistry", projectID)
 	body, err := httpLib.FetchArray(endpoint, "")
 	if err != nil {
-		display.ExitError("failed to fetch results: %s", err)
+		display.OutputError(&flags.OutputFormatConfig, "failed to fetch results: %s", err)
 		return
 	}
 
 	// Fetch cloud project regions
 	regions, err := fetchProjectRegions(projectID)
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
@@ -67,7 +67,7 @@ func ListContainerRegistries(_ *cobra.Command, _ []string) {
 		// Fetch plan details for each registry
 		var plan map[string]any
 		if err := httpLib.Client.Get(fmt.Sprintf("%s/%s/plan", endpoint, url.PathEscape(objMap["id"].(string))), &plan); err != nil {
-			display.ExitError("error fetching plan details: %s", err)
+			display.OutputError(&flags.OutputFormatConfig, "error fetching plan details: %s", err)
 			return
 		}
 		objMap["plan"] = plan
@@ -85,7 +85,7 @@ func ListContainerRegistries(_ *cobra.Command, _ []string) {
 
 	objects, err = filtersLib.FilterLines(objects, flags.GenericFilters)
 	if err != nil {
-		display.ExitError("failed to filter results: %s", err)
+		display.OutputError(&flags.OutputFormatConfig, "failed to filter results: %s", err)
 		return
 	}
 
@@ -95,7 +95,7 @@ func ListContainerRegistries(_ *cobra.Command, _ []string) {
 func GetContainerRegistry(_ *cobra.Command, args []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
@@ -103,14 +103,14 @@ func GetContainerRegistry(_ *cobra.Command, args []string) {
 	endpoint := fmt.Sprintf("/cloud/project/%s/containerRegistry/%s", projectID, url.PathEscape(args[0]))
 	var object map[string]any
 	if err := httpLib.Client.Get(endpoint, &object); err != nil {
-		display.ExitError("error fetching %s: %s", endpoint, err)
+		display.OutputError(&flags.OutputFormatConfig, "error fetching %s: %s", endpoint, err)
 		return
 	}
 
 	// Fetch plan details
 	var plan map[string]any
 	if err := httpLib.Client.Get(endpoint+"/plan", &plan); err != nil {
-		display.ExitError("error fetching plan details: %s", err)
+		display.OutputError(&flags.OutputFormatConfig, "error fetching plan details: %s", err)
 		return
 	}
 	object["plan"] = plan
@@ -120,12 +120,12 @@ func GetContainerRegistry(_ *cobra.Command, args []string) {
 
 	usedFloat, err := object["size"].(json.Number).Float64()
 	if err != nil {
-		display.ExitError("error parsing used storage: %s", err)
+		display.OutputError(&flags.OutputFormatConfig, "error parsing used storage: %s", err)
 		return
 	}
 	availableFloat, err := planLimits["imageStorage"].(json.Number).Float64()
 	if err != nil {
-		display.ExitError("error parsing available storage: %s", err)
+		display.OutputError(&flags.OutputFormatConfig, "error parsing available storage: %s", err)
 		return
 	}
 	object["usage"] = map[string]any{
@@ -139,7 +139,7 @@ func GetContainerRegistry(_ *cobra.Command, args []string) {
 func EditContainerRegistry(cmd *cobra.Command, args []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
@@ -150,7 +150,7 @@ func EditContainerRegistry(cmd *cobra.Command, args []string) {
 		map[string]any{"name": CloudContainerRegistryName},
 		assets.CloudOpenapiSchema,
 	); err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 }
@@ -158,7 +158,7 @@ func EditContainerRegistry(cmd *cobra.Command, args []string) {
 func CreateContainerRegistry(cmd *cobra.Command, args []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
@@ -172,25 +172,25 @@ func CreateContainerRegistry(cmd *cobra.Command, args []string) {
 		[]string{"name", "region"},
 	)
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
-	fmt.Printf("✅ Container registry '%s' created successfully\n", registry["id"])
+	display.OutputInfo(&flags.OutputFormatConfig, registry, "✅ Container registry '%s' created successfully", registry["id"])
 }
 
 func DeleteContainerRegistry(_ *cobra.Command, args []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
 	endpoint := fmt.Sprintf("/cloud/project/%s/containerRegistry/%s", projectID, url.PathEscape(args[0]))
 	if err := httpLib.Client.Delete(endpoint, nil); err != nil {
-		display.ExitError("failed to delete container registry: %s", err)
+		display.OutputError(&flags.OutputFormatConfig, "failed to delete container registry: %s", err)
 		return
 	}
 
-	fmt.Println("✅ Container registry deleted successfully")
+	display.OutputInfo(&flags.OutputFormatConfig, nil, "✅ Container registry deleted successfully")
 }

--- a/internal/services/cloud/cloud_database.go
+++ b/internal/services/cloud/cloud_database.go
@@ -77,7 +77,7 @@ type (
 func ListCloudDatabases(_ *cobra.Command, _ []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
@@ -87,7 +87,7 @@ func ListCloudDatabases(_ *cobra.Command, _ []string) {
 func GetCloudDatabase(_ *cobra.Command, args []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
@@ -97,7 +97,7 @@ func GetCloudDatabase(_ *cobra.Command, args []string) {
 func CreateDatabase(cmd *cobra.Command, args []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
@@ -110,7 +110,7 @@ func CreateDatabase(cmd *cobra.Command, args []string) {
 	for _, node := range DatabaseSpec.CLINodesList {
 		parts := strings.Split(node, ":")
 		if len(parts) != 2 {
-			display.ExitError("invalid node format: %s (expected format: flavor1:region1,flavor2:region2...)", node)
+			display.OutputError(&flags.OutputFormatConfig, "invalid node format: %s (expected format: flavor1:region1,flavor2:region2...)", node)
 			return
 		}
 		DatabaseSpec.NodesList = append(DatabaseSpec.NodesList, databaseNode{
@@ -129,33 +129,33 @@ func CreateDatabase(cmd *cobra.Command, args []string) {
 		assets.CloudOpenapiSchema,
 		[]string{"version", "plan"})
 	if err != nil {
-		display.ExitError("failed to create database: %s", err)
+		display.OutputError(&flags.OutputFormatConfig, "failed to create database: %s", err)
 		return
 	}
 
-	display.Outputf("✅ Database created successfully (id: %s)", database["id"])
+	display.OutputInfo(&flags.OutputFormatConfig, database, "✅ Database created successfully (id: %s)", database["id"])
 }
 
 func DeleteDatabase(cmd *cobra.Command, args []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
 	// Fetch database service to retrieve the engine
 	var databaseService map[string]any
 	if err := httpLib.Client.Get(fmt.Sprintf("/cloud/project/%s/database/service/%s", projectID, url.PathEscape(args[0])), &databaseService); err != nil {
-		display.ExitError("failed to fetch database service: %s", err)
+		display.OutputError(&flags.OutputFormatConfig, "failed to fetch database service: %s", err)
 		return
 	}
 
 	// Delete the database
 	endpoint := fmt.Sprintf("/cloud/project/%s/database/%s/%s", projectID, url.PathEscape(databaseService["engine"].(string)), url.PathEscape(args[0]))
 	if err := httpLib.Client.Delete(endpoint, nil); err != nil {
-		display.ExitError("failed to delete database: %s", err)
+		display.OutputError(&flags.OutputFormatConfig, "failed to delete database: %s", err)
 		return
 	}
 
-	display.Outputf("✅ Database deleted successfully")
+	display.OutputInfo(&flags.OutputFormatConfig, nil, "✅ Database deleted successfully")
 }

--- a/internal/services/cloud/cloud_instance.go
+++ b/internal/services/cloud/cloud_instance.go
@@ -120,7 +120,7 @@ var (
 func ListInstances(_ *cobra.Command, _ []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 	common.ManageListRequest(fmt.Sprintf("/cloud/project/%s/instance", projectID), "id", cloudprojectInstanceColumnsToDisplay, flags.GenericFilters)
@@ -129,7 +129,7 @@ func ListInstances(_ *cobra.Command, _ []string) {
 func GetInstance(_ *cobra.Command, args []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 	common.ManageObjectRequest(fmt.Sprintf("/cloud/project/%s/instance", projectID), args[0], cloudInstanceTemplate)
@@ -138,7 +138,7 @@ func GetInstance(_ *cobra.Command, args []string) {
 func SetInstanceName(_ *cobra.Command, args []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
@@ -147,107 +147,107 @@ func SetInstanceName(_ *cobra.Command, args []string) {
 		"instanceName": args[1],
 	}
 	if err := httpLib.Client.Put(endpoint, body, nil); err != nil {
-		display.ExitError("error renaming instance %q: %s\n", args[0], err)
+		display.OutputError(&flags.OutputFormatConfig, "error renaming instance %q: %s", args[0], err)
 		return
 	}
 
-	fmt.Printf("✅ Instance %s renamed to %s\n", args[0], args[1])
+	display.OutputInfo(&flags.OutputFormatConfig, nil, "✅ Instance %s renamed to %s", args[0], args[1])
 }
 
 func StartInstance(_ *cobra.Command, args []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
 	endpoint := fmt.Sprintf("/cloud/project/%s/instance/%s/start", projectID, url.PathEscape(args[0]))
 
 	if err := httpLib.Client.Post(endpoint, nil, nil); err != nil {
-		display.ExitError("error starting instance %q: %s\n", args[0], err)
+		display.OutputError(&flags.OutputFormatConfig, "error starting instance %q: %s", args[0], err)
 		return
 	}
 
-	fmt.Println("\n⚡️ Instance starting ...")
+	display.OutputInfo(&flags.OutputFormatConfig, nil, "⚡️ Instance starting…")
 }
 
 func StopInstance(_ *cobra.Command, args []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
 	endpoint := fmt.Sprintf("/cloud/project/%s/instance/%s/stop", projectID, url.PathEscape(args[0]))
 
 	if err := httpLib.Client.Post(endpoint, nil, nil); err != nil {
-		display.ExitError("error stopping instance %q: %s\n", args[0], err)
+		display.OutputError(&flags.OutputFormatConfig, "error stopping instance %q: %s", args[0], err)
 		return
 	}
 
-	fmt.Println("\n⚡️ Instance stopping ...")
+	display.OutputInfo(&flags.OutputFormatConfig, nil, "⚡️ Instance stopping…")
 }
 
 func ShelveInstance(_ *cobra.Command, args []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
 	endpoint := fmt.Sprintf("/cloud/project/%s/instance/%s/shelve", projectID, url.PathEscape(args[0]))
 
 	if err := httpLib.Client.Post(endpoint, nil, nil); err != nil {
-		display.ExitError("error shelving instance %q: %s\n", args[0], err)
+		display.OutputError(&flags.OutputFormatConfig, "error shelving instance %q: %s", args[0], err)
 		return
 	}
 
-	fmt.Println("\n⚡️ Instance is being shelved ...")
+	display.OutputInfo(&flags.OutputFormatConfig, nil, "⚡️ Instance is being shelved…")
 }
 
 func UnshelveInstance(_ *cobra.Command, args []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
 	endpoint := fmt.Sprintf("/cloud/project/%s/instance/%s/unshelve", projectID, url.PathEscape(args[0]))
 
 	if err := httpLib.Client.Post(endpoint, nil, nil); err != nil {
-		display.ExitError("error unshelving instance %q: %s\n", args[0], err)
+		display.OutputError(&flags.OutputFormatConfig, "error unshelving instance %q: %s", args[0], err)
 		return
 	}
 
-	fmt.Println("\n⚡️ Instance is being unshelved ...")
+	display.OutputInfo(&flags.OutputFormatConfig, nil, "⚡️ Instance is being unshelved…")
 }
 
 func ResumeInstance(_ *cobra.Command, args []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
 	endpoint := fmt.Sprintf("/cloud/project/%s/instance/%s/resume", projectID, url.PathEscape(args[0]))
 
 	if err := httpLib.Client.Post(endpoint, nil, nil); err != nil {
-		display.ExitError("error resuming instance %q: %s\n", args[0], err)
+		display.OutputError(&flags.OutputFormatConfig, "error resuming instance %q: %s", args[0], err)
 		return
 	}
 
-	fmt.Println("\n⚡️ Instance is being resumed ...")
+	display.OutputInfo(&flags.OutputFormatConfig, nil, "⚡️ Instance is being resumed…")
 }
 
 func RebootInstance(_ *cobra.Command, args []string) {
 	if InstanceRebootType != "soft" && InstanceRebootType != "hard" {
-		display.ExitError("invalid reboot type: %q. Use 'soft' or 'hard'.\n", InstanceRebootType)
+		display.OutputError(&flags.OutputFormatConfig, "invalid reboot type: %q. Use 'soft' or 'hard'.", InstanceRebootType)
 		return
 	}
 
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
@@ -257,22 +257,22 @@ func RebootInstance(_ *cobra.Command, args []string) {
 	}
 
 	if err := httpLib.Client.Post(endpoint, body, nil); err != nil {
-		display.ExitError("error rebooting instance %q: %s\n", args[0], err)
+		display.OutputError(&flags.OutputFormatConfig, "error rebooting instance %q: %s", args[0], err)
 		return
 	}
 
-	fmt.Println("\n⚡️ Instance is rebooting ...")
+	display.OutputInfo(&flags.OutputFormatConfig, nil, "⚡️ Instance is rebooting…")
 }
 
 func CreateInstance(cmd *cobra.Command, args []string) {
 	if len(args) == 0 {
-		display.ExitError("create command requires a region as the first argument.\nUsage:\n%s", cmd.UsageString())
+		display.OutputError(&flags.OutputFormatConfig, "create command requires a region as the first argument.\n\n%s", cmd.UsageString())
 		return
 	}
 
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "failed to get configured cloud project: %s", err)
 		return
 	}
 	region := args[0]
@@ -280,7 +280,7 @@ func CreateInstance(cmd *cobra.Command, args []string) {
 	// Run interactive image & flavor selectors if the flags are set
 	interactiveParams, err := GetInstanceFlavorAndImageInteractiveSelector(cmd, args)
 	if err != nil {
-		display.ExitError("failed to get interactive parameters: %s", err)
+		display.OutputError(&flags.OutputFormatConfig, "failed to get interactive parameters: %s", err)
 		return
 	}
 	if interactiveParams != nil {
@@ -302,41 +302,42 @@ func CreateInstance(cmd *cobra.Command, args []string) {
 		assets.CloudOpenapiSchema,
 		[]string{"name", "flavor", "bootFrom", "network"})
 	if err != nil {
-		display.ExitError("failed to create instance: %s", err)
+		display.OutputError(&flags.OutputFormatConfig, "failed to create instance: %s", err)
 		return
 	}
-
-	fmt.Println("\n⚡️ Instance creation started…")
 
 	if !flags.WaitForTask {
+		display.OutputInfo(&flags.OutputFormatConfig, nil, "⚡️ Instance creation started")
 		return
 	}
+
+	log.Println("⚡️ Instance creation started…")
 
 	operationID := operation["id"].(string)
 	instanceID, err := waitForCloudOperation(projectID, operationID, "instance#create", time.Hour)
 	if err != nil {
-		display.ExitError("failed to wait for instance creation: %s", err)
+		display.OutputError(&flags.OutputFormatConfig, "failed to wait for instance creation: %s", err)
 		return
 	}
 
-	fmt.Printf("✅ Instance %s created successfully\n", instanceID)
+	display.OutputInfo(&flags.OutputFormatConfig, map[string]any{"id": instanceID}, "✅ Instance %s created successfully", instanceID)
 }
 
 func DeleteInstance(_ *cobra.Command, args []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
 	endpoint := fmt.Sprintf("/cloud/project/%s/instance/%s", projectID, url.PathEscape(args[0]))
 
 	if err := httpLib.Client.Delete(endpoint, nil); err != nil {
-		display.ExitError("error deleting instance %q: %s\n", args[0], err)
+		display.OutputError(&flags.OutputFormatConfig, "error deleting instance %q: %s", args[0], err)
 		return
 	}
 
-	fmt.Println("✅ Instance successfully deleted")
+	display.OutputInfo(&flags.OutputFormatConfig, nil, "✅ Instance successfully deleted")
 }
 
 func GetInstanceFlavorAndImageInteractiveSelector(cmd *cobra.Command, args []string) (map[string]any, error) {
@@ -391,14 +392,14 @@ func ReinstallInstance(cmd *cobra.Command, args []string) {
 	// No instance ID given, print usage and exit
 	if len(args) == 0 {
 		cmd.Help()
-		display.ExitError("reinstall command requires an instance ID as the first argument.\nUsage:\n%s", cmd.UsageString())
+		display.OutputError(&flags.OutputFormatConfig, "reinstall command requires an instance ID as the first argument.\nUsage:\n%s", cmd.UsageString())
 		return
 	}
 
 	// Get cloud project ID
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
@@ -409,12 +410,12 @@ func ReinstallInstance(cmd *cobra.Command, args []string) {
 		ImageID: InstanceImageID,
 	})
 	if err != nil {
-		display.ExitError("failed to prepare arguments from command line: %s", err)
+		display.OutputError(&flags.OutputFormatConfig, "failed to prepare arguments from command line: %s", err)
 		return
 	}
 	var cliParameters map[string]any
 	if err := json.Unmarshal(jsonCliParameters, &cliParameters); err != nil {
-		display.ExitError("failed to parse arguments from command line: %s", err)
+		display.OutputError(&flags.OutputFormatConfig, "failed to parse arguments from command line: %s", err)
 		return
 	}
 
@@ -427,12 +428,12 @@ func ReinstallInstance(cmd *cobra.Command, args []string) {
 			stdin = append(stdin, scanner.Bytes()...)
 		}
 		if err := scanner.Err(); err != nil {
-			display.ExitError(err.Error())
+			display.OutputError(&flags.OutputFormatConfig, "%s", err)
 			return
 		}
 
 		if err := json.Unmarshal(stdin, &parameters); err != nil {
-			display.ExitError("failed to parse given installation data: %s", err)
+			display.OutputError(&flags.OutputFormatConfig, "failed to parse given installation data: %s", err)
 			return
 		}
 	} else if InstanceImageViaInteractiveSelector { // Install data given through an interactive image selector
@@ -442,7 +443,7 @@ func ReinstallInstance(cmd *cobra.Command, args []string) {
 		endpoint := fmt.Sprintf("/cloud/project/%s/instance/%s", projectID, url.PathEscape(args[0]))
 		var instance map[string]any
 		if err := httpLib.Client.Get(endpoint, &instance); err != nil {
-			display.ExitError("failed to fetch instance details: %s", err)
+			display.OutputError(&flags.OutputFormatConfig, "failed to fetch instance details: %s", err)
 			return
 		}
 		region := instance["region"].(string)
@@ -450,12 +451,12 @@ func ReinstallInstance(cmd *cobra.Command, args []string) {
 		// Run interactive image selector
 		selectedImage, selectedID, err := runImageSelector(projectID, region)
 		if err != nil {
-			display.ExitError("failed to select an image: %s", err)
+			display.OutputError(&flags.OutputFormatConfig, "failed to select an image: %s", err)
 			return
 		}
 
 		if selectedImage == "" {
-			display.ExitWarning("No image selected, exiting...")
+			display.OutputWarning(&flags.OutputFormatConfig, "No image selected, exiting…")
 			return
 		}
 
@@ -469,29 +470,29 @@ func ReinstallInstance(cmd *cobra.Command, args []string) {
 
 		examples, err := openapi.GetOperationRequestExamples(assets.CloudOpenapiSchema, "/cloud/project/{serviceName}/instance/{instanceId}/reinstall", "post", "", cliParameters)
 		if err != nil {
-			display.ExitError("failed to fetch API call examples: %s", err)
+			display.OutputError(&flags.OutputFormatConfig, "failed to fetch API call examples: %s", err)
 			return
 		}
 
 		_, choice, err := display.RunGenericChoicePicker("Please select an installation example", examples, 0)
 		if err != nil {
-			display.ExitError(err.Error())
+			display.OutputError(&flags.OutputFormatConfig, "%s", err)
 			return
 		}
 
 		if choice == "" {
-			display.ExitWarning("No installation example selected, exiting...")
+			display.OutputWarning(&flags.OutputFormatConfig, "No installation example selected, exiting…")
 			return
 		}
 
 		newValue, err := editor.EditValueWithEditor([]byte(choice))
 		if err != nil {
-			display.ExitError("failed to edit installation parameters using editor: %s", err)
+			display.OutputError(&flags.OutputFormatConfig, "failed to edit installation parameters using editor: %s", err)
 			return
 		}
 
 		if err := json.Unmarshal(newValue, &parameters); err != nil {
-			display.ExitError("failed to parse given installation parameters: %s", err)
+			display.OutputError(&flags.OutputFormatConfig, "failed to parse given installation parameters: %s", err)
 			return
 		}
 	} else if flags.ParametersFile != "" { // Install data given in a file
@@ -499,13 +500,13 @@ func ReinstallInstance(cmd *cobra.Command, args []string) {
 
 		fd, err := os.Open(flags.ParametersFile)
 		if err != nil {
-			display.ExitError("failed to open given file: %s", err)
+			display.OutputError(&flags.OutputFormatConfig, "failed to open given file: %s", err)
 			return
 		}
 		defer fd.Close()
 
 		if err := json.NewDecoder(fd).Decode(&parameters); err != nil {
-			display.ExitError("failed to parse given installation file: %s", err)
+			display.OutputError(&flags.OutputFormatConfig, "failed to parse given installation file: %s", err)
 			return
 		}
 	}
@@ -515,20 +516,20 @@ func ReinstallInstance(cmd *cobra.Command, args []string) {
 	// request examples coming from API schemas.
 	if !flags.ParametersViaEditor {
 		if err := utils.MergeMaps(parameters, cliParameters); err != nil {
-			display.ExitError("failed to merge replace values into example: %w", err)
+			display.OutputError(&flags.OutputFormatConfig, "failed to merge replace values into example: %s", err)
 			return
 		}
 	}
 
 	// Check if at least an image ID was provided as it is mandatory
 	if imageID, ok := parameters["imageId"]; !ok || imageID == "" {
-		display.ExitError("image ID parameter is mandatory to trigger a reinstallation")
+		display.OutputError(&flags.OutputFormatConfig, "image ID parameter is mandatory to trigger a reinstallation")
 		return
 	}
 
 	out, err := json.MarshalIndent(parameters, "", " ")
 	if err != nil {
-		display.ExitError("installation parameters cannot be marshalled: %s", err)
+		display.OutputError(&flags.OutputFormatConfig, "installation parameters cannot be marshalled: %s", err)
 		return
 	}
 
@@ -537,22 +538,23 @@ func ReinstallInstance(cmd *cobra.Command, args []string) {
 	var task map[string]any
 	endpoint := fmt.Sprintf("/cloud/project/%s/instance/%s/reinstall", projectID, url.PathEscape(args[0]))
 	if err := httpLib.Client.Post(endpoint, parameters, &task); err != nil {
-		display.ExitError("error reinstalling instance %q: %s\n", args[0], err)
+		display.OutputError(&flags.OutputFormatConfig, "error reinstalling instance %q: %s", args[0], err)
 		return
 	}
 
-	fmt.Println("\n⚡️ Reinstallation started ...")
+	log.Println("⚡️ Reinstallation started…")
 
 	if !flags.WaitForTask {
+		display.OutputInfo(&flags.OutputFormatConfig, nil, "⚡️ Reinstallation started…")
 		return
 	}
 
 	if err := waitForInstanceStatus(projectID, args[0], "ACTIVE"); err != nil {
-		display.ExitError("failed to wait for instance to be reinstalled: %s", err)
+		display.OutputError(&flags.OutputFormatConfig, "failed to wait for instance to be reinstalled: %s", err)
 		return
 	}
 
-	fmt.Println("✅ Reinstallation done")
+	display.OutputInfo(&flags.OutputFormatConfig, nil, "✅ Reinstallation done")
 }
 
 func waitForInstanceStatus(cloudProject, instanceID, targetStatus string) error {
@@ -571,7 +573,7 @@ func waitForInstanceStatus(cloudProject, instanceID, targetStatus string) error 
 		case "ERROR":
 			return fmt.Errorf("invalid state for instance: %s", instance["status"])
 		default:
-			log.Printf("Still waiting for instance to be in state 'ACTIVE' (status=%s) ...", instance["status"])
+			log.Printf("Still waiting for instance to be in state 'ACTIVE' (status=%s)…", instance["status"])
 			time.Sleep(30 * time.Second)
 		}
 	}
@@ -582,24 +584,24 @@ func waitForInstanceStatus(cloudProject, instanceID, targetStatus string) error 
 func ActivateMonthlyBilling(_ *cobra.Command, args []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
 	endpoint := fmt.Sprintf("/cloud/project/%s/instance/%s/activeMonthlyBilling", projectID, url.PathEscape(args[0]))
 
 	if err := httpLib.Client.Post(endpoint, nil, nil); err != nil {
-		display.ExitError("error activating monthly billing for instance %q: %s\n", args[0], err)
+		display.OutputError(&flags.OutputFormatConfig, "error activating monthly billing for instance %q: %s", args[0], err)
 		return
 	}
 
-	fmt.Println("✅ Monthly billing activated for instance")
+	display.OutputInfo(&flags.OutputFormatConfig, nil, "✅ Monthly billing activated for instance %q", args[0])
 }
 
 func ListInstanceInterfaces(_ *cobra.Command, args []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
@@ -611,7 +613,7 @@ func ListInstanceInterfaces(_ *cobra.Command, args []string) {
 func GetInstanceInterface(_ *cobra.Command, args []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
@@ -623,7 +625,7 @@ func GetInstanceInterface(_ *cobra.Command, args []string) {
 func CreateInstanceInterface(_ *cobra.Command, args []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
@@ -638,34 +640,34 @@ func CreateInstanceInterface(_ *cobra.Command, args []string) {
 	}
 
 	if err := httpLib.Client.Post(endpoint, body, nil); err != nil {
-		display.ExitError("error creating interface for instance %q: %s\n", args[0], err)
+		display.OutputError(&flags.OutputFormatConfig, "error creating interface for instance %q: %s", args[0], err)
 		return
 	}
 
-	fmt.Println("✅ Interface created successfully")
+	display.OutputInfo(&flags.OutputFormatConfig, nil, "✅ Interface created successfully")
 }
 
 func DeleteInstanceInterface(_ *cobra.Command, args []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
 	endpoint := fmt.Sprintf("/cloud/project/%s/instance/%s/interface/%s", projectID, url.PathEscape(args[0]), url.PathEscape(args[1]))
 
 	if err := httpLib.Client.Delete(endpoint, nil); err != nil {
-		display.ExitError("error deleting interface %s for instance %q: %s\n", args[1], args[0], err)
+		display.OutputError(&flags.OutputFormatConfig, "error deleting interface %s for instance %q: %s", args[1], args[0], err)
 		return
 	}
 
-	fmt.Println("✅ Interface deleted successfully")
+	display.OutputInfo(&flags.OutputFormatConfig, nil, "✅ Interface deleted successfully")
 }
 
 func EnableInstanceInRescueMode(_ *cobra.Command, args []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
@@ -679,28 +681,29 @@ func EnableInstanceInRescueMode(_ *cobra.Command, args []string) {
 	}
 
 	if err := httpLib.Client.Post(endpoint, body, nil); err != nil {
-		display.ExitError("error setting instance %q in rescue mode: %s\n", args[0], err)
+		display.OutputError(&flags.OutputFormatConfig, "error setting instance %q in rescue mode: %s", args[0], err)
 		return
 	}
 
-	fmt.Println("\n⚡️ Instance is being rebooted in rescue mode ...")
+	log.Println("⚡️ Instance is being rebooted in rescue mode…")
 
 	if !flags.WaitForTask {
+		display.OutputInfo(&flags.OutputFormatConfig, nil, "⚡️ Instance is being rebooted in rescue mode…")
 		return
 	}
 
 	if err := waitForInstanceStatus(projectID, args[0], "RESCUE"); err != nil {
-		display.ExitError("failed to wait for instance to be in rescue mode %s", err)
+		display.OutputError(&flags.OutputFormatConfig, "failed to wait for instance to be in rescue mode %s", err)
 		return
 	}
 
-	fmt.Println("✅ Instance is now in rescue mode")
+	display.OutputInfo(&flags.OutputFormatConfig, nil, "✅ Instance is now in rescue mode")
 }
 
 func DisableInstanceRescueMode(_ *cobra.Command, args []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
@@ -710,28 +713,29 @@ func DisableInstanceRescueMode(_ *cobra.Command, args []string) {
 	}
 
 	if err := httpLib.Client.Post(endpoint, body, nil); err != nil {
-		display.ExitError("error unsetting instance %q from rescue mode: %s\n", args[0], err)
+		display.OutputError(&flags.OutputFormatConfig, "error unsetting instance %q from rescue mode: %s", args[0], err)
 		return
 	}
 
-	fmt.Println("\n⚡️ Instance is exiting rescue mode ...")
+	log.Println("⚡️ Instance is exiting rescue mode…")
 
 	if !flags.WaitForTask {
+		display.OutputInfo(&flags.OutputFormatConfig, nil, "⚡️ Instance is exiting rescue mode…")
 		return
 	}
 
 	if err := waitForInstanceStatus(projectID, args[0], "ACTIVE"); err != nil {
-		display.ExitError("failed to wait for instance to exit rescue mode %s", err)
+		display.OutputError(&flags.OutputFormatConfig, "failed to wait for instance to exit rescue mode %s", err)
 		return
 	}
 
-	fmt.Println("✅ Instance is no longer in rescue mode")
+	display.OutputInfo(&flags.OutputFormatConfig, nil, "✅ Instance is no longer in rescue mode")
 }
 
 func SetInstanceFlavor(_ *cobra.Command, args []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
@@ -744,7 +748,7 @@ func SetInstanceFlavor(_ *cobra.Command, args []string) {
 		endpoint := fmt.Sprintf("/cloud/project/%s/instance/%s", projectID, url.PathEscape(args[0]))
 		var instance map[string]any
 		if err := httpLib.Client.Get(endpoint, &instance); err != nil {
-			display.ExitError("failed to fetch instance details: %s", err)
+			display.OutputError(&flags.OutputFormatConfig, "failed to fetch instance details: %s", err)
 			return
 		}
 		region := instance["region"].(string)
@@ -752,12 +756,12 @@ func SetInstanceFlavor(_ *cobra.Command, args []string) {
 		// Run interactive flavor selector
 		selectedFlavor, selectedID, err := runFlavorSelector(projectID, region)
 		if err != nil {
-			display.ExitError("failed to run flavor selector: %s", err)
+			display.OutputError(&flags.OutputFormatConfig, "failed to run flavor selector: %s", err)
 			return
 		}
 
 		if selectedFlavor == "" {
-			display.ExitWarning("No flavor selected, exiting...")
+			display.OutputWarning(&flags.OutputFormatConfig, "No flavor selected, exiting…")
 			return
 		}
 
@@ -765,7 +769,7 @@ func SetInstanceFlavor(_ *cobra.Command, args []string) {
 	} else if len(args) > 1 {
 		flavor = args[1]
 	} else {
-		display.ExitError("Flavor ID is required when not using the --flavor-selector flag")
+		display.OutputError(&flags.OutputFormatConfig, "Flavor ID is required when not using the --flavor-selector flag")
 		return
 	}
 
@@ -777,28 +781,29 @@ func SetInstanceFlavor(_ *cobra.Command, args []string) {
 	}
 
 	if err := httpLib.Client.Post(endpoint, body, nil); err != nil {
-		display.ExitError("error setting flavor for instance %q: %s\n", args[0], err)
+		display.OutputError(&flags.OutputFormatConfig, "error setting flavor for instance %q: %s", args[0], err)
 		return
 	}
 
-	fmt.Println("\n⚡️ Migrating instance to the desired flavor ...")
+	log.Println("⚡️ Migrating instance to the desired flavor…")
 
 	if !flags.WaitForTask {
+		display.OutputInfo(&flags.OutputFormatConfig, nil, "⚡️ Instance migration to the desired flavor started…")
 		return
 	}
 
 	if err := waitForInstanceStatus(projectID, args[0], "ACTIVE"); err != nil {
-		display.ExitError("failed to wait for instance to migrate to the desired flavor %s", err)
+		display.OutputError(&flags.OutputFormatConfig, "failed to wait for instance to migrate to the desired flavor: %s", err)
 		return
 	}
 
-	fmt.Println("✅ Instance correctly migrated to the desired flavor")
+	display.OutputInfo(&flags.OutputFormatConfig, nil, "✅ Instance correctly migrated to the desired flavor")
 }
 
 func CreateInstanceSnapshot(_ *cobra.Command, args []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
@@ -810,17 +815,17 @@ func CreateInstanceSnapshot(_ *cobra.Command, args []string) {
 
 	var response map[string]any
 	if err := httpLib.Client.Post(endpoint, body, &response); err != nil {
-		display.ExitError("error creating snapshot for instance %q: %s\n", args[0], err)
+		display.OutputError(&flags.OutputFormatConfig, "error creating snapshot for instance %q: %s", args[0], err)
 		return
 	}
 
-	fmt.Printf("✅ Snapshot created successfully with ID: %s\n", response["snapshotId"])
+	display.OutputInfo(&flags.OutputFormatConfig, response, "✅ Snapshot created successfully with ID: %s", response["snapshotId"])
 }
 
 func AbortInstanceSnapshot(_ *cobra.Command, args []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
@@ -828,7 +833,7 @@ func AbortInstanceSnapshot(_ *cobra.Command, args []string) {
 	endpoint := fmt.Sprintf("/cloud/project/%s/instance/%s", projectID, url.PathEscape(args[0]))
 	var instance map[string]any
 	if err := httpLib.Client.Get(endpoint, &instance); err != nil {
-		display.ExitError("failed to fetch instance details: %s", err)
+		display.OutputError(&flags.OutputFormatConfig, "failed to fetch instance details: %s", err)
 		return
 	}
 	region := instance["region"].(string)
@@ -836,9 +841,9 @@ func AbortInstanceSnapshot(_ *cobra.Command, args []string) {
 	// Abort the snapshot
 	endpoint = fmt.Sprintf("/cloud/project/%s/region/%s/instance/%s/abortSnapshot", projectID, url.PathEscape(region), url.PathEscape(args[0]))
 	if err := httpLib.Client.Post(endpoint, nil, nil); err != nil {
-		display.ExitError("error aborting snapshot for instance %q: %s\n", args[0], err)
+		display.OutputError(&flags.OutputFormatConfig, "error aborting snapshot for instance %q: %s", args[0], err)
 		return
 	}
 
-	fmt.Println("✅ Snapshot aborted successfully")
+	display.OutputInfo(&flags.OutputFormatConfig, nil, "✅ Snapshot aborted successfully")
 }

--- a/internal/services/cloud/cloud_kube.go
+++ b/internal/services/cloud/cloud_kube.go
@@ -162,7 +162,7 @@ type kubeNodepoolSpecTaintType struct {
 func ListKubes(_ *cobra.Command, _ []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
@@ -172,7 +172,7 @@ func ListKubes(_ *cobra.Command, _ []string) {
 func GetKube(_ *cobra.Command, args []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
@@ -180,7 +180,7 @@ func GetKube(_ *cobra.Command, args []string) {
 
 	var object map[string]any
 	if err := httpLib.Client.Get(endpoint, &object); err != nil {
-		display.ExitError("error fetching %s: %s", endpoint, err)
+		display.OutputError(&flags.OutputFormatConfig, "error fetching %s: %s", endpoint, err)
 		return
 	}
 
@@ -191,12 +191,12 @@ func GetKube(_ *cobra.Command, args []string) {
 	} else {
 		etcdUsage["usage"], err = etcdUsage["usage"].(json.Number).Float64()
 		if err != nil {
-			display.ExitError("failed to parse etcd usage 'usage' value: %s", err)
+			display.OutputError(&flags.OutputFormatConfig, "failed to parse etcd usage 'usage' value: %s", err)
 			return
 		}
 		etcdUsage["quota"], err = etcdUsage["quota"].(json.Number).Float64()
 		if err != nil {
-			display.ExitError("failed to parse etcd usage 'quota' value: %s", err)
+			display.OutputError(&flags.OutputFormatConfig, "failed to parse etcd usage 'quota' value: %s", err)
 			return
 		}
 		object["etcdUsage"] = etcdUsage
@@ -208,7 +208,7 @@ func GetKube(_ *cobra.Command, args []string) {
 func CreateKube(cmd *cobra.Command, args []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
@@ -222,17 +222,17 @@ func CreateKube(cmd *cobra.Command, args []string) {
 		assets.CloudOpenapiSchema,
 		[]string{"region"})
 	if err != nil {
-		display.ExitError("failed to create Kubernetes cluster: %s", err)
+		display.OutputError(&flags.OutputFormatConfig, "failed to create Kubernetes cluster: %s", err)
 		return
 	}
 
-	fmt.Printf("✅ Cluster %s created successfully (id: %s)\n", cluster["name"], cluster["id"])
+	display.OutputInfo(&flags.OutputFormatConfig, cluster, "✅ Cluster %s created successfully (id: %s)", cluster["name"], cluster["id"])
 }
 
 func EditKube(cmd *cobra.Command, args []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
@@ -246,7 +246,7 @@ func EditKube(cmd *cobra.Command, args []string) {
 		},
 		assets.CloudOpenapiSchema,
 	); err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 }
@@ -254,30 +254,30 @@ func EditKube(cmd *cobra.Command, args []string) {
 func DeleteKube(_ *cobra.Command, args []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
 	endpoint := fmt.Sprintf("/cloud/project/%s/kube/%s", projectID, url.PathEscape(args[0]))
 	if err := httpLib.Client.Delete(endpoint, nil); err != nil {
-		display.ExitError("failed to delete MKS cluster: %s", err)
+		display.OutputError(&flags.OutputFormatConfig, "failed to delete MKS cluster: %s", err)
 		return
 	}
 
-	fmt.Println("✅ MKS cluster is being deleted…")
+	display.OutputInfo(&flags.OutputFormatConfig, nil, "✅ MKS cluster is being deleted…")
 }
 
 func GetKubeCustomization(cmd *cobra.Command, args []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
 	endpoint := fmt.Sprintf("/cloud/project/%s/kube/%s/customization", projectID, url.PathEscape(args[0]))
 	var customization map[string]any
 	if err := httpLib.Client.Get(endpoint, &customization); err != nil {
-		display.ExitError("failed to fetch MKS cluster customization: %s", err)
+		display.OutputError(&flags.OutputFormatConfig, "failed to fetch MKS cluster customization: %s", err)
 		return
 	}
 
@@ -287,7 +287,7 @@ func GetKubeCustomization(cmd *cobra.Command, args []string) {
 func EditKubeCustomization(cmd *cobra.Command, args []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
@@ -298,7 +298,7 @@ func EditKubeCustomization(cmd *cobra.Command, args []string) {
 		KubeSpec.Customization,
 		assets.CloudOpenapiSchema,
 	); err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 }
@@ -306,7 +306,7 @@ func EditKubeCustomization(cmd *cobra.Command, args []string) {
 func ListKubeIPRestrictions(_ *cobra.Command, args []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
@@ -314,7 +314,7 @@ func ListKubeIPRestrictions(_ *cobra.Command, args []string) {
 
 	body, err := httpLib.FetchArray(endpoint, "")
 	if err != nil {
-		display.ExitError("failed to fetch IP restrictions: %s", err)
+		display.OutputError(&flags.OutputFormatConfig, "failed to fetch IP restrictions: %s", err)
 		return
 	}
 
@@ -330,13 +330,13 @@ func ListKubeIPRestrictions(_ *cobra.Command, args []string) {
 
 func EditKubeIPRestrictions(cmd *cobra.Command, args []string) {
 	if cmd.Flags().NFlag() == 0 {
-		display.ExitWarning("No parameters given, nothing to edit")
+		display.OutputWarning(&flags.OutputFormatConfig, "No parameters given, nothing to edit")
 		return
 	}
 
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
@@ -346,7 +346,7 @@ func EditKubeIPRestrictions(cmd *cobra.Command, args []string) {
 		// Fetch resource
 		var ips []string
 		if err := httpLib.Client.Get(endpoint, &ips); err != nil {
-			display.ExitError("error fetching resource %s", err)
+			display.OutputError(&flags.OutputFormatConfig, "error fetching resource %s", err)
 			return
 		}
 
@@ -355,24 +355,24 @@ func EditKubeIPRestrictions(cmd *cobra.Command, args []string) {
 			"ips": ips,
 		}, "", "  ")
 		if err != nil {
-			display.ExitError("failed to marshal writable body: %s", err)
+			display.OutputError(&flags.OutputFormatConfig, "failed to marshal writable body: %s", err)
 			return
 		}
 
 		// Edit value
 		updatedBody, err := editor.EditValueWithEditor(editableOutput)
 		if err != nil {
-			display.ExitError("failed to edit properties: %s", err)
+			display.OutputError(&flags.OutputFormatConfig, "failed to edit properties: %s", err)
 			return
 		}
 
 		// Update API call
 		if err := httpLib.Client.Put(endpoint, json.RawMessage(updatedBody), nil); err != nil {
-			display.ExitError("failed to update resource: %s", err)
+			display.OutputError(&flags.OutputFormatConfig, "failed to update resource: %s", err)
 			return
 		}
 
-		fmt.Println("✅ IP restrictions updated succesfully ...")
+		display.OutputInfo(&flags.OutputFormatConfig, nil, "✅ IP restrictions updated successfully…")
 		return
 	}
 
@@ -380,17 +380,17 @@ func EditKubeIPRestrictions(cmd *cobra.Command, args []string) {
 	if err := httpLib.Client.Put(endpoint, map[string]any{
 		"ips": KubeIPRestrictions,
 	}, nil); err != nil {
-		display.ExitError("failed to update IP restrictions: %s", err)
+		display.OutputError(&flags.OutputFormatConfig, "failed to update IP restrictions: %s", err)
 		return
 	}
 
-	fmt.Println("✅ IP restrictions updated succesfully ...")
+	display.OutputInfo(&flags.OutputFormatConfig, nil, "✅ IP restrictions updated successfully…")
 }
 
 func GenerateKubeConfig(cmd *cobra.Command, args []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
@@ -398,34 +398,34 @@ func GenerateKubeConfig(cmd *cobra.Command, args []string) {
 
 	var kubeConfig map[string]any
 	if err := httpLib.Client.Post(endpoint, nil, &kubeConfig); err != nil {
-		display.ExitError("failed to generate kube config: %s", err)
+		display.OutputError(&flags.OutputFormatConfig, "failed to generate kube config: %s", err)
 		return
 	}
 
-	fmt.Println(kubeConfig["content"])
+	display.OutputInfo(&flags.OutputFormatConfig, nil, "%s", kubeConfig["content"])
 }
 
 func ResetKubeConfig(cmd *cobra.Command, args []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
 	endpoint := fmt.Sprintf("/cloud/project/%s/kube/%s/kubeconfig/reset", projectID, url.PathEscape(args[0]))
 
 	if err := httpLib.Client.Post(endpoint, nil, nil); err != nil {
-		display.ExitError("failed to reset kube config: %s", err)
+		display.OutputError(&flags.OutputFormatConfig, "failed to reset kube config: %s", err)
 		return
 	}
 
-	fmt.Println("✅ Kube config reset successfully")
+	display.OutputInfo(&flags.OutputFormatConfig, nil, "✅ Kube config reset successfully")
 }
 
 func ListKubeNodes(_ *cobra.Command, args []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
@@ -437,7 +437,7 @@ func ListKubeNodes(_ *cobra.Command, args []string) {
 func GetKubeNode(_ *cobra.Command, args []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
@@ -449,23 +449,23 @@ func GetKubeNode(_ *cobra.Command, args []string) {
 func DeleteKubeNode(_ *cobra.Command, args []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
 	endpoint := fmt.Sprintf("/cloud/project/%s/kube/%s/node/%s", projectID, url.PathEscape(args[0]), url.PathEscape(args[1]))
 	if err := httpLib.Client.Delete(endpoint, nil); err != nil {
-		display.ExitError("failed to delete MKS node: %s", err)
+		display.OutputError(&flags.OutputFormatConfig, "failed to delete MKS node: %s", err)
 		return
 	}
 
-	fmt.Println("✅ MKS node deleted successfully")
+	display.OutputInfo(&flags.OutputFormatConfig, nil, "✅ MKS node deleted successfully")
 }
 
 func ListKubeNodepools(_ *cobra.Command, args []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
@@ -477,7 +477,7 @@ func ListKubeNodepools(_ *cobra.Command, args []string) {
 func GetKubeNodepool(_ *cobra.Command, args []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
@@ -489,7 +489,7 @@ func GetKubeNodepool(_ *cobra.Command, args []string) {
 func EditKubeNodepool(cmd *cobra.Command, args []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
@@ -500,7 +500,7 @@ func EditKubeNodepool(cmd *cobra.Command, args []string) {
 		KubeNodepoolSpec,
 		assets.CloudOpenapiSchema,
 	); err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 }
@@ -508,28 +508,28 @@ func EditKubeNodepool(cmd *cobra.Command, args []string) {
 func DeleteKubeNodepool(_ *cobra.Command, args []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
 	endpoint := fmt.Sprintf("/cloud/project/%s/kube/%s/nodepool/%s", projectID, url.PathEscape(args[0]), url.PathEscape(args[1]))
 	if err := httpLib.Client.Delete(endpoint, nil); err != nil {
-		display.ExitError("failed to delete MKS node pool: %s", err)
+		display.OutputError(&flags.OutputFormatConfig, "failed to delete MKS node pool: %s", err)
 		return
 	}
 
-	fmt.Println("✅ MKS node pool deleted successfully")
+	display.OutputInfo(&flags.OutputFormatConfig, nil, "✅ MKS node pool deleted successfully")
 }
 
 func CreateKubeNodepool(cmd *cobra.Command, args []string) {
 	if len(args) == 0 {
-		display.ExitError("create command requires the MKS cluster ID as the first argument.\nUsage:\n%s", cmd.UsageString())
+		display.OutputError(&flags.OutputFormatConfig, "create command requires the MKS cluster ID as the first argument.\nUsage:\n%s", cmd.UsageString())
 		return
 	}
 
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
@@ -537,13 +537,13 @@ func CreateKubeNodepool(cmd *cobra.Command, args []string) {
 	for _, taint := range KubeNodepoolSpec.Template.Spec.CommandLineTaints {
 		parts := strings.Split(taint, ":")
 		if len(parts) != 2 {
-			display.ExitError("invalid taint format: %q, expected format is key=value:effect", taint)
+			display.OutputError(&flags.OutputFormatConfig, "invalid taint format: %q, expected format is key=value:effect", taint)
 			return
 		}
 
 		kvParts := strings.Split(parts[0], "=")
 		if len(kvParts) != 2 {
-			display.ExitError("invalid taint format: %q, expected format is key=value:effect", taint)
+			display.OutputError(&flags.OutputFormatConfig, "invalid taint format: %q, expected format is key=value:effect", taint)
 			return
 		}
 
@@ -559,7 +559,7 @@ func CreateKubeNodepool(cmd *cobra.Command, args []string) {
 	// Run interactive flavor selector if the flag is set
 	flavor, err := GetKubeFlavorInteractiveSelector(cmd, args)
 	if err != nil {
-		display.ExitError("failed to get flavor from interactive selector: %s", err)
+		display.OutputError(&flags.OutputFormatConfig, "failed to get flavor from interactive selector: %s", err)
 		return
 	}
 	if flavor != nil {
@@ -576,11 +576,11 @@ func CreateKubeNodepool(cmd *cobra.Command, args []string) {
 		assets.CloudOpenapiSchema,
 		[]string{"flavorName"})
 	if err != nil {
-		display.ExitError("failed to create Kubernetes node pool: %s", err)
+		display.OutputError(&flags.OutputFormatConfig, "failed to create Kubernetes node pool: %s", err)
 		return
 	}
 
-	fmt.Printf("✅ Node pool %s created successfully\n", nodepool["id"])
+	display.OutputInfo(&flags.OutputFormatConfig, nodepool, "✅ Node pool %s created successfully", nodepool["id"])
 }
 
 func GetKubeFlavorInteractiveSelector(cmd *cobra.Command, args []string) (map[string]any, error) {
@@ -623,7 +623,7 @@ func GetKubeFlavorInteractiveSelector(cmd *cobra.Command, args []string) (map[st
 func GetKubeOIDCIntegration(_ *cobra.Command, args []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
@@ -631,7 +631,7 @@ func GetKubeOIDCIntegration(_ *cobra.Command, args []string) {
 
 	var oidcConfig map[string]any
 	if err := httpLib.Client.Get(endpoint, &oidcConfig); err != nil {
-		display.ExitError("failed to fetch OIDC configuration: %s", err)
+		display.OutputError(&flags.OutputFormatConfig, "failed to fetch OIDC configuration: %s", err)
 		return
 	}
 
@@ -641,7 +641,7 @@ func GetKubeOIDCIntegration(_ *cobra.Command, args []string) {
 func EditKubeOIDCIntegration(cmd *cobra.Command, args []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
@@ -652,7 +652,7 @@ func EditKubeOIDCIntegration(cmd *cobra.Command, args []string) {
 		KubeOIDCConfig,
 		assets.CloudOpenapiSchema,
 	); err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 }
@@ -660,7 +660,7 @@ func EditKubeOIDCIntegration(cmd *cobra.Command, args []string) {
 func CreateKubeOIDCIntegration(cmd *cobra.Command, args []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
@@ -673,34 +673,34 @@ func CreateKubeOIDCIntegration(cmd *cobra.Command, args []string) {
 		KubeOIDCConfig,
 		assets.CloudOpenapiSchema,
 		[]string{"clientId", "issuerUrl"}); err != nil {
-		display.ExitError("failed to create OIDC integration: %s", err)
+		display.OutputError(&flags.OutputFormatConfig, "failed to create OIDC integration: %s", err)
 		return
 	}
 
-	fmt.Println("✅ OIDC integration created successfully")
+	display.OutputInfo(&flags.OutputFormatConfig, nil, "✅ OIDC integration created successfully")
 }
 
 func DeleteKubeOIDCIntegration(_ *cobra.Command, args []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
 	endpoint := fmt.Sprintf("/cloud/project/%s/kube/%s/openIdConnect", projectID, url.PathEscape(args[0]))
 
 	if err := httpLib.Client.Delete(endpoint, nil); err != nil {
-		display.ExitError("failed to delete OIDC integration: %s", err)
+		display.OutputError(&flags.OutputFormatConfig, "failed to delete OIDC integration: %s", err)
 		return
 	}
 
-	fmt.Println("✅ OIDC integration deleted successfully")
+	display.OutputInfo(&flags.OutputFormatConfig, nil, "✅ OIDC integration deleted successfully")
 }
 
 func GetKubePrivateNetworkConfiguration(_cmd *cobra.Command, args []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
@@ -708,7 +708,7 @@ func GetKubePrivateNetworkConfiguration(_cmd *cobra.Command, args []string) {
 
 	var privateNetworkConfig map[string]any
 	if err := httpLib.Client.Get(endpoint, &privateNetworkConfig); err != nil {
-		display.ExitError("failed to fetch private network configuration: %s", err)
+		display.OutputError(&flags.OutputFormatConfig, "failed to fetch private network configuration: %s", err)
 		return
 	}
 
@@ -718,7 +718,7 @@ func GetKubePrivateNetworkConfiguration(_cmd *cobra.Command, args []string) {
 func EditKubePrivateNetworkConfiguration(cmd *cobra.Command, args []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
@@ -729,7 +729,7 @@ func EditKubePrivateNetworkConfiguration(cmd *cobra.Command, args []string) {
 		KubeSpec.PrivateNetworkConfiguration,
 		assets.CloudOpenapiSchema,
 	); err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 }
@@ -737,7 +737,7 @@ func EditKubePrivateNetworkConfiguration(cmd *cobra.Command, args []string) {
 func ResetKubeCluster(cmd *cobra.Command, args []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
@@ -751,34 +751,34 @@ func ResetKubeCluster(cmd *cobra.Command, args []string) {
 		assets.CloudOpenapiSchema,
 		nil)
 	if err != nil {
-		display.ExitError("failed to reset Kubernetes cluster: %s", err)
+		display.OutputError(&flags.OutputFormatConfig, "failed to reset Kubernetes cluster: %s", err)
 		return
 	}
 
-	fmt.Println("\n⚡️ Kubernetes cluster is being reset…")
+	display.OutputInfo(&flags.OutputFormatConfig, nil, "⚡️ Kubernetes cluster is being reset…")
 }
 
 func RestartKubeCluster(_ *cobra.Command, args []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
 	if err := httpLib.Client.Post(fmt.Sprintf("/cloud/project/%s/kube/%s/restart", projectID, url.PathEscape(args[0])), map[string]any{
 		"force": KubeForceAction,
 	}, nil); err != nil {
-		display.ExitError("failed to restart Kubernetes cluster: %s", err)
+		display.OutputError(&flags.OutputFormatConfig, "failed to restart Kubernetes cluster: %s", err)
 		return
 	}
 
-	fmt.Println("\n⚡️ Kubernetes cluster restarting…")
+	display.OutputInfo(&flags.OutputFormatConfig, nil, "⚡️ Kubernetes cluster restarting…")
 }
 
 func UpdateKubeCluster(_ *cobra.Command, args []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
@@ -792,17 +792,17 @@ func UpdateKubeCluster(_ *cobra.Command, args []string) {
 	}
 
 	if err := httpLib.Client.Post(endpoint, body, nil); err != nil {
-		display.ExitError("failed to update Kubernetes cluster: %s", err)
+		display.OutputError(&flags.OutputFormatConfig, "failed to update Kubernetes cluster: %s", err)
 		return
 	}
 
-	fmt.Println("\n⚡️ Kubernetes cluster update in progress…")
+	display.OutputInfo(&flags.OutputFormatConfig, nil, "⚡️ Kubernetes cluster update in progress…")
 }
 
 func UpdateKubeLoadBalancersSubnet(_ *cobra.Command, args []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
@@ -812,9 +812,9 @@ func UpdateKubeLoadBalancersSubnet(_ *cobra.Command, args []string) {
 	}
 
 	if err := httpLib.Client.Put(endpoint, body, nil); err != nil {
-		display.ExitError("failed to update load balancers subnet: %s", err)
+		display.OutputError(&flags.OutputFormatConfig, "failed to update load balancers subnet: %s", err)
 		return
 	}
 
-	fmt.Println("✅ Load balancers subnet updated successfully")
+	display.OutputInfo(&flags.OutputFormatConfig, nil, "✅ Load balancers subnet updated successfully")
 }

--- a/internal/services/cloud/cloud_loadbalancer.go
+++ b/internal/services/cloud/cloud_loadbalancer.go
@@ -32,7 +32,7 @@ var (
 func ListCloudLoadbalancers(_ *cobra.Command, _ []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
@@ -42,7 +42,7 @@ func ListCloudLoadbalancers(_ *cobra.Command, _ []string) {
 func GetCloudLoadbalancer(_ *cobra.Command, args []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
@@ -52,7 +52,7 @@ func GetCloudLoadbalancer(_ *cobra.Command, args []string) {
 func EditCloudLoadbalancer(cmd *cobra.Command, args []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
@@ -63,7 +63,7 @@ func EditCloudLoadbalancer(cmd *cobra.Command, args []string) {
 		CloudLoadbalancerUpdateFields,
 		assets.CloudOpenapiSchema,
 	); err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 }

--- a/internal/services/cloud/cloud_operation.go
+++ b/internal/services/cloud/cloud_operation.go
@@ -26,20 +26,20 @@ var (
 func ListCloudOperations(_ *cobra.Command, _ []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
 	var operations []map[string]any
 	err = httpLib.Client.Get(fmt.Sprintf("/cloud/project/%s/operation", projectID), &operations)
 	if err != nil {
-		display.ExitError("failed to fetch results: %s", err)
+		display.OutputError(&flags.OutputFormatConfig, "failed to fetch results: %s", err)
 		return
 	}
 
 	operations, err = filtersLib.FilterLines(operations, flags.GenericFilters)
 	if err != nil {
-		display.ExitError("failed to filter results: %s", err)
+		display.OutputError(&flags.OutputFormatConfig, "failed to filter results: %s", err)
 		return
 	}
 
@@ -49,7 +49,7 @@ func ListCloudOperations(_ *cobra.Command, _ []string) {
 func GetCloudOperation(_ *cobra.Command, args []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 

--- a/internal/services/cloud/cloud_project.go
+++ b/internal/services/cloud/cloud_project.go
@@ -52,7 +52,7 @@ func EditCloudProject(cmd *cobra.Command, args []string) {
 		CloudProjectSpec,
 		assets.CloudOpenapiSchema,
 	); err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 }

--- a/internal/services/cloud/cloud_quota.go
+++ b/internal/services/cloud/cloud_quota.go
@@ -23,14 +23,14 @@ var (
 func GetCloudQuota(_ *cobra.Command, args []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 	url := fmt.Sprintf("/cloud/project/%s/region/%s/quota", projectID, url.PathEscape(args[0]))
 
 	var object map[string]any
 	if err := httpLib.Client.Get(url, &object); err != nil {
-		display.ExitError("error fetching quotas for region %s: %s", args[0], err)
+		display.OutputError(&flags.OutputFormatConfig, "error fetching quotas for region %s: %s", args[0], err)
 		return
 	}
 

--- a/internal/services/cloud/cloud_rancher.go
+++ b/internal/services/cloud/cloud_rancher.go
@@ -47,7 +47,7 @@ type rancherIPRestriction struct {
 func ListCloudRanchers(_ *cobra.Command, _ []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
@@ -57,7 +57,7 @@ func ListCloudRanchers(_ *cobra.Command, _ []string) {
 func GetRancher(_ *cobra.Command, args []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
@@ -68,7 +68,7 @@ func EditRancher(cmd *cobra.Command, args []string) {
 	for _, ipRestriction := range RancherSpec.TargetSpec.CLIIPRestrictions {
 		parts := strings.Split(ipRestriction, ",")
 		if len(parts) != 2 {
-			display.ExitError("Invalid IP restriction format: %s. Expected format: '<cidrBlock>,<description>'", ipRestriction)
+			display.OutputError(&flags.OutputFormatConfig, "Invalid IP restriction format: %s. Expected format: '<cidrBlock>,<description>'", ipRestriction)
 			return
 		}
 		RancherSpec.TargetSpec.IPRestrictions = append(RancherSpec.TargetSpec.IPRestrictions, rancherIPRestriction{
@@ -79,7 +79,7 @@ func EditRancher(cmd *cobra.Command, args []string) {
 
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
@@ -90,7 +90,7 @@ func EditRancher(cmd *cobra.Command, args []string) {
 		RancherSpec,
 		assets.CloudV2OpenapiSchema,
 	); err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 }
@@ -98,7 +98,7 @@ func EditRancher(cmd *cobra.Command, args []string) {
 func CreateRancher(cmd *cobra.Command, args []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
@@ -112,25 +112,25 @@ func CreateRancher(cmd *cobra.Command, args []string) {
 		assets.CloudV2OpenapiSchema,
 		[]string{"targetSpec"})
 	if err != nil {
-		display.ExitError("failed to create Rancher service: %s", err)
+		display.OutputError(&flags.OutputFormatConfig, "failed to create Rancher service: %s", err)
 		return
 	}
 
-	display.Outputf("✅ Rancher %s created successfully (id: %s)", RancherSpec.TargetSpec.Name, rancher["id"])
+	display.OutputInfo(&flags.OutputFormatConfig, rancher, "✅ Rancher %s created successfully (id: %s)", RancherSpec.TargetSpec.Name, rancher["id"])
 }
 
 func DeleteRancher(_ *cobra.Command, args []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
 	endpoint := fmt.Sprintf("/v2/publicCloud/project/%s/rancher/%s", projectID, url.PathEscape(args[0]))
 	if err := httpLib.Client.Delete(endpoint, nil); err != nil {
-		display.ExitError("failed to delete Rancher service: %s", err)
+		display.OutputError(&flags.OutputFormatConfig, "failed to delete Rancher service: %s", err)
 		return
 	}
 
-	display.Outputf("✅ Rancher service is being deleted…")
+	display.OutputInfo(&flags.OutputFormatConfig, nil, "✅ Rancher service is being deleted…")
 }

--- a/internal/services/cloud/cloud_reference.go
+++ b/internal/services/cloud/cloud_reference.go
@@ -20,7 +20,7 @@ import (
 func GetFlavors(region string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
@@ -35,7 +35,7 @@ func GetFlavors(region string) {
 func GetImages(region, osType string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
@@ -55,14 +55,14 @@ func GetImages(region, osType string) {
 func ListContainerRegistryPlans(_ *cobra.Command, _ []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 	path := fmt.Sprintf("/cloud/project/%s/capabilities/containerRegistry", projectID)
 
 	var body []map[string]any
 	if err := httpLib.Client.Get(path, &body); err != nil {
-		display.ExitError("failed to fetch container registry plans: %s", err)
+		display.OutputError(&flags.OutputFormatConfig, "failed to fetch container registry plans: %s", err)
 		return
 	}
 
@@ -77,7 +77,7 @@ func ListContainerRegistryPlans(_ *cobra.Command, _ []string) {
 
 	updatedBody, err = filtersLib.FilterLines(updatedBody, flags.GenericFilters)
 	if err != nil {
-		display.ExitError("failed to filter results: %s", err)
+		display.OutputError(&flags.OutputFormatConfig, "failed to filter results: %s", err)
 		return
 	}
 
@@ -87,13 +87,13 @@ func ListContainerRegistryPlans(_ *cobra.Command, _ []string) {
 func ListRancherAvailableVersions(cmd *cobra.Command, _ []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
 	serviceID, err := cmd.Flags().GetString("rancher-id")
 	if err != nil {
-		display.ExitError("failed to get 'rancher-id' flag: %s", err)
+		display.OutputError(&flags.OutputFormatConfig, "failed to get 'rancher-id' flag: %s", err)
 		return
 	}
 
@@ -108,13 +108,13 @@ func ListRancherAvailableVersions(cmd *cobra.Command, _ []string) {
 func ListRancherAvailablePlans(cmd *cobra.Command, _ []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
 	serviceID, err := cmd.Flags().GetString("rancher-id")
 	if err != nil {
-		display.ExitError("failed to get 'rancher-id' flag: %s", err)
+		display.OutputError(&flags.OutputFormatConfig, "failed to get 'rancher-id' flag: %s", err)
 		return
 	}
 
@@ -129,14 +129,14 @@ func ListRancherAvailablePlans(cmd *cobra.Command, _ []string) {
 func ListDatabasesPlans(_ *cobra.Command, _ []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
 	endpoint := fmt.Sprintf("/cloud/project/%s/database/capabilities", projectID)
 	var body map[string]any
 	if err := httpLib.Client.Get(endpoint, &body); err != nil {
-		display.ExitError("failed to fetch database plans: %s", err)
+		display.OutputError(&flags.OutputFormatConfig, "failed to fetch database plans: %s", err)
 		return
 	}
 
@@ -147,7 +147,7 @@ func ListDatabasesPlans(_ *cobra.Command, _ []string) {
 
 	plans, err = filtersLib.FilterLines(plans, flags.GenericFilters)
 	if err != nil {
-		display.ExitError("failed to filter results: %s", err)
+		display.OutputError(&flags.OutputFormatConfig, "failed to filter results: %s", err)
 		return
 	}
 
@@ -157,14 +157,14 @@ func ListDatabasesPlans(_ *cobra.Command, _ []string) {
 func ListDatabasesNodeFlavors(_ *cobra.Command, _ []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
 	endpoint := fmt.Sprintf("/cloud/project/%s/database/capabilities", projectID)
 	var body map[string]any
 	if err := httpLib.Client.Get(endpoint, &body); err != nil {
-		display.ExitError("failed to fetch database plans: %s", err)
+		display.OutputError(&flags.OutputFormatConfig, "failed to fetch database plans: %s", err)
 		return
 	}
 
@@ -184,7 +184,7 @@ func ListDatabasesNodeFlavors(_ *cobra.Command, _ []string) {
 
 	flavors, err = filtersLib.FilterLines(flavors, flags.GenericFilters)
 	if err != nil {
-		display.ExitError("failed to filter results: %s", err)
+		display.OutputError(&flags.OutputFormatConfig, "failed to filter results: %s", err)
 		return
 	}
 
@@ -194,14 +194,14 @@ func ListDatabasesNodeFlavors(_ *cobra.Command, _ []string) {
 func ListDatabaseEngines(_ *cobra.Command, _ []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
 	endpoint := fmt.Sprintf("/cloud/project/%s/database/capabilities", projectID)
 	var body map[string]any
 	if err := httpLib.Client.Get(endpoint, &body); err != nil {
-		display.ExitError("failed to fetch database engines: %s", err)
+		display.OutputError(&flags.OutputFormatConfig, "failed to fetch database engines: %s", err)
 		return
 	}
 
@@ -224,7 +224,7 @@ func ListDatabaseEngines(_ *cobra.Command, _ []string) {
 
 	engines, err = filtersLib.FilterLines(engines, flags.GenericFilters)
 	if err != nil {
-		display.ExitError("failed to filter results: %s", err)
+		display.OutputError(&flags.OutputFormatConfig, "failed to filter results: %s", err)
 		return
 	}
 

--- a/internal/services/cloud/cloud_region.go
+++ b/internal/services/cloud/cloud_region.go
@@ -24,7 +24,7 @@ var (
 func ListCloudRegions(_ *cobra.Command, _ []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
@@ -34,7 +34,7 @@ func ListCloudRegions(_ *cobra.Command, _ []string) {
 func GetCloudRegion(_ *cobra.Command, args []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 

--- a/internal/services/cloud/cloud_ssh_key.go
+++ b/internal/services/cloud/cloud_ssh_key.go
@@ -26,20 +26,20 @@ var (
 func ListCloudSSHKeys(_ *cobra.Command, _ []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 	path := fmt.Sprintf("/cloud/project/%s/sshkey", projectID)
 
 	var body []map[string]any
 	if err := httpLib.Client.Get(path, &body); err != nil {
-		display.ExitError("failed to fetch SSH keys: %s", err)
+		display.OutputError(&flags.OutputFormatConfig, "failed to fetch SSH keys: %s", err)
 		return
 	}
 
 	body, err = filtersLib.FilterLines(body, flags.GenericFilters)
 	if err != nil {
-		display.ExitError("failed to filter results: %s", err)
+		display.OutputError(&flags.OutputFormatConfig, "failed to filter results: %s", err)
 		return
 	}
 
@@ -49,7 +49,7 @@ func ListCloudSSHKeys(_ *cobra.Command, _ []string) {
 func GetCloudSSHKey(_ *cobra.Command, args []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 

--- a/internal/services/cloud/cloud_storage_block.go
+++ b/internal/services/cloud/cloud_storage_block.go
@@ -51,7 +51,7 @@ var (
 func ListCloudVolumes(_ *cobra.Command, _ []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
@@ -61,7 +61,7 @@ func ListCloudVolumes(_ *cobra.Command, _ []string) {
 func GetVolume(_ *cobra.Command, args []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
@@ -71,7 +71,7 @@ func GetVolume(_ *cobra.Command, args []string) {
 func EditVolume(cmd *cobra.Command, args []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
@@ -82,7 +82,7 @@ func EditVolume(cmd *cobra.Command, args []string) {
 		VolumeSpec,
 		assets.CloudOpenapiSchema,
 	); err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 }
@@ -90,7 +90,7 @@ func EditVolume(cmd *cobra.Command, args []string) {
 func CreateVolume(cmd *cobra.Command, args []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
@@ -105,45 +105,45 @@ func CreateVolume(cmd *cobra.Command, args []string) {
 		[]string{"name", "size", "type"},
 	)
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
 	if !flags.WaitForTask {
-		fmt.Printf("\n⚡️ Volume creation started successfully (operation ID: %s)\n", task["id"])
-		fmt.Printf("You can check the status of the operation with: `ovhcloud cloud operation get %s`\n", task["id"])
+		display.OutputInfo(&flags.OutputFormatConfig, task, `⚡️ Volume creation started successfully (operation ID: %s)
+You can check the status of the operation with: 'ovhcloud cloud operation get %[1]s'`, task["id"])
 		return
 	}
 
 	volumeID, err := waitForCloudOperation(projectID, task["id"].(string), "ablockstorage.CreateVolume", 10*time.Minute)
 	if err != nil {
-		display.ExitError("failed to wait for volume creation: %s", err)
+		display.OutputError(&flags.OutputFormatConfig, "failed to wait for volume creation: %s", err)
 		return
 	}
 
-	fmt.Printf("✅ Volume %s created successfully\n", volumeID)
+	display.OutputInfo(&flags.OutputFormatConfig, nil, "✅ Volume %s created successfully", volumeID)
 }
 
 func DeleteVolume(_ *cobra.Command, args []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
 	endpoint := fmt.Sprintf("/cloud/project/%s/volume/%s", projectID, url.PathEscape(args[0]))
 	if err := httpLib.Client.Delete(endpoint, nil); err != nil {
-		display.ExitError("failed to delete volume: %s", err)
+		display.OutputError(&flags.OutputFormatConfig, "failed to delete volume: %s", err)
 		return
 	}
 
-	fmt.Printf("✅ Volume %s deleted successfully\n", args[0])
+	display.OutputInfo(&flags.OutputFormatConfig, nil, "✅ Volume %s deleted successfully", args[0])
 }
 
 func AttachVolumeToInstance(_ *cobra.Command, args []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
@@ -152,17 +152,17 @@ func AttachVolumeToInstance(_ *cobra.Command, args []string) {
 		map[string]string{"instanceId": args[1]},
 		nil,
 	); err != nil {
-		display.ExitError("failed to attach volume: %s", err)
+		display.OutputError(&flags.OutputFormatConfig, "failed to attach volume: %s", err)
 		return
 	}
 
-	fmt.Printf("✅ Volume %s attached to instance %s successfully\n", args[0], args[1])
+	display.OutputInfo(&flags.OutputFormatConfig, nil, "✅ Volume %s attached to instance %s successfully", args[0], args[1])
 }
 
 func DetachVolumeFromInstance(_ *cobra.Command, args []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
@@ -171,17 +171,17 @@ func DetachVolumeFromInstance(_ *cobra.Command, args []string) {
 		map[string]string{"instanceId": args[1]},
 		nil,
 	); err != nil {
-		display.ExitError("failed to detach volume: %s", err)
+		display.OutputError(&flags.OutputFormatConfig, "failed to detach volume: %s", err)
 		return
 	}
 
-	fmt.Printf("✅ Volume %s detached from instance %s successfully\n", args[0], args[1])
+	display.OutputInfo(&flags.OutputFormatConfig, nil, "✅ Volume %s detached from instance %s successfully", args[0], args[1])
 }
 
 func CreateVolumeSnapshot(_ *cobra.Command, args []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
@@ -191,17 +191,17 @@ func CreateVolumeSnapshot(_ *cobra.Command, args []string) {
 	)
 
 	if err := httpLib.Client.Post(endpoint, VolumeSnapShotSpec, &response); err != nil {
-		display.ExitError("failed to create snapshot: %s", err)
+		display.OutputError(&flags.OutputFormatConfig, "failed to create snapshot: %s", err)
 		return
 	}
 
-	fmt.Printf("✅ Snapshot for volume %s created successfully, id : %s\n", args[0], response["id"])
+	display.OutputInfo(&flags.OutputFormatConfig, response, "✅ Snapshot for volume %s created successfully, id : %s", args[0], response["id"])
 }
 
 func ListVolumeSnapshots(cmd *cobra.Command, args []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
@@ -209,7 +209,7 @@ func ListVolumeSnapshots(cmd *cobra.Command, args []string) {
 
 	volume, err := cmd.Flags().GetString("volume-id")
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 	if volume != "" {
@@ -222,33 +222,33 @@ func ListVolumeSnapshots(cmd *cobra.Command, args []string) {
 func DeleteVolumeSnapshot(_ *cobra.Command, args []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
 	endpoint := fmt.Sprintf("/cloud/project/%s/volume/snapshot/%s", projectID, url.PathEscape(args[0]))
 	if err := httpLib.Client.Delete(endpoint, nil); err != nil {
-		display.ExitError("failed to delete snapshot: %s", err)
+		display.OutputError(&flags.OutputFormatConfig, "failed to delete snapshot: %s", err)
 		return
 	}
 
-	fmt.Printf("✅ Snapshot %s deleted successfully\n", args[0])
+	display.OutputInfo(&flags.OutputFormatConfig, nil, "✅ Snapshot %s deleted successfully", args[0])
 }
 
 func UpsizeVolume(cmd *cobra.Command, args []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
 	size, err := strconv.Atoi(args[1])
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 	if size <= 0 {
-		display.ExitError("size must be a positive integer")
+		display.OutputError(&flags.OutputFormatConfig, "size must be a positive integer")
 		return
 	}
 
@@ -258,11 +258,11 @@ func UpsizeVolume(cmd *cobra.Command, args []string) {
 		map[string]int{"size": size},
 		nil,
 	); err != nil {
-		display.ExitError("failed to upsize volume: %s", err)
+		display.OutputError(&flags.OutputFormatConfig, "failed to upsize volume: %s", err)
 		return
 	}
 
-	fmt.Printf("✅ Volume %s upsized successfully to %dGB\n", args[0], size)
+	display.OutputInfo(&flags.OutputFormatConfig, nil, "✅ Volume %s upscaled successfully to %dGB", args[0], size)
 }
 
 func findVolumeBackup(backupId string) (string, map[string]any, error) {
@@ -296,14 +296,14 @@ func findVolumeBackup(backupId string) (string, map[string]any, error) {
 func ListVolumeBackups(_ *cobra.Command, args []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
 	// Fetch regions with volume feature available
 	regions, err := getCloudRegionsWithFeatureAvailable(projectID, "volume")
 	if err != nil {
-		display.ExitError("failed to fetch regions with volume feature available: %s", err)
+		display.OutputError(&flags.OutputFormatConfig, "failed to fetch regions with volume feature available: %s", err)
 		return
 	}
 
@@ -311,7 +311,7 @@ func ListVolumeBackups(_ *cobra.Command, args []string) {
 	endpoint := fmt.Sprintf("/cloud/project/%s/region", projectID)
 	volumeBackups, err := httpLib.FetchObjectsParallel[[]map[string]any](endpoint+"/%s/volumeBackup", regions, true)
 	if err != nil {
-		display.ExitError("failed to fetch volume backups: %s", err)
+		display.OutputError(&flags.OutputFormatConfig, "failed to fetch volume backups: %s", err)
 		return
 	}
 
@@ -324,7 +324,7 @@ func ListVolumeBackups(_ *cobra.Command, args []string) {
 	// Filter results
 	allVolumeBackups, err = filtersLib.FilterLines(allVolumeBackups, flags.GenericFilters)
 	if err != nil {
-		display.ExitError("failed to filter results: %s", err)
+		display.OutputError(&flags.OutputFormatConfig, "failed to filter results: %s", err)
 		return
 	}
 
@@ -334,7 +334,7 @@ func ListVolumeBackups(_ *cobra.Command, args []string) {
 func GetVolumeBackup(_ *cobra.Command, args []string) {
 	_, backup, err := findVolumeBackup(args[0])
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
@@ -344,22 +344,22 @@ func GetVolumeBackup(_ *cobra.Command, args []string) {
 func DeleteVolumeBackup(_ *cobra.Command, args []string) {
 	endpoint, _, err := findVolumeBackup(args[0])
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
 	if err := httpLib.Client.Delete(endpoint, nil); err != nil {
-		display.ExitError("failed to delete volume backup: %s", err)
+		display.OutputError(&flags.OutputFormatConfig, "failed to delete volume backup: %s", err)
 		return
 	}
 
-	fmt.Printf("✅ Volume backup %s deleted successfully\n", args[0])
+	display.OutputInfo(&flags.OutputFormatConfig, nil, "✅ Volume backup %s deleted successfully", args[0])
 }
 
 func CreateVolumeBackup(cmd *cobra.Command, args []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
@@ -369,7 +369,7 @@ func CreateVolumeBackup(cmd *cobra.Command, args []string) {
 		fmt.Sprintf("/cloud/project/%s/volume/%s", projectID, url.PathEscape(args[0])),
 		&volume,
 	); err != nil {
-		display.ExitError("failed to fetch volume: %s", err)
+		display.OutputError(&flags.OutputFormatConfig, "failed to fetch volume: %s", err)
 		return
 	}
 
@@ -383,17 +383,17 @@ func CreateVolumeBackup(cmd *cobra.Command, args []string) {
 		}
 	)
 	if err := httpLib.Client.Post(endpoint, body, &response); err != nil {
-		display.ExitError("failed to create volume backup: %s", err)
+		display.OutputError(&flags.OutputFormatConfig, "failed to create volume backup: %s", err)
 		return
 	}
 
-	fmt.Printf("✅ Volume backup for volume %s created successfully, id : %s\n", args[0], response["id"])
+	display.OutputInfo(&flags.OutputFormatConfig, response, "✅ Volume backup for volume %s created successfully (id: %s)", args[0], response["id"])
 }
 
 func RestoreVolumeBackup(_ *cobra.Command, args []string) {
 	endpoint, _, err := findVolumeBackup(args[0])
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
@@ -402,17 +402,17 @@ func RestoreVolumeBackup(_ *cobra.Command, args []string) {
 		map[string]string{"volumeId": args[1]},
 		nil,
 	); err != nil {
-		display.ExitError("failed to restore volume backup: %s", err)
+		display.OutputError(&flags.OutputFormatConfig, "failed to restore volume backup: %s", err)
 		return
 	}
 
-	fmt.Printf("✅ Volume backup %s is being restored to volume %s\n", args[0], args[1])
+	display.OutputInfo(&flags.OutputFormatConfig, nil, "✅ Volume backup %s is being restored to volume %s", args[0], args[1])
 }
 
 func CreateVolumeFromBackup(cmd *cobra.Command, args []string) {
 	endpoint, _, err := findVolumeBackup(args[0])
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
@@ -426,9 +426,9 @@ func CreateVolumeFromBackup(cmd *cobra.Command, args []string) {
 		body,
 		&response,
 	); err != nil {
-		display.ExitError("failed to create volume from backup: %s", err)
+		display.OutputError(&flags.OutputFormatConfig, "failed to create volume from backup: %s", err)
 		return
 	}
 
-	fmt.Printf("✅ Volume %s created successfully from backup %s\n", response["id"], args[0])
+	display.OutputInfo(&flags.OutputFormatConfig, response, "✅ Volume %s created successfully from backup %s", response["id"], args[0])
 }

--- a/internal/services/cloud/cloud_storage_s3.go
+++ b/internal/services/cloud/cloud_storage_s3.go
@@ -123,14 +123,14 @@ func locateStorageS3Container(projectID, containerName string) (string, map[stri
 func ListCloudStorageS3(_ *cobra.Command, _ []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
 	// Fetch regions with storage feature available
 	regions, err := getCloudRegionsWithFeatureAvailable(projectID, "storage-s3-high-perf", "storage-s3-standard")
 	if err != nil {
-		display.ExitError("failed to fetch regions with storage feature available: %s", err)
+		display.OutputError(&flags.OutputFormatConfig, "failed to fetch regions with storage feature available: %s", err)
 		return
 	}
 
@@ -138,7 +138,7 @@ func ListCloudStorageS3(_ *cobra.Command, _ []string) {
 	url := fmt.Sprintf("/cloud/project/%s/region", projectID)
 	containers, err := httpLib.FetchObjectsParallel[[]map[string]any](url+"/%s/storage", regions, true)
 	if err != nil {
-		display.ExitError("failed to fetch storage containers: %s", err)
+		display.OutputError(&flags.OutputFormatConfig, "failed to fetch storage containers: %s", err)
 		return
 	}
 
@@ -151,7 +151,7 @@ func ListCloudStorageS3(_ *cobra.Command, _ []string) {
 	// Filter results
 	allContainers, err = filtersLib.FilterLines(allContainers, flags.GenericFilters)
 	if err != nil {
-		display.ExitError("failed to filter results: %s", err)
+		display.OutputError(&flags.OutputFormatConfig, "failed to filter results: %s", err)
 		return
 	}
 
@@ -161,20 +161,20 @@ func ListCloudStorageS3(_ *cobra.Command, _ []string) {
 func GetStorageS3(_ *cobra.Command, args []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
 	_, foundContainer, err := locateStorageS3Container(projectID, args[0])
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
 	// Convert used space to float
 	usedFloat, err := foundContainer["objectsSize"].(json.Number).Float64()
 	if err != nil {
-		display.ExitError("error parsing used storage: %s", err)
+		display.OutputError(&flags.OutputFormatConfig, "error parsing used storage: %s", err)
 		return
 	}
 	foundContainer["objectsSize"] = usedFloat
@@ -185,13 +185,13 @@ func GetStorageS3(_ *cobra.Command, args []string) {
 func EditStorageS3(cmd *cobra.Command, args []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
 	foundURL, _, err := locateStorageS3Container(projectID, args[0])
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
@@ -202,20 +202,20 @@ func EditStorageS3(cmd *cobra.Command, args []string) {
 		StorageS3Spec,
 		assets.CloudOpenapiSchema,
 	); err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 }
 
 func CreateStorageS3(cmd *cobra.Command, args []string) {
 	if len(args) == 0 {
-		display.ExitError("region argument is required\n\n%s", cmd.UsageString())
+		display.OutputError(&flags.OutputFormatConfig, "region argument is required\n\n%s", cmd.UsageString())
 		return
 	}
 
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
@@ -229,49 +229,49 @@ func CreateStorageS3(cmd *cobra.Command, args []string) {
 		assets.CloudOpenapiSchema,
 		[]string{"name"})
 	if err != nil {
-		display.ExitError("failed to create s3 storage container: %s", err)
+		display.OutputError(&flags.OutputFormatConfig, "failed to create s3 storage container: %s", err)
 		return
 	}
 
-	fmt.Printf("✅ Container %s created successfully\n", container["name"])
+	display.OutputInfo(&flags.OutputFormatConfig, container, "✅ Container %s created successfully", container["name"])
 }
 
 func DeleteStorageS3(_ *cobra.Command, args []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
 	foundURL, _, err := locateStorageS3Container(projectID, args[0])
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
 	if err := httpLib.Client.Delete(foundURL, nil); err != nil {
-		display.ExitError("failed to delete storage container: %s", err)
+		display.OutputError(&flags.OutputFormatConfig, "failed to delete storage container: %s", err)
 		return
 	}
 
-	fmt.Printf("✅ Storage container %s deleted successfully\n", args[0])
+	display.OutputInfo(&flags.OutputFormatConfig, nil, "✅ Storage container %s deleted successfully", args[0])
 }
 
 func StorageS3BulkDeleteObjects(_ *cobra.Command, args []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
 	if len(StorageS3ObjectsToDelete) == 0 {
-		display.ExitWarning("no objects to delete. Use --object flag to specify objects to delete")
+		display.OutputWarning(&flags.OutputFormatConfig, "no objects to delete. Use --object flag to specify objects to delete")
 		return
 	}
 
 	foundURL, _, err := locateStorageS3Container(projectID, args[0])
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
@@ -287,7 +287,7 @@ func StorageS3BulkDeleteObjects(_ *cobra.Command, args []string) {
 			// Object name with version ID
 			objectsToDelete = append(objectsToDelete, map[string]any{"key": parts[0], "versionId": parts[1]})
 		default:
-			display.ExitError("invalid object format: %s. Use <object_name> or <object_name>:<version_id>", object)
+			display.OutputError(&flags.OutputFormatConfig, "invalid object format: %s. Use <object_name> or <object_name>:<version_id>", object)
 			return
 		}
 	}
@@ -295,23 +295,23 @@ func StorageS3BulkDeleteObjects(_ *cobra.Command, args []string) {
 	if err := httpLib.Client.Post(foundURL+"/bulkDeleteObjects", map[string]any{
 		"objects": objectsToDelete,
 	}, nil); err != nil {
-		display.ExitError("failed to delete objects: %s", err)
+		display.OutputError(&flags.OutputFormatConfig, "failed to delete objects: %s", err)
 		return
 	}
 
-	fmt.Println("✅ Objects deleted successfully")
+	display.OutputInfo(&flags.OutputFormatConfig, nil, "✅ Objects deleted successfully")
 }
 
 func ListStorageS3Objects(_ *cobra.Command, args []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
 	foundURL, _, err := locateStorageS3Container(projectID, args[0])
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
@@ -340,13 +340,13 @@ func ListStorageS3Objects(_ *cobra.Command, args []string) {
 func GetStorageS3Object(_ *cobra.Command, args []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
 	foundURL, _, err := locateStorageS3Container(projectID, args[0])
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
@@ -356,13 +356,13 @@ func GetStorageS3Object(_ *cobra.Command, args []string) {
 func EditStorageS3Object(cmd *cobra.Command, args []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
 	foundURL, _, err := locateStorageS3Container(projectID, args[0])
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
@@ -373,7 +373,7 @@ func EditStorageS3Object(cmd *cobra.Command, args []string) {
 		StorageS3ObjectSpec,
 		assets.CloudOpenapiSchema,
 	); err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 }
@@ -381,34 +381,34 @@ func EditStorageS3Object(cmd *cobra.Command, args []string) {
 func DeleteStorageS3Object(_ *cobra.Command, args []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
 	foundURL, _, err := locateStorageS3Container(projectID, args[0])
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
 	if err := httpLib.Client.Delete(foundURL+"/object/"+url.PathEscape(args[1]), nil); err != nil {
-		display.ExitError("failed to delete object: %s", err)
+		display.OutputError(&flags.OutputFormatConfig, "failed to delete object: %s", err)
 		return
 	}
 
-	fmt.Printf("✅ Object %s deleted successfully\n", args[1])
+	display.OutputInfo(&flags.OutputFormatConfig, nil, "✅ Object %s deleted successfully", args[1])
 }
 
 func ListStorageS3ObjectVersions(_ *cobra.Command, args []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
 	foundURL, _, err := locateStorageS3Container(projectID, args[0])
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
@@ -428,13 +428,13 @@ func ListStorageS3ObjectVersions(_ *cobra.Command, args []string) {
 func GetStorageS3ObjectVersion(_ *cobra.Command, args []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
 	foundURL, _, err := locateStorageS3Container(projectID, args[0])
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
@@ -446,13 +446,13 @@ func GetStorageS3ObjectVersion(_ *cobra.Command, args []string) {
 func EditStorageS3ObjectVersion(cmd *cobra.Command, args []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
 	foundURL, _, err := locateStorageS3Container(projectID, args[0])
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
@@ -463,7 +463,7 @@ func EditStorageS3ObjectVersion(cmd *cobra.Command, args []string) {
 		StorageS3ObjectSpec,
 		assets.CloudOpenapiSchema,
 	); err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 }
@@ -471,34 +471,34 @@ func EditStorageS3ObjectVersion(cmd *cobra.Command, args []string) {
 func DeleteStorageS3ObjectVersion(_ *cobra.Command, args []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
 	foundURL, _, err := locateStorageS3Container(projectID, args[0])
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
 	if err := httpLib.Client.Delete(foundURL+"/object/"+url.PathEscape(args[1])+"/version/"+url.PathEscape(args[2]), nil); err != nil {
-		display.ExitError("failed to delete object version: %s", err)
+		display.OutputError(&flags.OutputFormatConfig, "failed to delete object version: %s", err)
 		return
 	}
 
-	fmt.Printf("✅ Object version %s deleted successfully\n", args[2])
+	display.OutputInfo(&flags.OutputFormatConfig, nil, "✅ Object version %s deleted successfully", args[2])
 }
 
 func StorageS3GeneratePresignedURL(cmd *cobra.Command, args []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
 	foundURL, _, err := locateStorageS3Container(projectID, args[0])
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
@@ -511,30 +511,33 @@ func StorageS3GeneratePresignedURL(cmd *cobra.Command, args []string) {
 		assets.CloudOpenapiSchema,
 		nil)
 	if err != nil {
-		display.ExitError("failed to generate presigned URL: %s", err)
+		display.OutputError(&flags.OutputFormatConfig, "failed to generate presigned URL: %s", err)
 		return
 	}
 
-	fmt.Println("✅ Presigned URL generated successfully:")
-	fmt.Printf("-> %s %s\n", response["method"], response["url"])
+	var sb strings.Builder
+	sb.WriteString("✅ Presigned URL generated successfully:\n")
+	sb.WriteString(fmt.Sprintf("-> %s %s\n", response["method"], response["url"]))
 	if headers, ok := response["signedHeaders"].(map[string]any); ok {
-		fmt.Println("-> Headers:")
+		sb.WriteString("-> Headers:\n")
 		for key, value := range headers {
-			fmt.Printf("   - %s: %s\n", key, value)
+			sb.WriteString(fmt.Sprintf("   - %s: %s\n", key, value))
 		}
 	}
+
+	display.OutputInfo(&flags.OutputFormatConfig, response, "%s", &sb)
 }
 
 func StorageS3AddUser(cmd *cobra.Command, args []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
 	foundURL, _, err := locateStorageS3Container(projectID, args[0])
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
@@ -545,17 +548,17 @@ func StorageS3AddUser(cmd *cobra.Command, args []string) {
 	if err := httpLib.Client.Post(endpoint, map[string]any{
 		"roleName": userRole,
 	}, nil); err != nil {
-		display.ExitError("failed to add user: %s", err)
+		display.OutputError(&flags.OutputFormatConfig, "failed to add user: %s", err)
 		return
 	}
 
-	fmt.Printf("✅ User %s successfully added to the bucket\n", args[1])
+	display.OutputInfo(&flags.OutputFormatConfig, nil, "✅ User %s successfully added to the bucket", args[1])
 }
 
 func ListStorageS3Credentials(_ *cobra.Command, args []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
@@ -566,14 +569,14 @@ func ListStorageS3Credentials(_ *cobra.Command, args []string) {
 func CreateStorageS3Credentials(cmd *cobra.Command, args []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
 	credentials := map[string]any{}
 	endpoint := fmt.Sprintf("/cloud/project/%s/user/%s/s3Credentials", projectID, url.PathEscape(args[0]))
 	if err := httpLib.Client.Post(endpoint, nil, &credentials); err != nil {
-		display.ExitError("failed to create S3 credentials: %s", err)
+		display.OutputError(&flags.OutputFormatConfig, "failed to create S3 credentials: %s", err)
 		return
 	}
 
@@ -583,37 +586,37 @@ func CreateStorageS3Credentials(cmd *cobra.Command, args []string) {
 func DeleteStorageS3Credentials(_ *cobra.Command, args []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
 	endpoint := fmt.Sprintf("/cloud/project/%s/user/%s/s3Credentials/%s", projectID, url.PathEscape(args[0]), url.PathEscape(args[1]))
 	if err := httpLib.Client.Delete(endpoint, nil); err != nil {
-		display.ExitError("failed to delete S3 credentials: %s", err)
+		display.OutputError(&flags.OutputFormatConfig, "failed to delete S3 credentials: %s", err)
 		return
 	}
 
-	fmt.Printf("✅ S3 credentials %s for user %s deleted successfully\n", args[1], args[0])
+	display.OutputInfo(&flags.OutputFormatConfig, nil, "✅ S3 credentials %s for user %s deleted successfully", args[1], args[0])
 }
 
 func GetStorageS3Credentials(_ *cobra.Command, args []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
 	endpoint := fmt.Sprintf("/cloud/project/%s/user/%s/s3Credentials/%s", projectID, url.PathEscape(args[0]), url.PathEscape(args[1]))
 	var credentials map[string]any
 	if err := httpLib.Client.Get(endpoint, &credentials); err != nil {
-		display.ExitError("failed to get S3 credentials: %s", err)
+		display.OutputError(&flags.OutputFormatConfig, "failed to get S3 credentials: %s", err)
 		return
 	}
 
 	// Fetch credentials secret
 	secretEndpoint := fmt.Sprintf("/cloud/project/%s/user/%s/s3Credentials/%s/secret", projectID, url.PathEscape(args[0]), url.PathEscape(args[1]))
 	if err := httpLib.Client.Post(secretEndpoint, nil, &credentials); err != nil {
-		display.ExitError("failed to get S3 credentials secret: %s", err)
+		display.OutputError(&flags.OutputFormatConfig, "failed to get S3 credentials secret: %s", err)
 		return
 	}
 

--- a/internal/services/cloud/cloud_storage_swift.go
+++ b/internal/services/cloud/cloud_storage_swift.go
@@ -29,7 +29,7 @@ var (
 func ListCloudStorageSwift(_ *cobra.Command, _ []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
@@ -39,7 +39,7 @@ func ListCloudStorageSwift(_ *cobra.Command, _ []string) {
 func GetStorageSwift(_ *cobra.Command, args []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
@@ -49,7 +49,7 @@ func GetStorageSwift(_ *cobra.Command, args []string) {
 func EditStorageSwift(cmd *cobra.Command, args []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
@@ -62,7 +62,7 @@ func EditStorageSwift(cmd *cobra.Command, args []string) {
 		},
 		assets.CloudOpenapiSchema,
 	); err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 }

--- a/internal/services/cloud/cloud_user.go
+++ b/internal/services/cloud/cloud_user.go
@@ -50,20 +50,20 @@ var (
 func ListCloudUsers(_ *cobra.Command, _ []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 	path := fmt.Sprintf("/cloud/project/%s/user", projectID)
 
 	var body []map[string]any
 	if err := httpLib.Client.Get(path, &body); err != nil {
-		display.ExitError("failed to fetch SSH keys: %s", err)
+		display.OutputError(&flags.OutputFormatConfig, "failed to fetch SSH keys: %s", err)
 		return
 	}
 
 	body, err = filtersLib.FilterLines(body, flags.GenericFilters)
 	if err != nil {
-		display.ExitError("failed to filter results: %s", err)
+		display.OutputError(&flags.OutputFormatConfig, "failed to filter results: %s", err)
 		return
 	}
 
@@ -73,7 +73,7 @@ func ListCloudUsers(_ *cobra.Command, _ []string) {
 func GetCloudUser(_ *cobra.Command, args []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
@@ -83,7 +83,7 @@ func GetCloudUser(_ *cobra.Command, args []string) {
 func CreateCloudUser(cmd *cobra.Command, args []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
@@ -97,34 +97,34 @@ func CreateCloudUser(cmd *cobra.Command, args []string) {
 		nil,
 	)
 	if err != nil {
-		display.ExitError("failed to create user: %s", err)
+		display.OutputError(&flags.OutputFormatConfig, "failed to create user: %s", err)
 		return
 	}
 
-	fmt.Printf("✅ User '%s' created successfully\n", client["id"])
+	display.OutputInfo(&flags.OutputFormatConfig, client, "✅ User '%s' created successfully", client["id"])
 }
 
 func DeleteCloudUser(_ *cobra.Command, args []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
 	endpoint := fmt.Sprintf("/cloud/project/%s/user/%s", projectID, url.PathEscape(args[0]))
 
 	if err := httpLib.Client.Delete(endpoint, nil); err != nil {
-		display.ExitError("failed to delete user: %s", err)
+		display.OutputError(&flags.OutputFormatConfig, "failed to delete user: %s", err)
 		return
 	}
 
-	fmt.Printf("✅ User '%s' deleted successfully\n", args[0])
+	display.OutputInfo(&flags.OutputFormatConfig, nil, "✅ User '%s' deleted successfully", args[0])
 }
 
 func CreateUserS3Policy(cmd *cobra.Command, args []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
@@ -132,11 +132,11 @@ func CreateUserS3Policy(cmd *cobra.Command, args []string) {
 
 	jsonCliParameters, err := json.Marshal(StorageS3ContainerPolicySpec)
 	if err != nil {
-		display.ExitError("failed to prepare arguments from command line: %s", err)
+		display.OutputError(&flags.OutputFormatConfig, "failed to prepare arguments from command line: %s", err)
 		return
 	}
 	if err := json.Unmarshal(jsonCliParameters, &parameters); err != nil {
-		display.ExitError("failed to parse arguments from command line: %s", err)
+		display.OutputError(&flags.OutputFormatConfig, "failed to parse arguments from command line: %s", err)
 		return
 	}
 
@@ -148,7 +148,7 @@ func CreateUserS3Policy(cmd *cobra.Command, args []string) {
 			stdin = append(stdin, scanner.Bytes()...)
 		}
 		if err := scanner.Err(); err != nil {
-			display.ExitError("failed to read from stdin: %s", err)
+			display.OutputError(&flags.OutputFormatConfig, "failed to read from stdin: %s", err)
 			return
 		}
 
@@ -165,24 +165,24 @@ func CreateUserS3Policy(cmd *cobra.Command, args []string) {
 			map[string]any{},
 		)
 		if err != nil {
-			display.ExitError("failed to fetch API call examples: %s", err)
+			display.OutputError(&flags.OutputFormatConfig, "failed to fetch API call examples: %s", err)
 			return
 		}
 
 		_, choice, err := display.RunGenericChoicePicker("Please select a creation example", examples, 0)
 		if err != nil {
-			display.ExitError("failed to run choice picker: %s", err)
+			display.OutputError(&flags.OutputFormatConfig, "failed to run choice picker: %s", err)
 			return
 		}
 
 		if choice == "" {
-			display.ExitError("no example selected, exiting...")
+			display.OutputError(&flags.OutputFormatConfig, "no example selected, exiting…")
 			return
 		}
 
 		newValue, err := editor.EditValueWithEditor([]byte(choice))
 		if err != nil {
-			display.ExitError("failed to edit parameters using editor: %s", err)
+			display.OutputError(&flags.OutputFormatConfig, "failed to edit parameters using editor: %s", err)
 			return
 		}
 
@@ -193,20 +193,20 @@ func CreateUserS3Policy(cmd *cobra.Command, args []string) {
 
 		fileContent, err := os.ReadFile(flags.ParametersFile)
 		if err != nil {
-			display.ExitError("failed to open given file: %s", err)
+			display.OutputError(&flags.OutputFormatConfig, "failed to open given file: %s", err)
 			return
 		}
 		parameters["policy"] = string(fileContent)
 	}
 
 	if policy, ok := parameters["policy"]; !ok || policy == "" {
-		display.ExitError("A policy must be provided\n\n%s", cmd.UsageString())
+		display.OutputError(&flags.OutputFormatConfig, "A policy must be provided\n\n%s", cmd.UsageString())
 		return
 	}
 
 	out, err := json.MarshalIndent(parameters, "", " ")
 	if err != nil {
-		display.ExitError("parameters cannot be marshalled: %s", err)
+		display.OutputError(&flags.OutputFormatConfig, "parameters cannot be marshalled: %s", err)
 		return
 	}
 
@@ -214,17 +214,17 @@ func CreateUserS3Policy(cmd *cobra.Command, args []string) {
 
 	endpoint := fmt.Sprintf("/cloud/project/%s/user/%s/policy", projectID, url.PathEscape(args[0]))
 	if err := httpLib.Client.Post(endpoint, parameters, nil); err != nil {
-		display.ExitError("error creating resource: %s", err)
+		display.OutputError(&flags.OutputFormatConfig, "error creating resource: %s", err)
 		return
 	}
 
-	fmt.Printf("✅ Policy created successfully for user %s\n", args[0])
+	display.OutputInfo(&flags.OutputFormatConfig, nil, "✅ Policy created successfully for user %s", args[0])
 }
 
 func GetUserS3Policy(_ *cobra.Command, args []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 

--- a/internal/services/cloud/utils.go
+++ b/internal/services/cloud/utils.go
@@ -153,7 +153,7 @@ func waitForCloudOperation(projectID, operationID, action string, retryDuration 
 		case <-ctx.Done():
 			return "", errors.New("timeout waiting for operation to complete")
 		case <-ticker.C:
-			log.Printf("Still waiting for operation to complete (status=%s) ...", operation.Status)
+			log.Printf("Still waiting for operation to complete (status=%s)…", operation.Status)
 			continue
 		}
 	}

--- a/internal/services/common/common.go
+++ b/internal/services/common/common.go
@@ -42,13 +42,13 @@ var (
 func ManageListRequest(path, idField string, columnsToDisplay, filters []string) {
 	body, err := httpLib.FetchExpandedArray(path, idField)
 	if err != nil {
-		display.ExitError("failed to fetch results: %s", err)
+		display.OutputError(&flags.OutputFormatConfig, "failed to fetch results: %s", err)
 		return
 	}
 
 	body, err = filtersLib.FilterLines(body, filters)
 	if err != nil {
-		display.ExitError("failed to filter results: %s", err)
+		display.OutputError(&flags.OutputFormatConfig, "failed to filter results: %s", err)
 		return
 	}
 
@@ -58,7 +58,7 @@ func ManageListRequest(path, idField string, columnsToDisplay, filters []string)
 func ManageListRequestNoExpand(path string, columnsToDisplay, filters []string) {
 	body, err := httpLib.FetchArray(path, "")
 	if err != nil {
-		display.ExitError("failed to fetch results: %s", err)
+		display.OutputError(&flags.OutputFormatConfig, "failed to fetch results: %s", err)
 		return
 	}
 
@@ -69,7 +69,7 @@ func ManageListRequestNoExpand(path string, columnsToDisplay, filters []string) 
 
 	objects, err = filtersLib.FilterLines(objects, filters)
 	if err != nil {
-		display.ExitError("failed to filter results: %s", err)
+		display.OutputError(&flags.OutputFormatConfig, "failed to filter results: %s", err)
 		return
 	}
 
@@ -81,7 +81,7 @@ func ManageObjectRequest(path, objectID, templateContent string) {
 
 	var object map[string]any
 	if err := httpLib.Client.Get(url, &object); err != nil {
-		display.ExitError("error fetching %s: %s", url, err)
+		display.OutputError(&flags.OutputFormatConfig, "error fetching %s: %s", url, err)
 		return
 	}
 
@@ -131,7 +131,7 @@ func CreateResource(cmd *cobra.Command, path, endpoint, defaultExample string,
 		}
 
 		if choice == "" {
-			return nil, errors.New("No example selected, exiting...")
+			return nil, errors.New("no example selected, exiting…")
 		}
 
 		newValue, err := editor.EditValueWithEditor([]byte(choice))
@@ -190,7 +190,7 @@ func CreateResource(cmd *cobra.Command, path, endpoint, defaultExample string,
 
 func EditResource(cmd *cobra.Command, path, url string, cliParams any, openapiSpec []byte) error {
 	if cmd.Flags().NFlag() == 0 {
-		fmt.Println("🟠 No parameters given, nothing to edit")
+		display.OutputInfo(&flags.OutputFormatConfig, nil, "🟠 No parameters given, nothing to edit")
 		return nil
 	}
 
@@ -232,7 +232,7 @@ func EditResource(cmd *cobra.Command, path, url string, cliParams any, openapiSp
 			return fmt.Errorf("failed to update resource: %w", err)
 		}
 
-		fmt.Println("✅ Resource updated succesfully ...")
+		display.OutputInfo(&flags.OutputFormatConfig, nil, "✅ Resource updated successfully")
 
 		return nil
 	}
@@ -254,7 +254,7 @@ func EditResource(cmd *cobra.Command, path, url string, cliParams any, openapiSp
 		return fmt.Errorf("failed to update resource: %w", err)
 	}
 
-	fmt.Println("✅ Resource updated succesfully ...")
+	display.OutputInfo(&flags.OutputFormatConfig, nil, "✅ Resource updated successfully")
 
 	return nil
 }

--- a/internal/services/config/config.go
+++ b/internal/services/config/config.go
@@ -28,11 +28,11 @@ func ShowConfig(_ *cobra.Command, _ []string) {
 func SetConfig(_ *cobra.Command, args []string) {
 	if _, ok := config.ConfigurableFields[args[0]]; !ok {
 		allowedKeys := slices.Collect(maps.Keys(config.ConfigurableFields))
-		display.ExitError("unknown configuration field %q, customizable fields are: %s", args[0], allowedKeys)
+		display.OutputError(&flags.OutputFormatConfig, "unknown configuration field %q, customizable fields are: %s", args[0], allowedKeys)
 		return
 	}
 	if err := config.SetConfigValue(flags.CliConfig, flags.CliConfigPath, "", args[0], args[1]); err != nil {
-		display.ExitError("failed to set configuration: %s", err)
+		display.OutputError(&flags.OutputFormatConfig, "failed to set configuration: %s", err)
 		return
 	}
 }
@@ -46,12 +46,12 @@ func SetEndpoint(_ *cobra.Command, args []string) {
 		// Check if given value is a valid URL
 		url, err := url.Parse(args[0])
 		if err != nil {
-			display.ExitError("invalid API endpoint %q, valid values are [EU, CA, US] or a valid URL", args[0])
+			display.OutputError(&flags.OutputFormatConfig, "invalid API endpoint %q, valid values are [EU, CA, US] or a valid URL", args[0])
 			return
 		}
 
 		if url.Scheme != "https" && url.Scheme != "http" {
-			display.ExitError(`given url has an invalid scheme, only "http" and "https" are allowed`)
+			display.OutputError(&flags.OutputFormatConfig, `given url has an invalid scheme, only "http" and "https" are allowed`)
 			return
 		}
 
@@ -59,7 +59,7 @@ func SetEndpoint(_ *cobra.Command, args []string) {
 	}
 
 	if err := config.SetConfigValue(flags.CliConfig, flags.CliConfigPath, "", "endpoint", endpoint); err != nil {
-		display.ExitError("failed to set API endpoint configuration: %s", err)
+		display.OutputError(&flags.OutputFormatConfig, "failed to set API endpoint configuration: %s", err)
 		return
 	}
 }

--- a/internal/services/dedicatedceph/dedicatedceph.go
+++ b/internal/services/dedicatedceph/dedicatedceph.go
@@ -44,7 +44,7 @@ func EditDedicatedCeph(cmd *cobra.Command, args []string) {
 		DedicatedCephSpec,
 		assets.DedicatedcephOpenapiSchema,
 	); err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 }

--- a/internal/services/dedicatednasha/dedicatednasha.go
+++ b/internal/services/dedicatednasha/dedicatednasha.go
@@ -44,7 +44,7 @@ func EditDedicatedNasHA(cmd *cobra.Command, args []string) {
 		DedicatedNasHASpec,
 		assets.DedicatednashaOpenapiSchema,
 	); err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 }

--- a/internal/services/domainname/domainname.go
+++ b/internal/services/domainname/domainname.go
@@ -44,7 +44,7 @@ func EditDomainName(cmd *cobra.Command, args []string) {
 		DomainSpec,
 		assets.DomainOpenapiSchema,
 	); err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 }

--- a/internal/services/domainzone/domainzone.go
+++ b/internal/services/domainzone/domainzone.go
@@ -33,7 +33,7 @@ func GetDomainZone(_ *cobra.Command, args []string) {
 	// Fetch domain zone
 	var object map[string]any
 	if err := httpLib.Client.Get(path, &object); err != nil {
-		display.ExitError("error fetching %s: %s\n", path, err)
+		display.OutputError(&flags.OutputFormatConfig, "error fetching %s: %s", path, err)
 		return
 	}
 
@@ -41,7 +41,7 @@ func GetDomainZone(_ *cobra.Command, args []string) {
 	path = fmt.Sprintf("/domain/zone/%s/record", url.PathEscape(args[0]))
 	records, err := httpLib.FetchExpandedArray(path, "")
 	if err != nil {
-		display.ExitError("error fetching records for %s: %s", args[0], err)
+		display.OutputError(&flags.OutputFormatConfig, "error fetching records for %s: %s", args[0], err)
 		return
 	}
 	object["records"] = records

--- a/internal/services/emailmxplan/emailmxplan.go
+++ b/internal/services/emailmxplan/emailmxplan.go
@@ -61,7 +61,7 @@ func EditEmailMXPlan(cmd *cobra.Command, args []string) {
 		EmailMXPlanSpec,
 		assets.EmailmxplanOpenapiSchema,
 	); err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 }

--- a/internal/services/emailpro/emailpro.go
+++ b/internal/services/emailpro/emailpro.go
@@ -61,7 +61,7 @@ func EditEmailPro(cmd *cobra.Command, args []string) {
 		EmailProSpec,
 		assets.EmailproOpenapiSchema,
 	); err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 }

--- a/internal/services/hostingprivatedatabase/hostingprivatedatabase.go
+++ b/internal/services/hostingprivatedatabase/hostingprivatedatabase.go
@@ -44,7 +44,7 @@ func EditHostingPrivateDatabase(cmd *cobra.Command, args []string) {
 		},
 		assets.HostingprivatedatabaseOpenapiSchema,
 	); err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 }

--- a/internal/services/iam/iam.go
+++ b/internal/services/iam/iam.go
@@ -78,7 +78,7 @@ func GetIAMPolicy(_ *cobra.Command, args []string) {
 
 	var object map[string]any
 	if err := httpLib.Client.Get(path, &object); err != nil {
-		display.ExitError("error fetching IAM policy %s: %s", args[0], err)
+		display.OutputError(&flags.OutputFormatConfig, "error fetching IAM policy %s: %s", args[0], err)
 		return
 	}
 
@@ -94,7 +94,7 @@ func EditIAMPolicy(cmd *cobra.Command, args []string) {
 		IAMPolicySpec,
 		assets.IamOpenapiSchema,
 	); err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 }
@@ -116,7 +116,7 @@ func EditIAMPermissionsGroup(cmd *cobra.Command, args []string) {
 		IAMPolicySpec,
 		assets.IamOpenapiSchema,
 	); err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 }
@@ -137,7 +137,7 @@ func EditIAMResource(cmd *cobra.Command, args []string) {
 		IAMResourceSpec,
 		assets.IamOpenapiSchema,
 	); err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 }
@@ -151,7 +151,7 @@ func GetIAMResourceGroup(_ *cobra.Command, args []string) {
 
 	var object map[string]any
 	if err := httpLib.Client.Get(path, &object); err != nil {
-		display.ExitError("error fetching IAM resource group %s: %s", args[0], err)
+		display.OutputError(&flags.OutputFormatConfig, "error fetching IAM resource group %s: %s", args[0], err)
 		return
 	}
 
@@ -167,7 +167,7 @@ func EditIAMResourceGroup(cmd *cobra.Command, args []string) {
 		IAMPolicySpec,
 		assets.IamOpenapiSchema,
 	); err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 }

--- a/internal/services/ip/ip.go
+++ b/internal/services/ip/ip.go
@@ -44,7 +44,7 @@ func EditIp(cmd *cobra.Command, args []string) {
 		IPSpec,
 		assets.IpOpenapiSchema,
 	); err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 }
@@ -55,11 +55,11 @@ func IpSetReverse(_ *cobra.Command, args []string) {
 		"ipReverse": args[1],
 		"reverse":   args[2],
 	}, nil); err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
-	fmt.Println("\n⚡️ Reverse correctly set")
+	display.OutputInfo(&flags.OutputFormatConfig, nil, "⚡️ Reverse correctly set")
 }
 
 func IpGetReverse(_ *cobra.Command, args []string) {
@@ -70,9 +70,9 @@ func IpGetReverse(_ *cobra.Command, args []string) {
 func IpDeleteReverse(_ *cobra.Command, args []string) {
 	url := fmt.Sprintf("/ip/%s/reverse/%s", url.PathEscape(args[0]), url.PathEscape(args[1]))
 	if err := httpLib.Client.Delete(url, nil); err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
-	fmt.Println("\n⚡️ Reverse correctly deleted")
+	display.OutputInfo(&flags.OutputFormatConfig, nil, "⚡️ Reverse correctly deleted")
 }

--- a/internal/services/iploadbalancing/iploadbalancing.go
+++ b/internal/services/iploadbalancing/iploadbalancing.go
@@ -44,7 +44,7 @@ func EditIpLoadbalancing(cmd *cobra.Command, args []string) {
 		IPLoadbalancingSpec,
 		assets.IploadbalancingOpenapiSchema,
 	); err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 }

--- a/internal/services/ldp/ldp.go
+++ b/internal/services/ldp/ldp.go
@@ -44,7 +44,7 @@ func EditLdp(cmd *cobra.Command, args []string) {
 		LdpSpec,
 		assets.LdpOpenapiSchema,
 	); err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 }

--- a/internal/services/login/login.go
+++ b/internal/services/login/login.go
@@ -26,7 +26,7 @@ func Login(_ *cobra.Command, _ []string) {
 	credentials := display.RunLoginInput(customEndpoint)
 	for k, v := range credentials {
 		if v == "" {
-			display.ExitWarning("no value provided for %q", k)
+			display.OutputWarning(&flags.OutputFormatConfig, "no value provided for %q", k)
 			return
 		}
 	}
@@ -41,12 +41,12 @@ func Login(_ *cobra.Command, _ []string) {
 
 		_, path, err := display.RunGenericChoicePicker("Please choose a location to store your configuration", choices, 0)
 		if err != nil {
-			display.ExitError("failed to select a config path: %s", err)
+			display.OutputError(&flags.OutputFormatConfig, "failed to select a config path: %s", err)
 			return
 		}
 
 		if path == "" {
-			display.ExitWarning("no config path selected, configuration not saved")
+			display.OutputWarning(&flags.OutputFormatConfig, "no config path selected, configuration not saved")
 			return
 		}
 
@@ -65,7 +65,7 @@ func Login(_ *cobra.Command, _ []string) {
 	// Set credentials in config
 	for k, v := range credentials {
 		if err := config.SetConfigValue(flags.CliConfig, flags.CliConfigPath, configSection, k, v); err != nil {
-			display.ExitError("failed to write configuration %q: %s", k, err)
+			display.OutputError(&flags.OutputFormatConfig, "failed to write configuration %q: %s", k, err)
 			return
 		}
 	}

--- a/internal/services/overthebox/overthebox.go
+++ b/internal/services/overthebox/overthebox.go
@@ -45,7 +45,7 @@ func EditOverTheBox(cmd *cobra.Command, args []string) {
 		OverTheBoxSpec,
 		assets.OvertheboxOpenapiSchema,
 	); err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 }

--- a/internal/services/ovhcloudconnect/ovhcloudconnect.go
+++ b/internal/services/ovhcloudconnect/ovhcloudconnect.go
@@ -43,7 +43,7 @@ func EditOvhCloudConnect(cmd *cobra.Command, args []string) {
 		OvhCloudConnectSpec,
 		assets.OvhcloudconnectOpenapiSchema,
 	); err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 }

--- a/internal/services/packxdsl/packxdsl.go
+++ b/internal/services/packxdsl/packxdsl.go
@@ -43,7 +43,7 @@ func EditPackXDSL(cmd *cobra.Command, args []string) {
 		PackXDSLSpec,
 		assets.PackxdslOpenapiSchema,
 	); err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 }

--- a/internal/services/sms/sms.go
+++ b/internal/services/sms/sms.go
@@ -61,7 +61,7 @@ func EditSms(cmd *cobra.Command, args []string) {
 		SmsSpec,
 		assets.SmsOpenapiSchema,
 	); err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 }

--- a/internal/services/sslgateway/sslgateway.go
+++ b/internal/services/sslgateway/sslgateway.go
@@ -49,7 +49,7 @@ func EditSslGateway(cmd *cobra.Command, args []string) {
 		SSLGatewaySpec,
 		assets.SslgatewayOpenapiSchema,
 	); err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 }

--- a/internal/services/storagenetapp/storagenetapp.go
+++ b/internal/services/storagenetapp/storagenetapp.go
@@ -43,7 +43,7 @@ func EditStorageNetApp(cmd *cobra.Command, args []string) {
 		StorageNetAppSpec,
 		assets.SmsOpenapiSchema,
 	); err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 }

--- a/internal/services/telephony/telephony.go
+++ b/internal/services/telephony/telephony.go
@@ -50,7 +50,7 @@ func EditTelephony(cmd *cobra.Command, args []string) {
 		TelephonySpec,
 		assets.TelephonyOpenapiSchema,
 	); err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 }

--- a/internal/services/vmwareclouddirectorbackup/vmwareclouddirectorbackup.go
+++ b/internal/services/vmwareclouddirectorbackup/vmwareclouddirectorbackup.go
@@ -49,13 +49,13 @@ func EditVmwareCloudDirectorBackup(cmd *cobra.Command, args []string) {
 	for _, offer := range VmwareCloudDirectorBackupSpec.TargetSpec.CliOffers {
 		offerParts := strings.Split(offer, ":")
 		if len(offerParts) != 2 {
-			display.ExitError("Invalid offer format: %s. Expected format is '<name>:<quotaInTB>'", offer)
+			display.OutputError(&flags.OutputFormatConfig, "Invalid offer format: %s. Expected format is '<name>:<quotaInTB>'", offer)
 			return
 		}
 
 		intQuota, err := strconv.Atoi(offerParts[1])
 		if err != nil {
-			display.ExitError("Invalid quota value '%s' for offer '%s'. It should be an integer.", offerParts[1], offerParts[0])
+			display.OutputError(&flags.OutputFormatConfig, "Invalid quota value '%s' for offer '%s'. It should be an integer.", offerParts[1], offerParts[0])
 			return
 		}
 
@@ -74,7 +74,7 @@ func EditVmwareCloudDirectorBackup(cmd *cobra.Command, args []string) {
 		VmwareCloudDirectorBackupSpec,
 		assets.VmwareclouddirectorbackupOpenapiSchema,
 	); err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 }

--- a/internal/services/vmwareclouddirectororganization/vmwareclouddirectororganization.go
+++ b/internal/services/vmwareclouddirectororganization/vmwareclouddirectororganization.go
@@ -46,7 +46,7 @@ func EditVmwareCloudDirectorOrganization(cmd *cobra.Command, args []string) {
 		VmwareCloudDirectorOrganizationSpec,
 		assets.VmwareclouddirectororganizationOpenapiSchema,
 	); err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 }

--- a/internal/services/vps/utils.go
+++ b/internal/services/vps/utils.go
@@ -53,7 +53,7 @@ func waitForVpsTask(serviceName string, taskInput map[string]any, retryDuration 
 		case <-ctx.Done():
 			return nil, errors.New("timeout waiting for task to complete")
 		case <-ticker.C:
-			log.Printf("Still waiting for task to complete (status=%s) ...", task["state"])
+			log.Printf("Still waiting for task to complete (status=%s)…", task["state"])
 			continue
 		}
 	}

--- a/internal/services/vrack/vrack.go
+++ b/internal/services/vrack/vrack.go
@@ -44,7 +44,7 @@ func EditVrack(cmd *cobra.Command, args []string) {
 		VrackSpec,
 		assets.VrackOpenapiSchema,
 	); err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 }

--- a/internal/services/vrackservices/vrackservices.go
+++ b/internal/services/vrackservices/vrackservices.go
@@ -11,9 +11,7 @@ import (
 
 	"github.com/ovh/ovhcloud-cli/internal/assets"
 	"github.com/ovh/ovhcloud-cli/internal/display"
-	"github.com/ovh/ovhcloud-cli/internal/editor"
 	"github.com/ovh/ovhcloud-cli/internal/flags"
-	httpLib "github.com/ovh/ovhcloud-cli/internal/http"
 	"github.com/ovh/ovhcloud-cli/internal/services/common"
 	"github.com/spf13/cobra"
 )
@@ -33,14 +31,15 @@ func GetVrackServices(_ *cobra.Command, args []string) {
 	common.ManageObjectRequest("/v2/vrackServices/resource", args[0], vrackservicesTemplate)
 }
 
-func EditVrackServices(_ *cobra.Command, args []string) {
+func EditVrackServices(cmd *cobra.Command, args []string) {
 	endpoint := fmt.Sprintf("/v2/vrackServices/resource/%s", url.PathEscape(args[0]))
-	if err := editor.EditResource(
-		httpLib.Client,
+	if err := common.EditResource(
+		cmd,
 		"/vrackServices/resource/{vrackServicesId}",
 		endpoint,
+		nil,
 		assets.VrackservicesOpenapiSchema,
 	); err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 	}
 }

--- a/internal/services/webhosting/webhosting.go
+++ b/internal/services/webhosting/webhosting.go
@@ -43,7 +43,7 @@ func EditWebHosting(cmd *cobra.Command, args []string) {
 		WebHostingSpec,
 		assets.WebhostingOpenapiSchema,
 	); err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 }

--- a/internal/services/xdsl/xdsl.go
+++ b/internal/services/xdsl/xdsl.go
@@ -45,7 +45,7 @@ func EditXdsl(cmd *cobra.Command, args []string) {
 		XdslSpec,
 		assets.XdslOpenapiSchema,
 	); err != nil {
-		display.ExitError(err.Error())
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 }


### PR DESCRIPTION
# Description

Output the right format (basic, JSON, YAML, custom) in all commands.

## Type of change

- [x] Improvement (improvement of existing commands)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have commented my code
- [x] I updated the documentation by running `make doc`
- [x] I ran `go mod tidy`
- [x] I have added tests that prove my fix is effective or that my feature works
