### PR TITLE
doc: Fix wrong indentation for code blocks

### DIFF
--- a/doc/ovhcloud_baremetal_reinstall.md
+++ b/doc/ovhcloud_baremetal_reinstall.md
@@ -9,7 +9,7 @@ There are three ways to define the installation parameters:
 
 1. Using only CLI flags:
 
-  ovhcloud baremetal reinstall ns1234.ip-11.22.33.net --os byolinux_64 --language fr-fr --image-url https://...
+	ovhcloud baremetal reinstall ns1234.ip-11.22.33.net --os byolinux_64 --language fr-fr --image-url https://...
 
 2. Using a configuration file:
 
@@ -32,7 +32,7 @@ There are three ways to define the installation parameters:
 
 3. Using your default text editor:
 
-  ovhcloud baremetal reinstall ns1234.ip-11.22.33.net --editor
+	ovhcloud baremetal reinstall ns1234.ip-11.22.33.net --editor
 
   You will be able to choose from several installation examples. Once an example has been selected, the CLI will open your
   default text editor to update the parameters. When saving the file, the reinstallation will be run.

--- a/doc/ovhcloud_cloud_database_create.md
+++ b/doc/ovhcloud_cloud_database_create.md
@@ -5,23 +5,23 @@ Create a new database
 ### Synopsis
 
 Use this command to create a database in the given public cloud project.
-		There are two ways to define the creation parameters:
+There are two ways to define the creation parameters:
 
-		1. Using only CLI flags:
+1. Using only CLI flags:
 
-		  ovhcloud cloud database create --engine mysql --version 8 --plan essential  --nodes-list "db1-4:DE"
+	ovhcloud cloud database create --engine mysql --version 8 --plan essential  --nodes-list "db1-4:DE"
 
-		2. Using your default text editor:
+2. Using your default text editor:
 
-		  ovhcloud cloud database create --engine kafka --editor
+	ovhcloud cloud database create --engine kafka --editor
 
-		  You will be able to choose from several examples of parameters. Once an example has been selected, the CLI will open your
-		  default text editor to update the parameters. When saving the file, the creation will start.
+  You will be able to choose from several examples of parameters. Once an example has been selected, the CLI will open your
+  default text editor to update the parameters. When saving the file, the creation will start.
 
-		  Note that it is also possible to override values in the presented examples using command line flags like the following:
+  Note that it is also possible to override values in the presented examples using command line flags like the following:
 
-			ovhcloud cloud database create --engine mysql --editor --version 8
-		
+	ovhcloud cloud database create --engine mysql --editor --version 8
+
 
 ```
 ovhcloud cloud database create [flags]

--- a/doc/ovhcloud_cloud_instance_create.md
+++ b/doc/ovhcloud_cloud_instance_create.md
@@ -9,7 +9,7 @@ There are three ways to define the creation parameters:
 
 1. Using only CLI flags:
 
-  ovhcloud cloud instance create GRA9 --name MyNewInstance --boot-from.image <image_id> --flavor <flavor_id>
+	ovhcloud cloud instance create GRA9 --name MyNewInstance --boot-from.image <image_id> --flavor <flavor_id>
 
 2. Using a configuration file:
 
@@ -32,11 +32,11 @@ There are three ways to define the creation parameters:
 
   It is also possible to use the interactive image and flavor selector to define the image and flavor parameters, like the following:
 
-  	ovhcloud cloud instance create BHS5 --init-file ./params.json --image-selector --flavor-selector
+	ovhcloud cloud instance create BHS5 --init-file ./params.json --image-selector --flavor-selector
 
 3. Using your default text editor:
 
-  ovhcloud cloud instance create GRA11 --editor
+	ovhcloud cloud instance create GRA11 --editor
 
   You will be able to choose from several examples of parameters. Once an example has been selected, the CLI will open your
   default text editor to update the parameters. When saving the file, the creation will start.
@@ -47,7 +47,7 @@ There are three ways to define the creation parameters:
 
   You can also use the interactive image and flavor selector to define the image and flavor parameters, like the following:
 
-  	ovhcloud cloud instance create RBX8 --editor --image-selector --flavor-selector
+	ovhcloud cloud instance create RBX8 --editor --image-selector --flavor-selector
 
 
 ```

--- a/doc/ovhcloud_cloud_instance_reinstall.md
+++ b/doc/ovhcloud_cloud_instance_reinstall.md
@@ -11,11 +11,11 @@ There are three ways to define the installation parameters:
 
 1. Using only CLI flags:
 
-  ovhcloud cloud instance reinstall c7e272d4-4c11-11f0-bf07-0050568ce122 --image <image_id>
+	ovhcloud cloud instance reinstall c7e272d4-4c11-11f0-bf07-0050568ce122 --image <image_id>
 
 2. Using the interactive image selector:
 
-  ovhcloud cloud instance reinstall c7e272d4-4c11-11f0-bf07-0050568ce122 --image-selector
+	ovhcloud cloud instance reinstall c7e272d4-4c11-11f0-bf07-0050568ce122 --image-selector
 
 3. Using a configuration file:
 
@@ -38,7 +38,7 @@ There are three ways to define the installation parameters:
 
 4. Using your default text editor:
 
-  ovhcloud cloud instance reinstall c7e272d4-4c11-11f0-bf07-0050568ce122 --editor
+	ovhcloud cloud instance reinstall c7e272d4-4c11-11f0-bf07-0050568ce122 --editor
 
   You will be able to choose from several installation examples. Once an example has been selected, the CLI will open your
   default text editor to update the parameters. When saving the file, the reinstallation will be run.

--- a/doc/ovhcloud_cloud_kube_create.md
+++ b/doc/ovhcloud_cloud_kube_create.md
@@ -9,7 +9,7 @@ There are three ways to define the creation parameters:
 
 1. Using only CLI flags:
 
-  ovhcloud cloud kube create --name MyNewCluster --region SBG5 --version 1.32
+	ovhcloud cloud kube create --name MyNewCluster --region SBG5 --version 1.32
 
 2. Using a configuration file:
 
@@ -32,7 +32,7 @@ There are three ways to define the creation parameters:
 
 3. Using your default text editor:
 
-  ovhcloud cloud kube create --editor
+	ovhcloud cloud kube create --editor
 
   You will be able to choose from several examples of parameters. Once an example has been selected, the CLI will open your
   default text editor to update the parameters. When saving the file, the creation will start.

--- a/doc/ovhcloud_cloud_kube_nodepool_create.md
+++ b/doc/ovhcloud_cloud_kube_nodepool_create.md
@@ -9,7 +9,7 @@ There are three ways to define the creation parameters:
 
 1. Using only CLI flags:
 
-  ovhcloud cloud kube nodepool create <cluster_id> --flavor-name b3-16 --desired-nodes 3 --name newnodepool
+	ovhcloud cloud kube nodepool create <cluster_id> --flavor-name b3-16 --desired-nodes 3 --name newnodepool
 
 2. Using a configuration file:
 
@@ -36,7 +36,7 @@ There are three ways to define the creation parameters:
 
 3. Using your default text editor:
 
-  ovhcloud cloud kube nodepool create <cluster_id> --editor
+	ovhcloud cloud kube nodepool create <cluster_id> --editor
 
   You will be able to choose from several examples of parameters. Once an example has been selected, the CLI will open your
   default text editor to update the parameters. When saving the file, the creation will start.

--- a/doc/ovhcloud_cloud_kube_oidc_create.md
+++ b/doc/ovhcloud_cloud_kube_oidc_create.md
@@ -9,7 +9,7 @@ There are three ways to define the parameters:
 
 1. Using only CLI flags:
 
-  ovhcloud cloud kube oidc create <cluster_id> --issuer-url <url>
+	ovhcloud cloud kube oidc create <cluster_id> --issuer-url <url>
 
 2. Using a configuration file:
 
@@ -32,7 +32,7 @@ There are three ways to define the parameters:
 
 3. Using your default text editor:
 
-  ovhcloud cloud kube oidc create <cluster_id> --editor
+	ovhcloud cloud kube oidc create <cluster_id> --editor
 
   You will be able to choose from several examples of parameters. Once an example has been selected, the CLI will open your
   default text editor to update the parameters. When saving the file, the creation will start.

--- a/doc/ovhcloud_cloud_kube_reset.md
+++ b/doc/ovhcloud_cloud_kube_reset.md
@@ -11,7 +11,7 @@ There are three ways to define the reset parameters:
 
 1. Using only CLI flags:
 
-  ovhcloud cloud kube reset <cluster_id> --name MyNewCluster --version 1.32
+	ovhcloud cloud kube reset <cluster_id> --name MyNewCluster --version 1.32
 
 2. Using a configuration file:
 
@@ -34,7 +34,7 @@ There are three ways to define the reset parameters:
 
 3. Using your default text editor:
 
-  ovhcloud cloud kube reset <cluster_id> --editor
+	ovhcloud cloud kube reset <cluster_id> --editor
 
   You will be able to choose from several examples of parameters. Once an example has been selected, the CLI will open your
   default text editor to update the parameters. When saving the file, the reset will start.

--- a/doc/ovhcloud_cloud_network_gateway_create.md
+++ b/doc/ovhcloud_cloud_network_gateway_create.md
@@ -19,7 +19,7 @@ There are three ways to define the parameters:
 
 1. Using only CLI flags:
 
-  ovhcloud cloud network gateway create <region> --name MyGateway --model xl
+	ovhcloud cloud network gateway create <region> --name MyGateway --model xl
 
 2. Using a configuration file:
 
@@ -42,7 +42,7 @@ There are three ways to define the parameters:
 
 3. Using your default text editor:
 
-  ovhcloud cloud network gateway create <region> --editor
+	ovhcloud cloud network gateway create <region> --editor
 
   You will be able to choose from several examples of parameters. Once an example has been selected, the CLI will open your
   default text editor to update the parameters. When saving the file, the creation will start.

--- a/doc/ovhcloud_cloud_network_private_create.md
+++ b/doc/ovhcloud_cloud_network_private_create.md
@@ -9,7 +9,7 @@ There are three ways to define the parameters:
 
 1. Using only CLI flags:
 
-  ovhcloud cloud network private create <region> --name MyNetwork
+	ovhcloud cloud network private create <region> --name MyNetwork
 
 2. Using a configuration file:
 
@@ -32,7 +32,7 @@ There are three ways to define the parameters:
 
 3. Using your default text editor:
 
-  ovhcloud cloud network private create <region> --editor
+	ovhcloud cloud network private create <region> --editor
 
   You will be able to choose from several examples of parameters. Once an example has been selected, the CLI will open your
   default text editor to update the parameters. When saving the file, the creation will start.

--- a/doc/ovhcloud_cloud_rancher_create.md
+++ b/doc/ovhcloud_cloud_rancher_create.md
@@ -9,7 +9,7 @@ There are three ways to define the creation parameters:
 
 1. Using only CLI flags:
 
-  ovhcloud cloud rancher create --name MyNewRancher --plan OVHCLOUD_EDITION --version 2.11.3
+	ovhcloud cloud rancher create --name MyNewRancher --plan OVHCLOUD_EDITION --version 2.11.3
 
 2. Using a configuration file:
 
@@ -32,7 +32,7 @@ There are three ways to define the creation parameters:
 
 3. Using your default text editor:
 
-  ovhcloud cloud rancher create --editor
+	ovhcloud cloud rancher create --editor
 
   You will be able to choose from several examples of parameters. Once an example has been selected, the CLI will open your
   default text editor to update the parameters. When saving the file, the creation will start.

--- a/doc/ovhcloud_cloud_storage-s3_create.md
+++ b/doc/ovhcloud_cloud_storage-s3_create.md
@@ -9,7 +9,7 @@ There are three ways to define the creation parameters:
 
 1. Using only CLI flags:
 
-  ovhcloud cloud storage-s3 create BHS --name mynewContainer
+	ovhcloud cloud storage-s3 create BHS --name mynewContainer
 
 2. Using a configuration file:
 
@@ -32,7 +32,7 @@ There are three ways to define the creation parameters:
 
 3. Using your default text editor:
 
-  ovhcloud cloud storage-s3 create GRA --editor
+	ovhcloud cloud storage-s3 create GRA --editor
 
   You will be able to choose from several examples of parameters. Once an example has been selected, the CLI will open your
   default text editor to update the parameters. When saving the file, the creation will start.

--- a/internal/cmd/baremetal.go
+++ b/internal/cmd/baremetal.go
@@ -90,7 +90,7 @@ There are three ways to define the installation parameters:
 
 1. Using only CLI flags:
 
-  ovhcloud baremetal reinstall ns1234.ip-11.22.33.net --os byolinux_64 --language fr-fr --image-url https://...
+	ovhcloud baremetal reinstall ns1234.ip-11.22.33.net --os byolinux_64 --language fr-fr --image-url https://...
 
 2. Using a configuration file:
 
@@ -113,7 +113,7 @@ There are three ways to define the installation parameters:
 
 3. Using your default text editor:
 
-  ovhcloud baremetal reinstall ns1234.ip-11.22.33.net --editor
+	ovhcloud baremetal reinstall ns1234.ip-11.22.33.net --editor
 
   You will be able to choose from several installation examples. Once an example has been selected, the CLI will open your
   default text editor to update the parameters. When saving the file, the reinstallation will be run.

--- a/internal/cmd/cloud_database.go
+++ b/internal/cmd/cloud_database.go
@@ -48,23 +48,23 @@ func getDatabaseCreationCmd() *cobra.Command {
 		Use:   "create",
 		Short: "Create a new database",
 		Long: `Use this command to create a database in the given public cloud project.
-		There are two ways to define the creation parameters:
+There are two ways to define the creation parameters:
 
-		1. Using only CLI flags:
+1. Using only CLI flags:
 
-		  ovhcloud cloud database create --engine mysql --version 8 --plan essential  --nodes-list "db1-4:DE"
+	ovhcloud cloud database create --engine mysql --version 8 --plan essential  --nodes-list "db1-4:DE"
 
-		2. Using your default text editor:
+2. Using your default text editor:
 
-		  ovhcloud cloud database create --engine kafka --editor
+	ovhcloud cloud database create --engine kafka --editor
 
-		  You will be able to choose from several examples of parameters. Once an example has been selected, the CLI will open your
-		  default text editor to update the parameters. When saving the file, the creation will start.
+  You will be able to choose from several examples of parameters. Once an example has been selected, the CLI will open your
+  default text editor to update the parameters. When saving the file, the creation will start.
 
-		  Note that it is also possible to override values in the presented examples using command line flags like the following:
+  Note that it is also possible to override values in the presented examples using command line flags like the following:
 
-			ovhcloud cloud database create --engine mysql --editor --version 8
-		`,
+	ovhcloud cloud database create --engine mysql --editor --version 8
+`,
 		Run:  cloud.CreateDatabase,
 		Args: cobra.NoArgs,
 	}

--- a/internal/cmd/cloud_instance.go
+++ b/internal/cmd/cloud_instance.go
@@ -22,7 +22,7 @@ There are three ways to define the creation parameters:
 
 1. Using only CLI flags:
 
-  ovhcloud cloud instance create GRA9 --name MyNewInstance --boot-from.image <image_id> --flavor <flavor_id>
+	ovhcloud cloud instance create GRA9 --name MyNewInstance --boot-from.image <image_id> --flavor <flavor_id>
 
 2. Using a configuration file:
 
@@ -45,11 +45,11 @@ There are three ways to define the creation parameters:
 
   It is also possible to use the interactive image and flavor selector to define the image and flavor parameters, like the following:
 
-  	ovhcloud cloud instance create BHS5 --init-file ./params.json --image-selector --flavor-selector
+	ovhcloud cloud instance create BHS5 --init-file ./params.json --image-selector --flavor-selector
 
 3. Using your default text editor:
 
-  ovhcloud cloud instance create GRA11 --editor
+	ovhcloud cloud instance create GRA11 --editor
 
   You will be able to choose from several examples of parameters. Once an example has been selected, the CLI will open your
   default text editor to update the parameters. When saving the file, the creation will start.
@@ -60,7 +60,7 @@ There are three ways to define the creation parameters:
 
   You can also use the interactive image and flavor selector to define the image and flavor parameters, like the following:
 
-  	ovhcloud cloud instance create RBX8 --editor --image-selector --flavor-selector
+	ovhcloud cloud instance create RBX8 --editor --image-selector --flavor-selector
 `,
 		Run:  cloud.CreateInstance,
 		Args: cobra.MaximumNArgs(1),
@@ -240,11 +240,11 @@ There are three ways to define the installation parameters:
 
 1. Using only CLI flags:
 
-  ovhcloud cloud instance reinstall c7e272d4-4c11-11f0-bf07-0050568ce122 --image <image_id>
+	ovhcloud cloud instance reinstall c7e272d4-4c11-11f0-bf07-0050568ce122 --image <image_id>
 
 2. Using the interactive image selector:
 
-  ovhcloud cloud instance reinstall c7e272d4-4c11-11f0-bf07-0050568ce122 --image-selector
+	ovhcloud cloud instance reinstall c7e272d4-4c11-11f0-bf07-0050568ce122 --image-selector
 
 3. Using a configuration file:
 
@@ -267,7 +267,7 @@ There are three ways to define the installation parameters:
 
 4. Using your default text editor:
 
-  ovhcloud cloud instance reinstall c7e272d4-4c11-11f0-bf07-0050568ce122 --editor
+	ovhcloud cloud instance reinstall c7e272d4-4c11-11f0-bf07-0050568ce122 --editor
 
   You will be able to choose from several installation examples. Once an example has been selected, the CLI will open your
   default text editor to update the parameters. When saving the file, the reinstallation will be run.

--- a/internal/cmd/cloud_kube.go
+++ b/internal/cmd/cloud_kube.go
@@ -316,7 +316,7 @@ There are three ways to define the creation parameters:
 
 1. Using only CLI flags:
 
-  ovhcloud cloud kube create --name MyNewCluster --region SBG5 --version 1.32
+	ovhcloud cloud kube create --name MyNewCluster --region SBG5 --version 1.32
 
 2. Using a configuration file:
 
@@ -339,7 +339,7 @@ There are three ways to define the creation parameters:
 
 3. Using your default text editor:
 
-  ovhcloud cloud kube create --editor
+	ovhcloud cloud kube create --editor
 
   You will be able to choose from several examples of parameters. Once an example has been selected, the CLI will open your
   default text editor to update the parameters. When saving the file, the creation will start.
@@ -402,7 +402,7 @@ There are three ways to define the reset parameters:
 
 1. Using only CLI flags:
 
-  ovhcloud cloud kube reset <cluster_id> --name MyNewCluster --version 1.32
+	ovhcloud cloud kube reset <cluster_id> --name MyNewCluster --version 1.32
 
 2. Using a configuration file:
 
@@ -425,7 +425,7 @@ There are three ways to define the reset parameters:
 
 3. Using your default text editor:
 
-  ovhcloud cloud kube reset <cluster_id> --editor
+	ovhcloud cloud kube reset <cluster_id> --editor
 
   You will be able to choose from several examples of parameters. Once an example has been selected, the CLI will open your
   default text editor to update the parameters. When saving the file, the reset will start.
@@ -486,7 +486,7 @@ There are three ways to define the creation parameters:
 
 1. Using only CLI flags:
 
-  ovhcloud cloud kube nodepool create <cluster_id> --flavor-name b3-16 --desired-nodes 3 --name newnodepool
+	ovhcloud cloud kube nodepool create <cluster_id> --flavor-name b3-16 --desired-nodes 3 --name newnodepool
 
 2. Using a configuration file:
 
@@ -513,7 +513,7 @@ There are three ways to define the creation parameters:
 
 3. Using your default text editor:
 
-  ovhcloud cloud kube nodepool create <cluster_id> --editor
+	ovhcloud cloud kube nodepool create <cluster_id> --editor
 
   You will be able to choose from several examples of parameters. Once an example has been selected, the CLI will open your
   default text editor to update the parameters. When saving the file, the creation will start.
@@ -574,7 +574,7 @@ There are three ways to define the parameters:
 
 1. Using only CLI flags:
 
-  ovhcloud cloud kube oidc create <cluster_id> --issuer-url <url>
+	ovhcloud cloud kube oidc create <cluster_id> --issuer-url <url>
 
 2. Using a configuration file:
 
@@ -597,7 +597,7 @@ There are three ways to define the parameters:
 
 3. Using your default text editor:
 
-  ovhcloud cloud kube oidc create <cluster_id> --editor
+	ovhcloud cloud kube oidc create <cluster_id> --editor
 
   You will be able to choose from several examples of parameters. Once an example has been selected, the CLI will open your
   default text editor to update the parameters. When saving the file, the creation will start.

--- a/internal/cmd/cloud_network.go
+++ b/internal/cmd/cloud_network.go
@@ -242,7 +242,7 @@ There are three ways to define the parameters:
 
 1. Using only CLI flags:
 
-  ovhcloud cloud network private create <region> --name MyNetwork
+	ovhcloud cloud network private create <region> --name MyNetwork
 
 2. Using a configuration file:
 
@@ -265,7 +265,7 @@ There are three ways to define the parameters:
 
 3. Using your default text editor:
 
-  ovhcloud cloud network private create <region> --editor
+	ovhcloud cloud network private create <region> --editor
 
   You will be able to choose from several examples of parameters. Once an example has been selected, the CLI will open your
   default text editor to update the parameters. When saving the file, the creation will start.
@@ -325,7 +325,7 @@ There are three ways to define the parameters:
 
 1. Using only CLI flags:
 
-  ovhcloud cloud network gateway create <region> --name MyGateway --model xl
+	ovhcloud cloud network gateway create <region> --name MyGateway --model xl
 
 2. Using a configuration file:
 
@@ -348,7 +348,7 @@ There are three ways to define the parameters:
 
 3. Using your default text editor:
 
-  ovhcloud cloud network gateway create <region> --editor
+	ovhcloud cloud network gateway create <region> --editor
 
   You will be able to choose from several examples of parameters. Once an example has been selected, the CLI will open your
   default text editor to update the parameters. When saving the file, the creation will start.

--- a/internal/cmd/cloud_rancher.go
+++ b/internal/cmd/cloud_rancher.go
@@ -66,7 +66,7 @@ There are three ways to define the creation parameters:
 
 1. Using only CLI flags:
 
-  ovhcloud cloud rancher create --name MyNewRancher --plan OVHCLOUD_EDITION --version 2.11.3
+	ovhcloud cloud rancher create --name MyNewRancher --plan OVHCLOUD_EDITION --version 2.11.3
 
 2. Using a configuration file:
 
@@ -89,7 +89,7 @@ There are three ways to define the creation parameters:
 
 3. Using your default text editor:
 
-  ovhcloud cloud rancher create --editor
+	ovhcloud cloud rancher create --editor
 
   You will be able to choose from several examples of parameters. Once an example has been selected, the CLI will open your
   default text editor to update the parameters. When saving the file, the creation will start.

--- a/internal/cmd/cloud_storage_s3.go
+++ b/internal/cmd/cloud_storage_s3.go
@@ -233,7 +233,7 @@ There are three ways to define the creation parameters:
 
 1. Using only CLI flags:
 
-  ovhcloud cloud storage-s3 create BHS --name mynewContainer
+	ovhcloud cloud storage-s3 create BHS --name mynewContainer
 
 2. Using a configuration file:
 
@@ -256,7 +256,7 @@ There are three ways to define the creation parameters:
 
 3. Using your default text editor:
 
-  ovhcloud cloud storage-s3 create GRA --editor
+	ovhcloud cloud storage-s3 create GRA --editor
 
   You will be able to choose from several examples of parameters. Once an example has been selected, the CLI will open your
   default text editor to update the parameters. When saving the file, the creation will start.


### PR DESCRIPTION
# Description

Re-indent some code examples in commands long help so they're correctly rendered.

## Type of change

Please delete options that are not relevant.

- [x] Documentation update

# Checklist:

- [x] I updated the documentation by running `make doc`