### PR TITLE
feat: Add commands to manage DBs in a cloud database service

### DIFF
--- a/doc/ovhcloud_cloud.md
+++ b/doc/ovhcloud_cloud.md
@@ -30,7 +30,7 @@ Manage your projects and services in the Public Cloud universe
 
 * [ovhcloud](ovhcloud.md)	 - CLI to manage your OVHcloud services
 * [ovhcloud cloud container-registry](ovhcloud_cloud_container-registry.md)	 - Manage container registries in the given cloud project
-* [ovhcloud cloud database](ovhcloud_cloud_database.md)	 - Manage databases in the given cloud project
+* [ovhcloud cloud database-service](ovhcloud_cloud_database-service.md)	 - Manage database services in the given cloud project
 * [ovhcloud cloud instance](ovhcloud_cloud_instance.md)	 - Manage instances in the given cloud project
 * [ovhcloud cloud kube](ovhcloud_cloud_kube.md)	 - Manage Kubernetes clusters in the given cloud project
 * [ovhcloud cloud loadbalancer](ovhcloud_cloud_loadbalancer.md)	 - Manage loadbalancers in the given cloud project

--- a/doc/ovhcloud_cloud_database-service.md
+++ b/doc/ovhcloud_cloud_database-service.md
@@ -1,12 +1,12 @@
-## ovhcloud cloud database
+## ovhcloud cloud database-service
 
-Manage databases in the given cloud project
+Manage database services in the given cloud project
 
 ### Options
 
 ```
       --cloud-project string   Cloud project ID
-  -h, --help                   help for database
+  -h, --help                   help for database-service
 ```
 
 ### Options inherited from parent commands
@@ -30,9 +30,10 @@ Manage databases in the given cloud project
 ### SEE ALSO
 
 * [ovhcloud cloud](ovhcloud_cloud.md)	 - Manage your projects and services in the Public Cloud universe
-* [ovhcloud cloud database create](ovhcloud_cloud_database_create.md)	 - Create a new database
-* [ovhcloud cloud database delete](ovhcloud_cloud_database_delete.md)	 - Delete a specific database
-* [ovhcloud cloud database edit](ovhcloud_cloud_database_edit.md)	 - Edit a specific database
-* [ovhcloud cloud database get](ovhcloud_cloud_database_get.md)	 - Get a specific database
-* [ovhcloud cloud database list](ovhcloud_cloud_database_list.md)	 - List your databases
+* [ovhcloud cloud database-service create](ovhcloud_cloud_database-service_create.md)	 - Create a new database service
+* [ovhcloud cloud database-service database](ovhcloud_cloud_database-service_database.md)	 - Manage databases in a specific database service
+* [ovhcloud cloud database-service delete](ovhcloud_cloud_database-service_delete.md)	 - Delete a specific database service
+* [ovhcloud cloud database-service edit](ovhcloud_cloud_database-service_edit.md)	 - Edit a specific database service
+* [ovhcloud cloud database-service get](ovhcloud_cloud_database-service_get.md)	 - Get a specific database services
+* [ovhcloud cloud database-service list](ovhcloud_cloud_database-service_list.md)	 - List your database services
 

--- a/doc/ovhcloud_cloud_database-service_create.md
+++ b/doc/ovhcloud_cloud_database-service_create.md
@@ -1,30 +1,30 @@
-## ovhcloud cloud database create
+## ovhcloud cloud database-service create
 
-Create a new database
+Create a new database service
 
 ### Synopsis
 
-Use this command to create a database in the given public cloud project.
+Use this command to create a database service in the given public cloud project.
 There are two ways to define the creation parameters:
 
 1. Using only CLI flags:
 
-	ovhcloud cloud database create --engine mysql --version 8 --plan essential  --nodes-list "db1-4:DE"
+	ovhcloud cloud database-service create --engine mysql --version 8 --plan essential  --nodes-list "db1-4:DE"
 
 2. Using your default text editor:
 
-	ovhcloud cloud database create --engine kafka --editor
+	ovhcloud cloud database-service create --engine kafka --editor
 
   You will be able to choose from several examples of parameters. Once an example has been selected, the CLI will open your
   default text editor to update the parameters. When saving the file, the creation will start.
 
   Note that it is also possible to override values in the presented examples using command line flags like the following:
 
-	ovhcloud cloud database create --engine mysql --editor --version 8
+	ovhcloud cloud database-service create --engine mysql --editor --version 8
 
 
 ```
-ovhcloud cloud database create [flags]
+ovhcloud cloud database-service create [flags]
 ```
 
 ### Options
@@ -73,5 +73,5 @@ ovhcloud cloud database create [flags]
 
 ### SEE ALSO
 
-* [ovhcloud cloud database](ovhcloud_cloud_database.md)	 - Manage databases in the given cloud project
+* [ovhcloud cloud database-service](ovhcloud_cloud_database-service.md)	 - Manage database services in the given cloud project
 

--- a/doc/ovhcloud_cloud_database-service_database.md
+++ b/doc/ovhcloud_cloud_database-service_database.md
@@ -1,0 +1,37 @@
+## ovhcloud cloud database-service database
+
+Manage databases in a specific database service
+
+### Options
+
+```
+  -h, --help   help for database
+```
+
+### Options inherited from parent commands
+
+```
+      --cloud-project string   Cloud project ID
+  -d, --debug                  Activate debug mode (will log all HTTP requests details)
+  -f, --format string          Output value according to given format (expression using https://github.com/PaesslerAG/gval syntax)
+                               Examples:
+                                 --format 'id' (to extract a single field)
+                                 --format 'nested.field.subfield' (to extract a nested field)
+                                 --format '[id, 'name']' (to extract multiple fields as an array)
+                                 --format '{"newKey": oldKey, "otherKey": nested.field}' (to extract and rename fields in an object)
+                                 --format 'name+","+type' (to extract and concatenate fields in a string)
+                                 --format '(nbFieldA + nbFieldB) * 10' (to compute values from numeric fields)
+  -e, --ignore-errors          Ignore errors in API calls when it is not fatal to the execution
+  -i, --interactive            Interactive output
+  -j, --json                   Output in JSON
+  -y, --yaml                   Output in YAML
+```
+
+### SEE ALSO
+
+* [ovhcloud cloud database-service](ovhcloud_cloud_database-service.md)	 - Manage database services in the given cloud project
+* [ovhcloud cloud database-service database create](ovhcloud_cloud_database-service_database_create.md)	 - Create a new database in the given database service
+* [ovhcloud cloud database-service database delete](ovhcloud_cloud_database-service_database_delete.md)	 - Delete a specific database in the given database service
+* [ovhcloud cloud database-service database get](ovhcloud_cloud_database-service_database_get.md)	 - Get a specific database in the given database service
+* [ovhcloud cloud database-service database list](ovhcloud_cloud_database-service_database_list.md)	 - List all databases in the given database service
+

--- a/doc/ovhcloud_cloud_database-service_database_create.md
+++ b/doc/ovhcloud_cloud_database-service_database_create.md
@@ -1,0 +1,38 @@
+## ovhcloud cloud database-service database create
+
+Create a new database in the given database service
+
+```
+ovhcloud cloud database-service database create <cluster_id> [flags]
+```
+
+### Options
+
+```
+  -h, --help          help for create
+      --name string   Name of the database to create
+```
+
+### Options inherited from parent commands
+
+```
+      --cloud-project string   Cloud project ID
+  -d, --debug                  Activate debug mode (will log all HTTP requests details)
+  -f, --format string          Output value according to given format (expression using https://github.com/PaesslerAG/gval syntax)
+                               Examples:
+                                 --format 'id' (to extract a single field)
+                                 --format 'nested.field.subfield' (to extract a nested field)
+                                 --format '[id, 'name']' (to extract multiple fields as an array)
+                                 --format '{"newKey": oldKey, "otherKey": nested.field}' (to extract and rename fields in an object)
+                                 --format 'name+","+type' (to extract and concatenate fields in a string)
+                                 --format '(nbFieldA + nbFieldB) * 10' (to compute values from numeric fields)
+  -e, --ignore-errors          Ignore errors in API calls when it is not fatal to the execution
+  -i, --interactive            Interactive output
+  -j, --json                   Output in JSON
+  -y, --yaml                   Output in YAML
+```
+
+### SEE ALSO
+
+* [ovhcloud cloud database-service database](ovhcloud_cloud_database-service_database.md)	 - Manage databases in a specific database service
+

--- a/doc/ovhcloud_cloud_database-service_database_delete.md
+++ b/doc/ovhcloud_cloud_database-service_database_delete.md
@@ -1,0 +1,37 @@
+## ovhcloud cloud database-service database delete
+
+Delete a specific database in the given database service
+
+```
+ovhcloud cloud database-service database delete <cluster_id> <database_id> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for delete
+```
+
+### Options inherited from parent commands
+
+```
+      --cloud-project string   Cloud project ID
+  -d, --debug                  Activate debug mode (will log all HTTP requests details)
+  -f, --format string          Output value according to given format (expression using https://github.com/PaesslerAG/gval syntax)
+                               Examples:
+                                 --format 'id' (to extract a single field)
+                                 --format 'nested.field.subfield' (to extract a nested field)
+                                 --format '[id, 'name']' (to extract multiple fields as an array)
+                                 --format '{"newKey": oldKey, "otherKey": nested.field}' (to extract and rename fields in an object)
+                                 --format 'name+","+type' (to extract and concatenate fields in a string)
+                                 --format '(nbFieldA + nbFieldB) * 10' (to compute values from numeric fields)
+  -e, --ignore-errors          Ignore errors in API calls when it is not fatal to the execution
+  -i, --interactive            Interactive output
+  -j, --json                   Output in JSON
+  -y, --yaml                   Output in YAML
+```
+
+### SEE ALSO
+
+* [ovhcloud cloud database-service database](ovhcloud_cloud_database-service_database.md)	 - Manage databases in a specific database service
+

--- a/doc/ovhcloud_cloud_database-service_database_get.md
+++ b/doc/ovhcloud_cloud_database-service_database_get.md
@@ -1,0 +1,37 @@
+## ovhcloud cloud database-service database get
+
+Get a specific database in the given database service
+
+```
+ovhcloud cloud database-service database get <cluster_id> <database_id> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for get
+```
+
+### Options inherited from parent commands
+
+```
+      --cloud-project string   Cloud project ID
+  -d, --debug                  Activate debug mode (will log all HTTP requests details)
+  -f, --format string          Output value according to given format (expression using https://github.com/PaesslerAG/gval syntax)
+                               Examples:
+                                 --format 'id' (to extract a single field)
+                                 --format 'nested.field.subfield' (to extract a nested field)
+                                 --format '[id, 'name']' (to extract multiple fields as an array)
+                                 --format '{"newKey": oldKey, "otherKey": nested.field}' (to extract and rename fields in an object)
+                                 --format 'name+","+type' (to extract and concatenate fields in a string)
+                                 --format '(nbFieldA + nbFieldB) * 10' (to compute values from numeric fields)
+  -e, --ignore-errors          Ignore errors in API calls when it is not fatal to the execution
+  -i, --interactive            Interactive output
+  -j, --json                   Output in JSON
+  -y, --yaml                   Output in YAML
+```
+
+### SEE ALSO
+
+* [ovhcloud cloud database-service database](ovhcloud_cloud_database-service_database.md)	 - Manage databases in a specific database service
+

--- a/doc/ovhcloud_cloud_database-service_database_list.md
+++ b/doc/ovhcloud_cloud_database-service_database_list.md
@@ -1,15 +1,22 @@
-## ovhcloud cloud database delete
+## ovhcloud cloud database-service database list
 
-Delete a specific database
+List all databases in the given database service
 
 ```
-ovhcloud cloud database delete <database_id> [flags]
+ovhcloud cloud database-service database list <cluster_id> [flags]
 ```
 
 ### Options
 
 ```
-  -h, --help   help for delete
+      --filter stringArray   Filter results by any property using https://github.com/PaesslerAG/gval syntax
+                             Examples:
+                               --filter 'state="running"'
+                               --filter 'name=~"^my.*"'
+                               --filter 'nested.property.subproperty>10'
+                               --filter 'startDate>="2023-12-01"'
+                               --filter 'name=~"something" && nbField>10'
+  -h, --help                 help for list
 ```
 
 ### Options inherited from parent commands
@@ -33,5 +40,5 @@ ovhcloud cloud database delete <database_id> [flags]
 
 ### SEE ALSO
 
-* [ovhcloud cloud database](ovhcloud_cloud_database.md)	 - Manage databases in the given cloud project
+* [ovhcloud cloud database-service database](ovhcloud_cloud_database-service_database.md)	 - Manage databases in a specific database service
 

--- a/doc/ovhcloud_cloud_database-service_delete.md
+++ b/doc/ovhcloud_cloud_database-service_delete.md
@@ -1,0 +1,37 @@
+## ovhcloud cloud database-service delete
+
+Delete a specific database service
+
+```
+ovhcloud cloud database-service delete <cluster_id> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for delete
+```
+
+### Options inherited from parent commands
+
+```
+      --cloud-project string   Cloud project ID
+  -d, --debug                  Activate debug mode (will log all HTTP requests details)
+  -f, --format string          Output value according to given format (expression using https://github.com/PaesslerAG/gval syntax)
+                               Examples:
+                                 --format 'id' (to extract a single field)
+                                 --format 'nested.field.subfield' (to extract a nested field)
+                                 --format '[id, 'name']' (to extract multiple fields as an array)
+                                 --format '{"newKey": oldKey, "otherKey": nested.field}' (to extract and rename fields in an object)
+                                 --format 'name+","+type' (to extract and concatenate fields in a string)
+                                 --format '(nbFieldA + nbFieldB) * 10' (to compute values from numeric fields)
+  -e, --ignore-errors          Ignore errors in API calls when it is not fatal to the execution
+  -i, --interactive            Interactive output
+  -j, --json                   Output in JSON
+  -y, --yaml                   Output in YAML
+```
+
+### SEE ALSO
+
+* [ovhcloud cloud database-service](ovhcloud_cloud_database-service.md)	 - Manage database services in the given cloud project
+

--- a/doc/ovhcloud_cloud_database-service_edit.md
+++ b/doc/ovhcloud_cloud_database-service_edit.md
@@ -1,29 +1,29 @@
-## ovhcloud cloud database edit
+## ovhcloud cloud database-service edit
 
-Edit a specific database
+Edit a specific database service
 
 ### Synopsis
 
-Use this command to edit a database in the given public cloud project.
+Use this command to edit a database service in the given public cloud project.
 There are two ways to define the edition parameters:
 
 1. Using only CLI flags:
 
-	ovhcloud cloud database edit <database_id> --description "My database"
+	ovhcloud cloud database-service edit <cluster_id> --description "My database"
 
 2. Using your default text editor:
 
-	ovhcloud cloud database edit <database_id> --editor
+	ovhcloud cloud database-service edit <cluster_id> --editor
 
   The CLI will open your default text editor to update the parameters. When saving the file, the edition will be applied.
 
   Note that it is also possible to override values in the presented examples using command line flags like the following:
 
-	ovhcloud cloud database edit <database_id> --editor --description "My database"
+	ovhcloud cloud database-service edit <cluster_id> --editor --description "My database cluster"
 
 
 ```
-ovhcloud cloud database edit <database_id> [flags]
+ovhcloud cloud database-service edit <cluster_id> [flags]
 ```
 
 ### Options
@@ -64,5 +64,5 @@ ovhcloud cloud database edit <database_id> [flags]
 
 ### SEE ALSO
 
-* [ovhcloud cloud database](ovhcloud_cloud_database.md)	 - Manage databases in the given cloud project
+* [ovhcloud cloud database-service](ovhcloud_cloud_database-service.md)	 - Manage database services in the given cloud project
 

--- a/doc/ovhcloud_cloud_database-service_get.md
+++ b/doc/ovhcloud_cloud_database-service_get.md
@@ -1,9 +1,9 @@
-## ovhcloud cloud database get
+## ovhcloud cloud database-service get
 
-Get a specific database
+Get a specific database services
 
 ```
-ovhcloud cloud database get <database_id> [flags]
+ovhcloud cloud database-service get <cluster_id> [flags]
 ```
 
 ### Options
@@ -33,5 +33,5 @@ ovhcloud cloud database get <database_id> [flags]
 
 ### SEE ALSO
 
-* [ovhcloud cloud database](ovhcloud_cloud_database.md)	 - Manage databases in the given cloud project
+* [ovhcloud cloud database-service](ovhcloud_cloud_database-service.md)	 - Manage database services in the given cloud project
 

--- a/doc/ovhcloud_cloud_database-service_list.md
+++ b/doc/ovhcloud_cloud_database-service_list.md
@@ -1,9 +1,9 @@
-## ovhcloud cloud database list
+## ovhcloud cloud database-service list
 
-List your databases
+List your database services
 
 ```
-ovhcloud cloud database list [flags]
+ovhcloud cloud database-service list [flags]
 ```
 
 ### Options
@@ -40,5 +40,5 @@ ovhcloud cloud database list [flags]
 
 ### SEE ALSO
 
-* [ovhcloud cloud database](ovhcloud_cloud_database.md)	 - Manage databases in the given cloud project
+* [ovhcloud cloud database-service](ovhcloud_cloud_database-service.md)	 - Manage database services in the given cloud project
 

--- a/internal/cmd/cloud_database_test.go
+++ b/internal/cmd/cloud_database_test.go
@@ -31,7 +31,7 @@ func (ms *MockSuite) TestCloudDatabaseCreateCmd(assert, require *td.T) {
 		httpmock.NewStringResponder(200, `{"id": "0f0c43f0-979a-11f0-94fd-0050568ce122"}`),
 	)
 
-	out, err := cmd.Execute("cloud", "database", "create", "--cloud-project", "fakeProjectID", "--engine", "mysql", "--version", "8", "--plan", "essential", "--nodes-list", "db1-4:DE")
+	out, err := cmd.Execute("cloud", "database-service", "create", "--cloud-project", "fakeProjectID", "--engine", "mysql", "--version", "8", "--plan", "essential", "--nodes-list", "db1-4:DE")
 
 	require.CmpNoError(err)
 	assert.String(out, `✅ Database created successfully (id: 0f0c43f0-979a-11f0-94fd-0050568ce122)`)
@@ -134,7 +134,7 @@ func (ms *MockSuite) TestCloudDatabaseEditCmd(assert, require *td.T) {
 		httpmock.NewStringResponder(200, `{"id": "0f0c43f0-979a-11f0-94fd-0050568ce122"}`),
 	)
 
-	out, err := cmd.Execute("cloud", "database", "edit", "fakeDatabaseID", "--cloud-project", "fakeProjectID", "--version", "8", "--plan", "discovery", "--yaml")
+	out, err := cmd.Execute("cloud", "database-service", "edit", "fakeDatabaseID", "--cloud-project", "fakeProjectID", "--version", "8", "--plan", "discovery", "--yaml")
 
 	require.CmpNoError(err)
 	assert.String(out, `message: ✅ Resource updated successfully


### PR DESCRIPTION
# Description

- Rename command `cloud database` to `cloud database-service`
- Add subcommands to manage databases in a Public Cloud Database service

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that can break a current behavior)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have commented my code
- [x] I updated the documentation by running `make doc`
- [x] I ran `go mod tidy`
