### PR TITLE
fix: Avoid using homebrew_curl in generated Cask

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -69,7 +69,6 @@ homebrew_casks:
     binary: ovhcloud
     url:
       template: "https://github.com/ovh/ovhcloud-cli/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
-      using: ":homebrew_curl"
     repository:
       owner: ovh
       name: homebrew-tap


### PR DESCRIPTION
# Description

Avoid using `homebrew_curl` in the generated Homebrew Cask.

## Type of change

- [x] Improvement (improvement of existing commands)