### PR TITLE
Feat/reorder inst dirs preference order

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -262,7 +262,6 @@ End of functions from https://github.com/client9/shlib
 ------------------------------------------------------------------------
 EOF
 
-PROJECT_NAME="ovhcloud"
 OWNER=ovh
 REPO="ovhcloud-cli"
 BINARY=ovhcloud
@@ -276,7 +275,6 @@ log_prefix() {
 	echo "$PREFIX"
 }
 
-PLATFORM="${OS}/${ARCH}"
 GITHUB_DOWNLOAD=https://github.com/${OWNER}/${REPO}/releases/download
 
 uname_os_check "$OS"


### PR DESCRIPTION
# Description

This patch modifies the logic used to determine the
preference order of installation directories. It'll
look like this:

1. -b PATH
2. ${BINDIR}
3. ${XDG_BIN_HOME}
4. ${HOME}/.local/bin
5. ./bin

Fixes #42 (issue)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] Improvement (improvement of existing commands)

# Checklist:

- [x] My code follows the style guidelines of this project

Signed-off-by: Christian Goeschel Ndjomouo <cgoesc2@wgu.edu>