### PR TITLE
feat: Add cloud subnet creation command

### DIFF
--- a/doc/ovhcloud_cloud_network_private_subnet.md
+++ b/doc/ovhcloud_cloud_network_private_subnet.md
@@ -30,6 +30,7 @@ Manage subnets in a specific private network
 ### SEE ALSO
 
 * [ovhcloud cloud network private](ovhcloud_cloud_network_private.md)	 - Manage private networks in the given cloud project
+* [ovhcloud cloud network private subnet create](ovhcloud_cloud_network_private_subnet_create.md)	 - Create a subnet in the given private network
 * [ovhcloud cloud network private subnet delete](ovhcloud_cloud_network_private_subnet_delete.md)	 - Delete a specific subnet in a private network
 * [ovhcloud cloud network private subnet edit](ovhcloud_cloud_network_private_subnet_edit.md)	 - Edit a specific subnet in a private network
 * [ovhcloud cloud network private subnet get](ovhcloud_cloud_network_private_subnet_get.md)	 - Get a specific subnet in a private network

--- a/doc/ovhcloud_cloud_network_private_subnet_create.md
+++ b/doc/ovhcloud_cloud_network_private_subnet_create.md
@@ -1,0 +1,87 @@
+## ovhcloud cloud network private subnet create
+
+Create a subnet in the given private network
+
+### Synopsis
+
+Use this command to create a new subnet in a private network.
+There are three ways to define the parameters:
+
+1. Using only CLI flags:
+
+	ovhcloud cloud network private subnet create <network_id> --network 192.168.1.0/24 --start 192.168.1.12 --end 192.168.1.24 --region GRA9
+
+2. Using a configuration file:
+
+  First you can generate an example of parameters file using the following command:
+
+	ovhcloud cloud network private subnet create <network_id> --init-file ./params.json
+
+  You will be able to choose from several examples of parameters. Once an example has been selected, the content is written in the given file.
+  After editing the file to set the correct creation parameters, run:
+
+	ovhcloud cloud network private subnet create <network_id> --from-file ./params.json
+
+  Note that you can also pipe the content of the parameters file, like the following:
+
+	cat ./params.json | ovhcloud cloud network private subnet create <network_id>
+
+  In both cases, you can override the parameters in the given file using command line flags, for example:
+
+	ovhcloud cloud network private subnet create <network_id> --from-file ./params.json --region BHS5
+
+3. Using your default text editor:
+
+	ovhcloud cloud network private subnet create <network_id> --editor
+
+  You will be able to choose from several examples of parameters. Once an example has been selected, the CLI will open your
+  default text editor to update the parameters. When saving the file, the creation will start.
+
+  Note that it is also possible to override values in the presented examples using command line flags like the following:
+
+	ovhcloud cloud network private subnet create <network_id> --editor --region DE1
+
+
+```
+ovhcloud cloud network private subnet create <network_id> [flags]
+```
+
+### Options
+
+```
+      --dhcp               Enable DHCP for the subnet
+      --editor             Use a text editor to define parameters
+      --end string         Last IP for this region (eg: 192.168.1.24)
+      --from-file string   File containing parameters
+  -h, --help               help for create
+      --init-file string   Create a file with example parameters
+      --network string     Global network CIDR (eg: 192.168.1.0/24)
+      --no-gateway         Use this flag if you don't want to set a default gateway IP
+      --region string      Region for the subnet
+      --replace            Replace parameters file if it already exists
+      --start string       First IP for this region (eg: 192.168.1.12)
+```
+
+### Options inherited from parent commands
+
+```
+      --cloud-project string   Cloud project ID
+  -d, --debug                  Activate debug mode (will log all HTTP requests details)
+  -f, --format string          Output value according to given format (expression using https://github.com/PaesslerAG/gval syntax)
+                               Examples:
+                                 --format 'id' (to extract a single field)
+                                 --format 'nested.field.subfield' (to extract a nested field)
+                                 --format '[id, 'name']' (to extract multiple fields as an array)
+                                 --format '{"newKey": oldKey, "otherKey": nested.field}' (to extract and rename fields in an object)
+                                 --format 'name+","+type' (to extract and concatenate fields in a string)
+                                 --format '(nbFieldA + nbFieldB) * 10' (to compute values from numeric fields)
+  -e, --ignore-errors          Ignore errors in API calls when it is not fatal to the execution
+  -i, --interactive            Interactive output
+  -j, --json                   Output in JSON
+  -y, --yaml                   Output in YAML
+```
+
+### SEE ALSO
+
+* [ovhcloud cloud network private subnet](ovhcloud_cloud_network_private_subnet.md)	 - Manage subnets in a specific private network
+

--- a/internal/cmd/cloud_network.go
+++ b/internal/cmd/cloud_network.go
@@ -103,15 +103,17 @@ func initCloudNetworkCommand(cloudCmd *cobra.Command) {
 		Args:  cobra.ExactArgs(2),
 	})
 
+	privateNetworkSubnetCmd.AddCommand(getSubnetCreationCmd())
+
 	privateNetworkSubnetEditCmd := &cobra.Command{
 		Use:   "edit <network_id> <subnet_id>",
 		Short: "Edit a specific subnet in a private network",
 		Run:   cloud.EditPrivateNetworkSubnet,
 		Args:  cobra.ExactArgs(2),
 	}
-	privateNetworkSubnetEditCmd.Flags().BoolVar(&cloud.CloudNetworkSubnetSpec.Dhcp, "enable-dhcp", false, "Enable DHCP (set to true if you don't want to set a default gateway IP)")
-	privateNetworkSubnetEditCmd.Flags().BoolVar(&cloud.CloudNetworkSubnetSpec.DisableGateway, "disable-gateway", false, "Set to true if you want to disable the default gateway")
-	privateNetworkSubnetEditCmd.Flags().StringVar(&cloud.CloudNetworkSubnetSpec.GatewayIp, "gateway-ip", "", "Gateway IP address")
+	privateNetworkSubnetEditCmd.Flags().BoolVar(&cloud.CloudNetworkSubnetEditSpec.Dhcp, "enable-dhcp", false, "Enable DHCP (set to true if you don't want to set a default gateway IP)")
+	privateNetworkSubnetEditCmd.Flags().BoolVar(&cloud.CloudNetworkSubnetEditSpec.DisableGateway, "disable-gateway", false, "Set to true if you want to disable the default gateway")
+	privateNetworkSubnetEditCmd.Flags().StringVar(&cloud.CloudNetworkSubnetEditSpec.GatewayIp, "gateway-ip", "", "Gateway IP address")
 	addInteractiveEditorFlag(privateNetworkSubnetEditCmd)
 	privateNetworkSubnetCmd.AddCommand(privateNetworkSubnetEditCmd)
 
@@ -304,6 +306,67 @@ There are three ways to define the parameters:
 	privateNetworkCreateCmd.MarkFlagsMutuallyExclusive("from-file", "editor")
 
 	return privateNetworkCreateCmd
+}
+
+func getSubnetCreationCmd() *cobra.Command {
+	privateNetworkSubnetCreateCmd := &cobra.Command{
+		Use:   "create <network_id>",
+		Short: "Create a subnet in the given private network",
+		Long: `Use this command to create a new subnet in a private network.
+There are three ways to define the parameters:
+
+1. Using only CLI flags:
+
+	ovhcloud cloud network private subnet create <network_id> --network 192.168.1.0/24 --start 192.168.1.12 --end 192.168.1.24 --region GRA9
+
+2. Using a configuration file:
+
+  First you can generate an example of parameters file using the following command:
+
+	ovhcloud cloud network private subnet create <network_id> --init-file ./params.json
+
+  You will be able to choose from several examples of parameters. Once an example has been selected, the content is written in the given file.
+  After editing the file to set the correct creation parameters, run:
+
+	ovhcloud cloud network private subnet create <network_id> --from-file ./params.json
+
+  Note that you can also pipe the content of the parameters file, like the following:
+
+	cat ./params.json | ovhcloud cloud network private subnet create <network_id>
+
+  In both cases, you can override the parameters in the given file using command line flags, for example:
+
+	ovhcloud cloud network private subnet create <network_id> --from-file ./params.json --region BHS5
+
+3. Using your default text editor:
+
+	ovhcloud cloud network private subnet create <network_id> --editor
+
+  You will be able to choose from several examples of parameters. Once an example has been selected, the CLI will open your
+  default text editor to update the parameters. When saving the file, the creation will start.
+
+  Note that it is also possible to override values in the presented examples using command line flags like the following:
+
+	ovhcloud cloud network private subnet create <network_id> --editor --region DE1
+`,
+		Run:  cloud.CreatePrivateNetworkSubnet,
+		Args: cobra.ExactArgs(1),
+	}
+
+	privateNetworkSubnetCreateCmd.Flags().BoolVar(&cloud.CloudNetworkSubnetSpec.DHCP, "dhcp", false, "Enable DHCP for the subnet")
+	privateNetworkSubnetCreateCmd.Flags().BoolVar(&cloud.CloudNetworkSubnetSpec.NoGateway, "no-gateway", false, "Use this flag if you don't want to set a default gateway IP")
+	privateNetworkSubnetCreateCmd.Flags().StringVar(&cloud.CloudNetworkSubnetSpec.Network, "network", "", "Global network CIDR (eg: 192.168.1.0/24)")
+	privateNetworkSubnetCreateCmd.Flags().StringVar(&cloud.CloudNetworkSubnetSpec.Start, "start", "", "First IP for this region (eg: 192.168.1.12)")
+	privateNetworkSubnetCreateCmd.Flags().StringVar(&cloud.CloudNetworkSubnetSpec.End, "end", "", "Last IP for this region (eg: 192.168.1.24)")
+	privateNetworkSubnetCreateCmd.Flags().StringVar(&cloud.CloudNetworkSubnetSpec.Region, "region", "", "Region for the subnet")
+
+	// Common flags for other means to define parameters
+	addInitParameterFileFlag(privateNetworkSubnetCreateCmd, assets.CloudOpenapiSchema, "/cloud/project/{serviceName}/network/private/{networkId}/subnet", "post", cloud.PrivateNetworkSubnetCreationExample, nil)
+	addInteractiveEditorFlag(privateNetworkSubnetCreateCmd)
+	addFromFileFlag(privateNetworkSubnetCreateCmd)
+	privateNetworkSubnetCreateCmd.MarkFlagsMutuallyExclusive("from-file", "editor")
+
+	return privateNetworkSubnetCreateCmd
 }
 
 func getGatewayCreationCmd() *cobra.Command {

--- a/internal/services/cloud/parameter-samples/private-network-subnet-create.json
+++ b/internal/services/cloud/parameter-samples/private-network-subnet-create.json
@@ -1,0 +1,8 @@
+{
+  "dhcp": false,
+  "end": "192.168.1.24",
+  "network": "192.168.1.0/24",
+  "noGateway": false,
+  "region": "GRA9",
+  "start": "192.168.1.0"
+}


### PR DESCRIPTION
# Description

Add cloud subnet creation command (`cloud network private subnet create`).

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have commented my code
- [x] I updated the documentation by running `make doc`
- [x] I ran `go mod tidy`
- [x] I have added tests that prove my fix is effective or that my feature works
