### PR TITLE
fix(login): extend fields width to prevent horizontal scroll

### DIFF
--- a/internal/display/login.go
+++ b/internal/display/login.go
@@ -34,21 +34,21 @@ func RunLoginInput(customEndpoint bool) map[string]string {
 		appKeyInput.Focus()
 	}
 	appKeyInput.CharLimit = 16
-	appKeyInput.Width = 30
+	appKeyInput.Width = 32
 	appKeyInput.Prompt = ""
 	inputs = append(inputs, appKeyInput)
 
 	appSecretInput := textinput.New()
 	appSecretInput.Placeholder = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 	appSecretInput.CharLimit = 32
-	appSecretInput.Width = 30
+	appSecretInput.Width = 32
 	appSecretInput.Prompt = ""
 	inputs = append(inputs, appSecretInput)
 
 	consumerKeyInput := textinput.New()
 	consumerKeyInput.Placeholder = "yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy"
 	consumerKeyInput.CharLimit = 32
-	consumerKeyInput.Width = 30
+	consumerKeyInput.Width = 32
 	consumerKeyInput.Prompt = ""
 	inputs = append(inputs, consumerKeyInput)
 


### PR DESCRIPTION
# Description

Makes the input fields in the `login` interactive command as large as the expected length allowed to prevent horizontal scrolling.

Fixes #52

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (improvement of existing commands)
- [ ] Breaking change (fix or feature that can break a current behavior)
- [ ] Documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code
- [ ] I updated the documentation by running `make doc`
- [ ] I ran `go mod tidy`
- [ ] I have added tests that prove my fix is effective or that my feature works
