### PR TITLE
doc: Fix contributing url

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ Add the appropriate line to your shell’s startup file (`~/.bashrc`, `~/.zshrc`
 
 You've developed a new cool feature? Fixed an annoying bug? We'd be happy to hear from you, there are no small contributions!
  
-Have a look in [CONTRIBUTING.md](https://github.com/ovh/ovhcloud-cli/blob/master/CONTRIBUTING.md)
+Have a look in [CONTRIBUTING.md](https://github.com/ovh/ovhcloud-cli/blob/main/CONTRIBUTING.md)
 
 ## Build
 


### PR DESCRIPTION
# Description

URL to the CONTRIBUTING.md file is pointing to the `master` branch which doesn't exist.
GitHub automatically handle the redirection but it could be replaced by the actual default branch. 

## Type of change

Please delete options that are not relevant.

- [x] Documentation update

# Checklist:

- [x] My code follows the style guidelines of this project