### PR TITLE
doc: Fix README build target

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ Have a look in [CONTRIBUTING.md](https://github.com/ovh/ovhcloud-cli/blob/main/C
 
 ```sh
 # Build the OVHcloud cli
-make build
+make all
 
 # Cross-compile for other targets in ./dist
 make release-snapshot


### PR DESCRIPTION
# Description

Makefile target "build" doesn't exist, we should use target "all" instead.

## Type of change

Please delete options that are not relevant.

- [X] Documentation update

# Checklist:

- [X] My code follows the style guidelines of this project

Thomas