### PR TITLE
feat: Add options to s3 objects bulk-delete command

### DIFF
--- a/doc/ovhcloud_cloud_storage-s3_bulk-delete.md
+++ b/doc/ovhcloud_cloud_storage-s3_bulk-delete.md
@@ -9,8 +9,10 @@ ovhcloud cloud storage-s3 bulk-delete <container_name> [flags]
 ### Options
 
 ```
+      --all               Delete all objects in the container
   -h, --help              help for bulk-delete
       --objects strings   List of objects to delete (format is '<object_name>' or '<object_name>:<version_id>'
+      --prefix string     Prefix to filter objects to delete
 ```
 
 ### Options inherited from parent commands

--- a/internal/cmd/cloud_storage_s3.go
+++ b/internal/cmd/cloud_storage_s3.go
@@ -66,6 +66,11 @@ func initCloudStorageS3Command(cloudCmd *cobra.Command) {
 		Args:  cobra.ExactArgs(1),
 	}
 	bulkDeleteCmd.Flags().StringSliceVar(&cloud.StorageS3ObjectsToDelete, "objects", nil, "List of objects to delete (format is '<object_name>' or '<object_name>:<version_id>'")
+	bulkDeleteCmd.Flags().BoolVar(&cloud.StorageS3BulkDeleteAll, "all", false, "Delete all objects in the container")
+	bulkDeleteCmd.Flags().StringVar(&cloud.StorageS3BulkDeletePrefix, "prefix", "", "Prefix to filter objects to delete")
+	bulkDeleteCmd.MarkFlagsOneRequired("objects", "all", "prefix")
+	bulkDeleteCmd.MarkFlagsMutuallyExclusive("objects", "all", "prefix")
+
 	storageS3Cmd.AddCommand(bulkDeleteCmd)
 
 	// Object commands

--- a/internal/cmd/cloud_storage_s3_test.go
+++ b/internal/cmd/cloud_storage_s3_test.go
@@ -1,0 +1,163 @@
+// SPDX-FileCopyrightText: 2025 OVH SAS <opensource@ovh.net>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd_test
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/jarcoal/httpmock"
+	"github.com/maxatome/go-testdeep/td"
+	"github.com/maxatome/tdhttpmock"
+	"github.com/ovh/ovhcloud-cli/internal/cmd"
+)
+
+func (ms *MockSuite) TestCloudStorageS3BulkDeletePrefixCmd(assert, require *td.T) {
+	httpmock.RegisterResponder(http.MethodGet, "https://eu.api.ovh.com/1.0/cloud/project/fakeProjectID/region",
+		httpmock.NewStringResponder(200, `["BHS"]`))
+
+	httpmock.RegisterResponder(http.MethodGet, "https://eu.api.ovh.com/1.0/cloud/project/fakeProjectID/region/BHS",
+		httpmock.NewStringResponder(200, `{
+			"name": "BHS",
+			"type": "region",
+			"status": "UP",
+			"services": [
+				{
+					"name": "storage",
+					"status": "UP"
+				},
+				{
+					"name": "storage-s3-high-perf",
+					"status": "UP"
+				},
+				{
+					"name": "storage-s3-standard",
+					"status": "UP"
+				}
+			],
+			"countryCode": "ca",
+			"ipCountries": [],
+			"continentCode": "NA",
+			"availabilityZones": [],
+			"datacenterLocation": "BHS"
+		}`))
+
+	httpmock.RegisterResponder(http.MethodGet,
+		"https://eu.api.ovh.com/1.0/cloud/project/fakeProjectID/region/BHS/storage/fakeContainer",
+		httpmock.NewStringResponder(200, `{
+			"name": "fakeContainer",
+			"virtualHost": "https://fakeContainer.test.ovh.net/",
+			"ownerId": 0,
+			"objectsCount": 15,
+			"objectsSize": 4147089,
+			"objects": [
+				{"key": "logs/log1.txt"},
+				{"key": "logs/log2.txt"},
+				{"key": "images/img1.png"}
+			],
+			"region": "BHS",
+			"createdAt": "2025-02-10T14:24:12Z"
+		}`))
+
+	httpmock.RegisterResponder(http.MethodGet,
+		"https://eu.api.ovh.com/1.0/cloud/project/fakeProjectID/region/BHS/storage/fakeContainer/object?prefix=logs%2F",
+		httpmock.NewStringResponder(200, `[
+			{"key": "logs/log1.txt"},
+			{"key": "logs/log2.txt"}
+		]`).Then(httpmock.NewStringResponder(200, `[]`)),
+	)
+
+	httpmock.RegisterMatcherResponder(http.MethodPost,
+		"https://eu.api.ovh.com/1.0/cloud/project/fakeProjectID/region/BHS/storage/fakeContainer/bulkDeleteObjects",
+		tdhttpmock.JSONBody(td.JSON(`
+			{
+				"objects": [
+					{"key": "logs/log1.txt"},
+					{"key": "logs/log2.txt"}
+				]
+			}`),
+		),
+		httpmock.NewStringResponder(200, ``),
+	)
+
+	out, err := cmd.Execute("cloud", "storage-s3", "bulk-delete", "fakeContainer", "--cloud-project", "fakeProjectID", "--prefix", "logs/", "--json")
+	require.CmpNoError(err)
+	assert.Cmp(json.RawMessage(out), td.JSON(`{"message": "✅ Objects deleted successfully"}`))
+}
+
+func (ms *MockSuite) TestCloudStorageS3BulkDeleteAllCmd(assert, require *td.T) {
+	httpmock.RegisterResponder(http.MethodGet, "https://eu.api.ovh.com/1.0/cloud/project/fakeProjectID/region",
+		httpmock.NewStringResponder(200, `["BHS"]`))
+
+	httpmock.RegisterResponder(http.MethodGet, "https://eu.api.ovh.com/1.0/cloud/project/fakeProjectID/region/BHS",
+		httpmock.NewStringResponder(200, `{
+			"name": "BHS",
+			"type": "region",
+			"status": "UP",
+			"services": [
+				{
+					"name": "storage",
+					"status": "UP"
+				},
+				{
+					"name": "storage-s3-high-perf",
+					"status": "UP"
+				},
+				{
+					"name": "storage-s3-standard",
+					"status": "UP"
+				}
+			],
+			"countryCode": "ca",
+			"ipCountries": [],
+			"continentCode": "NA",
+			"availabilityZones": [],
+			"datacenterLocation": "BHS"
+		}`))
+
+	httpmock.RegisterResponder(http.MethodGet,
+		"https://eu.api.ovh.com/1.0/cloud/project/fakeProjectID/region/BHS/storage/fakeContainer",
+		httpmock.NewStringResponder(200, `{
+			"name": "fakeContainer",
+			"virtualHost": "https://fakeContainer.test.ovh.net/",
+			"ownerId": 0,
+			"objectsCount": 15,
+			"objectsSize": 4147089,
+			"objects": [
+				{"key": "logs/log1.txt"},
+				{"key": "logs/log2.txt"},
+				{"key": "images/img1.png"}
+			],
+			"region": "BHS",
+			"createdAt": "2025-02-10T14:24:12Z"
+		}`))
+
+	httpmock.RegisterResponder(http.MethodGet,
+		"https://eu.api.ovh.com/1.0/cloud/project/fakeProjectID/region/BHS/storage/fakeContainer/object",
+		httpmock.NewStringResponder(200, `[
+			{"key": "logs/log1.txt"},
+			{"key": "logs/log2.txt"},
+			{"key": "images/img1.png"}
+		]`).Then(httpmock.NewStringResponder(200, `[]`)),
+	)
+
+	httpmock.RegisterMatcherResponder(http.MethodPost,
+		"https://eu.api.ovh.com/1.0/cloud/project/fakeProjectID/region/BHS/storage/fakeContainer/bulkDeleteObjects",
+		tdhttpmock.JSONBody(td.JSON(`
+			{
+				"objects": [
+					{"key": "logs/log1.txt"},
+					{"key": "logs/log2.txt"},
+					{"key": "images/img1.png"}
+				]
+			}`),
+		),
+		httpmock.NewStringResponder(200, ``),
+	)
+
+	out, err := cmd.Execute("cloud", "storage-s3", "bulk-delete", "fakeContainer", "--cloud-project", "fakeProjectID", "--all", "--json")
+	require.CmpNoError(err)
+	assert.Cmp(json.RawMessage(out), td.JSON(`{"message": "✅ Objects deleted successfully"}`))
+}


### PR DESCRIPTION
# Description

Add options `--all` and `--prefix` to s3 objects bulk-delete command.

Fixes #61 (issue)

## Type of change

- [x] Improvement (improvement of existing commands)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have commented my code
- [x] I updated the documentation by running `make doc`
- [x] I ran `go mod tidy`
- [x] I have added tests that prove my fix is effective or that my feature works
