### PR TITLE
fix: Avoid displaying <nil> in tables

### DIFF
--- a/internal/cmd/cloud_reference_test.go
+++ b/internal/cmd/cloud_reference_test.go
@@ -72,6 +72,32 @@ func (ms *MockSuite) TestCloudReferenceRancherPlansListCmd(assert, require *td.T
 `)
 }
 
+func (ms *MockSuite) TestCloudReferenceRancherPlansListCmdWithNil(assert, require *td.T) {
+	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/v2/publicCloud/project/fakeProjectID/reference/rancher/plan",
+		httpmock.NewStringResponder(200, `[
+			{
+				"name": "OVHCLOUD_EDITION",
+				"status": "AVAILABLE"
+			},
+			{
+				"name": "STANDARD",
+				"status": "AVAILABLE"
+			}
+		]`).Once())
+
+	out, err := cmd.Execute("cloud", "reference", "rancher", "list-plans", "--cloud-project", "fakeProjectID")
+
+	require.CmpNoError(err)
+	assert.String(out, `
+┌──────────────────┬───────────┬─────────┐
+│       name       │  status   │ message │
+├──────────────────┼───────────┼─────────┤
+│ OVHCLOUD_EDITION │ AVAILABLE │         │
+│ STANDARD         │ AVAILABLE │         │
+└──────────────────┴───────────┴─────────┘
+💡 Use option --json or --yaml to get the raw output with all information`[1:])
+}
+
 func (ms *MockSuite) TestCloudReferenceDatabasesPlansListCmd(assert, require *td.T) {
 	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/1.0/cloud/project/fakeProjectID/database/capabilities",
 		httpmock.NewStringResponder(200, `{

--- a/internal/display/display.go
+++ b/internal/display/display.go
@@ -123,6 +123,11 @@ func RenderTable(values []map[string]any, columnsToDisplay []string, outputForma
 				exitError("failed to select row field: %s", err)
 			}
 
+			if val == nil {
+				row = append(row, "")
+				continue
+			}
+
 			switch val.(type) {
 			case float32, float64:
 				// TODO: default formatting without decimals, may cause issues at some point


### PR DESCRIPTION
# Description

Avoid displaying `<nil>` in tables

Fixes #57 (issue)

## Type of change

- [x] Improvement (improvement of existing commands)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have commented my code
- [x] I updated the documentation by running `make doc`
- [x] I ran `go mod tidy`
- [x] I have added tests that prove my fix is effective or that my feature works
