### PR TITLE
fix: Handle case when image is nil when fetching an instance

### DIFF
--- a/internal/cmd/cloud_instance_test.go
+++ b/internal/cmd/cloud_instance_test.go
@@ -1,0 +1,126 @@
+// SPDX-FileCopyrightText: 2025 OVH SAS <opensource@ovh.net>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd_test
+
+import (
+	"net/http"
+
+	"github.com/jarcoal/httpmock"
+	"github.com/maxatome/go-testdeep/td"
+	"github.com/ovh/ovhcloud-cli/internal/cmd"
+)
+
+func (ms *MockSuite) TestCloudInstanceNullImageCmd(assert, require *td.T) {
+	httpmock.RegisterResponder(http.MethodGet,
+		"https://eu.api.ovh.com/1.0/cloud/project/fakeProjectID/instance/fakeInstanceID",
+		httpmock.NewStringResponder(200, `
+			{
+				"id": "fakeInstanceID",
+				"name": "TestInstance",
+				"ipAddresses": [
+					{
+						"ip": "1.2.3.4",
+						"type": "public",
+						"version": 4,
+						"networkId": "bc63b98d13fbba642b2653711cc9d156ca7b404f009f7227172d37b5280a6",
+						"gatewayIp": "1.2.3.4"
+					},
+					{
+						"ip": "2001:db8::1",
+						"type": "public",
+						"version": 6,
+						"networkId": "bc63b98d13fbba642b2653711cc9d156ca7b404f009f7227172d37b5280a6",
+						"gatewayIp": "2001:db8::ff"
+					}
+				],
+				"status": "ACTIVE",
+				"created": "2025-09-24T17:21:31Z",
+				"region": "GRA9",
+				"flavor": {
+					"id": "906e8259-0340-4856-95b5-4ea2d26fe377",
+					"name": "b2-7",
+					"region": "GRA9",
+					"ram": 7,
+					"disk": 50,
+					"vcpus": 2,
+					"type": "ovh.ssd.eg",
+					"osType": "linux",
+					"inboundBandwidth": 250,
+					"outboundBandwidth": 250,
+					"available": true,
+					"planCodes": {
+						"monthly": "b2-7.monthly.postpaid",
+						"hourly": "b2-7.consumption",
+						"license": null
+					},
+					"capabilities": [
+						{
+							"name": "resize",
+							"enabled": true
+						},
+						{
+							"name": "snapshot",
+							"enabled": true
+						},
+						{
+							"name": "volume",
+							"enabled": true
+						},
+						{
+							"name": "failoverip",
+							"enabled": true
+						}
+					],
+					"quota": 791
+				},
+				"image": null,
+				"sshKey": null,
+				"monthlyBilling": null,
+				"planCode": "b2-7.consumption",
+				"licensePlanCode": null,
+				"operationIds": [],
+				"currentMonthOutgoingTraffic": null,
+				"rescuePassword": null,
+				"availabilityZone": null
+			}`,
+		),
+	)
+
+	out, err := cmd.Execute("cloud", "instance", "get", "fakeInstanceID", "--cloud-project", "fakeProjectID")
+
+	require.CmpNoError(err)
+	assert.Cmp(cleanWhitespacesHelper(out), `
+  # 🚀 Instance fakeInstanceID
+
+  *TestInstance*
+
+  ## General information
+
+  **Region**:            GRA9
+  **Availability zone**:
+  **Status**:            ACTIVE
+  **Creation date**:     2025-09-24T17:21:31Z
+
+  IP addresses:
+
+   IP                     | Type                   | Gateway IP
+  ------------------------|------------------------|------------------------
+   1.2.3.4                | public                 | 1.2.3.4
+   2001:db8::1            | public                 | 2001:db8::ff
+
+  ## Flavor details
+
+  **Name**:                   b2-7
+  **Operating system**:       linux
+  **Number of disks**:        50
+  **RAM**:                    7 Mio
+  **vCPUs**:                  2
+  **Max inbound bandwidth**:  250Mbit/s
+  **Max outbound bandwidth**: 250Mbit/s
+
+  💡 Use option --json or --yaml to get the raw output with all information
+
+`)
+}

--- a/internal/services/cloud/templates/cloud_instance.tmpl
+++ b/internal/services/cloud/templates/cloud_instance.tmpl
@@ -26,6 +26,7 @@ IP addresses:
 **Max inbound bandwidth**:  {{index .Result "flavor" "inboundBandwidth"}}Mbit/s
 **Max outbound bandwidth**: {{index .Result "flavor" "outboundBandwidth"}}Mbit/s
 
+{{if index .Result "image" -}}
 ## Image details
 
 **Name**:                   {{index .Result "image" "name"}}
@@ -34,5 +35,6 @@ IP addresses:
 **Minimum RAM required**:   {{index .Result "image" "minRam"}}
 **Size**:                   {{index .Result "image" "size"}}Gib
 **Status**:                 {{index .Result "image" "status"}}
+{{- end}}
 
 💡 Use option --json or --yaml to get the raw output with all information


### PR DESCRIPTION
# Description

Avoid templating error when fetching an instance that has a null `image` field.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have commented my code
- [x] I updated the documentation by running `make doc`
- [x] I ran `go mod tidy`
- [x] I have added tests that prove my fix is effective or that my feature works
