### PR TITLE
fix: Avoid panic when listing baremetal compatible OSes

### DIFF
--- a/internal/cmd/baremetal_test.go
+++ b/internal/cmd/baremetal_test.go
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: 2025 OVH SAS <opensource@ovh.net>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd_test
+
+import (
+	"github.com/jarcoal/httpmock"
+	"github.com/maxatome/go-testdeep/td"
+	"github.com/ovh/ovhcloud-cli/internal/cmd"
+)
+
+func (ms *MockSuite) TestBaremetalListCompatibleOSCmd(assert, require *td.T) {
+	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/1.0/dedicated/server/fakeBaremetal/install/compatibleTemplates",
+		httpmock.NewStringResponder(200, `{
+			"ovh": [
+				"alma8-cpanel-latest_64",
+				"alma8-plesk18_64",
+				"alma8_64",
+				"alma9-cpanel-latest_64",
+				"alma9-plesk18_64",
+				"alma9_64",
+				"byoi_64",
+				"byolinux_64"
+			]
+		}`),
+	)
+
+	out, err := cmd.Execute("baremetal", "list-compatible-os", "fakeBaremetal")
+
+	require.CmpNoError(err)
+	assert.String(out, `
+┌────────┬────────────────────────┐
+│ source │          name          │
+├────────┼────────────────────────┤
+│ ovh    │ alma8-cpanel-latest_64 │
+│ ovh    │ alma8-plesk18_64       │
+│ ovh    │ alma8_64               │
+│ ovh    │ alma9-cpanel-latest_64 │
+│ ovh    │ alma9-plesk18_64       │
+│ ovh    │ alma9_64               │
+│ ovh    │ byoi_64                │
+│ ovh    │ byolinux_64            │
+└────────┴────────────────────────┘
+💡 Use option --json or --yaml to get the raw output with all information`[1:])
+}

--- a/internal/services/baremetal/baremetal.go
+++ b/internal/services/baremetal/baremetal.go
@@ -532,11 +532,14 @@ func GetBaremetalCompatibleOses(_ *cobra.Command, args []string) {
 			"name":   os,
 		})
 	}
-	for _, os := range oses["personal"].([]any) {
-		formattedValues = append(formattedValues, map[string]any{
-			"source": "personal",
-			"name":   os,
-		})
+
+	if personalOSes, ok := oses["personal"]; ok {
+		for _, os := range personalOSes.([]any) {
+			formattedValues = append(formattedValues, map[string]any{
+				"source": "personal",
+				"name":   os,
+			})
+		}
 	}
 
 	formattedValues, err := filtersLib.FilterLines(formattedValues, flags.GenericFilters)


### PR DESCRIPTION
# Description

Avoid panic when using `baremetal list-compatible-os` on an account without personal OSes.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have commented my code
- [x] I updated the documentation by running `make doc`
- [x] I ran `go mod tidy`
- [x] I have added tests that prove my fix is effective or that my feature works
