### PR TITLE
Add make build target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,9 @@ LD_PKG	  = $(shell go list ./internal/version)
 LD_FLAGS  = -s -w -extldflags -static -X ${LD_PKG}.Version=${VERSION}
 BUILD_CMD = CGO_ENABLED=0 go build
 
-all:
+all: build
+
+build:
 	${BUILD_CMD} -ldflags "${LD_FLAGS}" -o ovhcloud ./cmd/ovhcloud
 
 wasm:


### PR DESCRIPTION
# Description

I noticed that `make build` is mentioned in the [CONTRIBUTING.md](https://github.com/ovh/ovhcloud-cli/blob/main/CONTRIBUTING.md#7-checklist-before-opening-a-pr), but there is no such target. This PR just adds this.
 
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)