### PR TITLE
fix(cloud_loadbalancer): Improve displayed info

### DIFF
--- a/internal/cmd/cloud_loadbalancer_test.go
+++ b/internal/cmd/cloud_loadbalancer_test.go
@@ -82,6 +82,14 @@ func (ms *MockSuite) TestCloudLoadbalancerGetCmd(assert, require *td.T) {
 			"vipSubnetId": "44a869c4-a8db-11f0-899f-0050568ce122"
 		}`))
 
+	httpmock.RegisterResponder(http.MethodGet,
+		"https://eu.api.ovh.com/1.0/cloud/project/fakeProjectID/region/SBG5/loadbalancing/flavor/f862fa22-6275-4f8f-885e-66a8faf5e44e",
+		httpmock.NewStringResponder(200, `{
+			"id": "f862fa22-6275-4f8f-885e-66a8faf5e44e",
+			"name": "medium",
+			"description": "Medium Load Balancer Flavor"
+		}`))
+
 	out, err := cmd.Execute("cloud", "loadbalancer", "get", "fakeLB", "--cloud-project", "fakeProjectID")
 	require.CmpNoError(err)
 	assert.Cmp(cleanWhitespacesHelper(out), `
@@ -94,7 +102,7 @@ func (ms *MockSuite) TestCloudLoadbalancerGetCmd(assert, require *td.T) {
   **Region**:              SBG5
   **Operating status**:    online
   **Provisioning status**: active
-  **Flavor ID**:           f862fa22-6275-4f8f-885e-66a8faf5e44e
+  **Flavor**:              medium (ID: f862fa22-6275-4f8f-885e-66a8faf5e44e)
   **Creation date**:       2024-07-30T08:26:51Z
 
   ## Technical information

--- a/internal/services/cloud/templates/cloud_loadbalancer.tmpl
+++ b/internal/services/cloud/templates/cloud_loadbalancer.tmpl
@@ -8,7 +8,7 @@ _{{index .Result "name"}}_
 **Region**:              {{index .Result "region"}}
 **Operating status**:    {{index .Result "operatingStatus"}}
 **Provisioning status**: {{index .Result "provisioningStatus"}}
-**Flavor ID**:           {{index .Result "flavorId"}}
+**Flavor**:              {{if index .Result "flavor"}}{{index .Result "flavor" "name"}} (ID: {{index .Result "flavorId"}}){{else}}{{index .Result "flavorId"}}{{end}}
 **Creation date**:       {{index .Result "createdAt"}}
 
 ## Technical information
@@ -16,6 +16,6 @@ _{{index .Result "name"}}_
 **VIP address**:        {{index .Result "vipAddress"}}
 **VIP network ID**:     {{index .Result "vipNetworkId"}}
 **VIP subnet ID**:      {{index .Result "vipSubnetId"}}
-{{if index .Result "floatingIp"}}**Floating IP**:       {{index .Result "floatingIp"}}{{end}}
+{{if index .Result "floatingIp"}}**Floating IP**:        {{index .Result "floatingIp" "ip"}}{{end}}
 
 💡 Use option --json or --yaml to get the raw output with all information


### PR DESCRIPTION
# Description

Improve display when fetching a loadbalancer:
- Display correctly the associated floating IP
- Fetch the flavor info to display the name with the ID

Fixes #111 (issue)

## Type of change

- [x] Improvement (improvement of existing commands)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have commented my code
- [x] I updated the documentation by running `make doc`
- [x] I ran `go mod tidy`
- [x] I have added tests that prove my fix is effective or that my feature works
