### PR TITLE
fix: Add /v1 prefix to API calls

### DIFF
--- a/internal/cmd/account_test.go
+++ b/internal/cmd/account_test.go
@@ -16,7 +16,7 @@ import (
 
 func (ms *MockSuite) TestOauth2ClientCreateCmd(assert, require *td.T) {
 	httpmock.RegisterMatcherResponder(http.MethodPost,
-		"https://eu.api.ovh.com/1.0/me/api/oauth2/client",
+		"https://eu.api.ovh.com/v1/me/api/oauth2/client",
 		tdhttpmock.JSONBody(td.JSON(`
 			{
 				"callbackUrls": [

--- a/internal/cmd/baremetal_test.go
+++ b/internal/cmd/baremetal_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func (ms *MockSuite) TestBaremetalListCompatibleOSCmd(assert, require *td.T) {
-	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/1.0/dedicated/server/fakeBaremetal/install/compatibleTemplates",
+	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/v1/dedicated/server/fakeBaremetal/install/compatibleTemplates",
 		httpmock.NewStringResponder(200, `{
 			"ovh": [
 				"alma8-cpanel-latest_64",

--- a/internal/cmd/cloud_container_registry_test.go
+++ b/internal/cmd/cloud_container_registry_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func (ms *MockSuite) TestCloudContainerRegistryListCmd(assert, require *td.T) {
-	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/1.0/cloud/project/fakeProjectID/containerRegistry",
+	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/v1/cloud/project/fakeProjectID/containerRegistry",
 		httpmock.NewStringResponder(200, `[
 			{
 				"createdAt": "2025-08-22T09:24:18.953364Z",
@@ -28,10 +28,10 @@ func (ms *MockSuite) TestCloudContainerRegistryListCmd(assert, require *td.T) {
 			}
 		]`).Once())
 
-	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/1.0/cloud/project/fakeProjectID/region",
+	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/v1/cloud/project/fakeProjectID/region",
 		httpmock.NewStringResponder(200, `["GRA", "EU-WEST-PAR"]`).Once())
 
-	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/1.0/cloud/project/fakeProjectID/region/GRA",
+	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/v1/cloud/project/fakeProjectID/region/GRA",
 		httpmock.NewStringResponder(200, `{
 			"name": "GRA",
 			"type": "region",
@@ -44,7 +44,7 @@ func (ms *MockSuite) TestCloudContainerRegistryListCmd(assert, require *td.T) {
 			"datacenterLocation": "GRA"
 		}`).Once())
 
-	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/1.0/cloud/project/fakeProjectID/region/EU-WEST-PAR",
+	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/v1/cloud/project/fakeProjectID/region/EU-WEST-PAR",
 		httpmock.NewStringResponder(200, `{
 			"name": "EU-WEST-PAR",
 			"type": "region-3-az",
@@ -57,7 +57,7 @@ func (ms *MockSuite) TestCloudContainerRegistryListCmd(assert, require *td.T) {
 			"datacenterLocation": "EU-WEST-PAR"
 		}`).Once())
 
-	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/1.0/cloud/project/fakeProjectID/containerRegistry/0b1b2dc2-952b-11f0-afd9-0050568ce122/plan",
+	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/v1/cloud/project/fakeProjectID/containerRegistry/0b1b2dc2-952b-11f0-afd9-0050568ce122/plan",
 		httpmock.NewStringResponder(200, `{
 			"code": "registry.s-plan-equivalent.hour.consumption",
 			"createdAt": "2019-09-13T15:53:33.599585Z",

--- a/internal/cmd/cloud_database_test.go
+++ b/internal/cmd/cloud_database_test.go
@@ -15,7 +15,7 @@ import (
 
 func (ms *MockSuite) TestCloudDatabaseCreateCmd(assert, require *td.T) {
 	httpmock.RegisterMatcherResponder(http.MethodPost,
-		"https://eu.api.ovh.com/1.0/cloud/project/fakeProjectID/database/mysql",
+		"https://eu.api.ovh.com/v1/cloud/project/fakeProjectID/database/mysql",
 		tdhttpmock.JSONBody(td.JSON(`
 			{
 				"nodesList": [
@@ -39,7 +39,7 @@ func (ms *MockSuite) TestCloudDatabaseCreateCmd(assert, require *td.T) {
 
 func (ms *MockSuite) TestCloudDatabaseEditCmd(assert, require *td.T) {
 	httpmock.RegisterResponder(http.MethodGet,
-		"https://eu.api.ovh.com/1.0/cloud/project/fakeProjectID/database/service/fakeDatabaseID",
+		"https://eu.api.ovh.com/v1/cloud/project/fakeProjectID/database/service/fakeDatabaseID",
 		httpmock.NewStringResponder(200, `{
 				"id": "fakeDatabaseID",
 				"engine": "mysql"
@@ -47,7 +47,7 @@ func (ms *MockSuite) TestCloudDatabaseEditCmd(assert, require *td.T) {
 	)
 
 	httpmock.RegisterResponder(http.MethodGet,
-		"https://eu.api.ovh.com/1.0/cloud/project/fakeProjectID/database/mysql/fakeDatabaseID",
+		"https://eu.api.ovh.com/v1/cloud/project/fakeProjectID/database/mysql/fakeDatabaseID",
 		httpmock.NewStringResponder(200, `{
 			"createdAt": "2025-09-22T14:16:18.506458+02:00",
 			"plan": "essential",
@@ -100,7 +100,7 @@ func (ms *MockSuite) TestCloudDatabaseEditCmd(assert, require *td.T) {
 	)
 
 	httpmock.RegisterMatcherResponder(http.MethodPut,
-		"https://eu.api.ovh.com/1.0/cloud/project/fakeProjectID/database/mysql/fakeDatabaseID",
+		"https://eu.api.ovh.com/v1/cloud/project/fakeProjectID/database/mysql/fakeDatabaseID",
 		tdhttpmock.JSONBody(td.JSON(`
 			{
 				"backupTime": "09:10:00",

--- a/internal/cmd/cloud_instance_test.go
+++ b/internal/cmd/cloud_instance_test.go
@@ -14,7 +14,7 @@ import (
 
 func (ms *MockSuite) TestCloudInstanceNullImageCmd(assert, require *td.T) {
 	httpmock.RegisterResponder(http.MethodGet,
-		"https://eu.api.ovh.com/1.0/cloud/project/fakeProjectID/instance/fakeInstanceID",
+		"https://eu.api.ovh.com/v1/cloud/project/fakeProjectID/instance/fakeInstanceID",
 		httpmock.NewStringResponder(200, `
 			{
 				"id": "fakeInstanceID",

--- a/internal/cmd/cloud_kube_test.go
+++ b/internal/cmd/cloud_kube_test.go
@@ -11,10 +11,10 @@ import (
 )
 
 func (ms *MockSuite) TestCloudKubeListCmd(assert, require *td.T) {
-	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/1.0/cloud/project/fakeProjectID/kube",
+	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/v1/cloud/project/fakeProjectID/kube",
 		httpmock.NewStringResponder(200, `["kube-12345"]`).Once())
 
-	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/1.0/cloud/project/fakeProjectID/kube/kube-12345",
+	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/v1/cloud/project/fakeProjectID/kube/kube-12345",
 		httpmock.NewStringResponder(200, `{
 			"id": "kube-12345",
 			"name": "test-kube",

--- a/internal/cmd/cloud_loadbalancer_test.go
+++ b/internal/cmd/cloud_loadbalancer_test.go
@@ -13,10 +13,10 @@ import (
 )
 
 func (ms *MockSuite) TestCloudLoadbalancerGetCmd(assert, require *td.T) {
-	httpmock.RegisterResponder(http.MethodGet, "https://eu.api.ovh.com/1.0/cloud/project/fakeProjectID/region",
+	httpmock.RegisterResponder(http.MethodGet, "https://eu.api.ovh.com/v1/cloud/project/fakeProjectID/region",
 		httpmock.NewStringResponder(200, `["GRA11", "SBG5", "BHS5"]`))
 
-	httpmock.RegisterResponder(http.MethodGet, "https://eu.api.ovh.com/1.0/cloud/project/fakeProjectID/region/GRA11",
+	httpmock.RegisterResponder(http.MethodGet, "https://eu.api.ovh.com/v1/cloud/project/fakeProjectID/region/GRA11",
 		httpmock.NewStringResponder(200, `{
 			"name": "GRA11",
 			"type": "region",
@@ -34,7 +34,7 @@ func (ms *MockSuite) TestCloudLoadbalancerGetCmd(assert, require *td.T) {
 			"datacenterLocation": "GRA11"
 		}`))
 
-	httpmock.RegisterResponder(http.MethodGet, "https://eu.api.ovh.com/1.0/cloud/project/fakeProjectID/region/SBG5",
+	httpmock.RegisterResponder(http.MethodGet, "https://eu.api.ovh.com/v1/cloud/project/fakeProjectID/region/SBG5",
 		httpmock.NewStringResponder(200, `{
 			"name": "SBG5",
 			"type": "region",
@@ -52,7 +52,7 @@ func (ms *MockSuite) TestCloudLoadbalancerGetCmd(assert, require *td.T) {
 			"datacenterLocation": "SBG5"
 		}`))
 
-	httpmock.RegisterResponder(http.MethodGet, "https://eu.api.ovh.com/1.0/cloud/project/fakeProjectID/region/BHS5",
+	httpmock.RegisterResponder(http.MethodGet, "https://eu.api.ovh.com/v1/cloud/project/fakeProjectID/region/BHS5",
 		httpmock.NewStringResponder(200, `{
 			"name": "BHS5",
 			"type": "region",
@@ -66,7 +66,7 @@ func (ms *MockSuite) TestCloudLoadbalancerGetCmd(assert, require *td.T) {
 		}`))
 
 	httpmock.RegisterResponder(http.MethodGet,
-		"https://eu.api.ovh.com/1.0/cloud/project/fakeProjectID/region/SBG5/loadbalancing/loadbalancer/fakeLB",
+		"https://eu.api.ovh.com/v1/cloud/project/fakeProjectID/region/SBG5/loadbalancing/loadbalancer/fakeLB",
 		httpmock.NewStringResponder(200, `{
 			"createdAt": "2024-07-30T08:26:51Z",
 			"flavorId": "f862fa22-6275-4f8f-885e-66a8faf5e44e",
@@ -83,7 +83,7 @@ func (ms *MockSuite) TestCloudLoadbalancerGetCmd(assert, require *td.T) {
 		}`))
 
 	httpmock.RegisterResponder(http.MethodGet,
-		"https://eu.api.ovh.com/1.0/cloud/project/fakeProjectID/region/SBG5/loadbalancing/flavor/f862fa22-6275-4f8f-885e-66a8faf5e44e",
+		"https://eu.api.ovh.com/v1/cloud/project/fakeProjectID/region/SBG5/loadbalancing/flavor/f862fa22-6275-4f8f-885e-66a8faf5e44e",
 		httpmock.NewStringResponder(200, `{
 			"id": "f862fa22-6275-4f8f-885e-66a8faf5e44e",
 			"name": "medium",

--- a/internal/cmd/cloud_network_test.go
+++ b/internal/cmd/cloud_network_test.go
@@ -16,7 +16,7 @@ import (
 
 func (ms *MockSuite) TestCloudPrivateNetworkCreateCmd(assert, require *td.T) {
 	httpmock.RegisterMatcherResponder(http.MethodPost,
-		"https://eu.api.ovh.com/1.0/cloud/project/fakeProjectID/region/BHS5/network",
+		"https://eu.api.ovh.com/v1/cloud/project/fakeProjectID/region/BHS5/network",
 		tdhttpmock.JSONBody(td.JSON(`
 			{
 				"gateway": {
@@ -35,7 +35,7 @@ func (ms *MockSuite) TestCloudPrivateNetworkCreateCmd(assert, require *td.T) {
 		httpmock.NewStringResponder(200, `{"id": "operation-12345"}`),
 	)
 
-	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/1.0/cloud/project/fakeProjectID/operation/operation-12345",
+	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/v1/cloud/project/fakeProjectID/operation/operation-12345",
 		httpmock.NewStringResponder(200, `
 		{
 			"id": "6610ec10-9b09-11f0-a8ac-0050568ce122",
@@ -66,7 +66,7 @@ func (ms *MockSuite) TestCloudPrivateNetworkCreateCmd(assert, require *td.T) {
 		}`),
 	)
 
-	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/1.0/cloud/project/fakeProjectID/network/private",
+	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/v1/cloud/project/fakeProjectID/network/private",
 		httpmock.NewStringResponder(200, `[
 			{
 				"id": "pn-example",
@@ -85,7 +85,7 @@ func (ms *MockSuite) TestCloudPrivateNetworkCreateCmd(assert, require *td.T) {
 		]`),
 	)
 
-	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/1.0/cloud/project/fakeProjectID/region/BHS5/network/80c1de3e-9b09-11f0-993b-0050568ce122/subnet",
+	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/v1/cloud/project/fakeProjectID/region/BHS5/network/80c1de3e-9b09-11f0-993b-0050568ce122/subnet",
 		httpmock.NewStringResponder(200, `[
 			{
 				"id": "c59a3fdc-9b0f-11f0-ac97-0050568ce122",
@@ -104,7 +104,7 @@ func (ms *MockSuite) TestCloudPrivateNetworkCreateCmd(assert, require *td.T) {
 		]`),
 	)
 
-	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/1.0/cloud/project/fakeProjectID/region/BHS5/gateway?subnetId=c59a3fdc-9b0f-11f0-ac97-0050568ce122",
+	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/v1/cloud/project/fakeProjectID/region/BHS5/gateway?subnetId=c59a3fdc-9b0f-11f0-ac97-0050568ce122",
 		httpmock.NewStringResponder(200, `[
 			{
 				"id": "e7045f34-8f2b-41a4-a734-97b7b0e323de",
@@ -159,7 +159,7 @@ message: '✅ Network pn-example created successfully (Openstack ID: 80c1de3e-9b
 
 func (ms *MockSuite) TestCloudPrivateNetworkSubnetCreateCmd(assert, require *td.T) {
 	httpmock.RegisterMatcherResponder(http.MethodPost,
-		"https://eu.api.ovh.com/1.0/cloud/project/fakeProjectID/network/private/pn-123456/subnet",
+		"https://eu.api.ovh.com/v1/cloud/project/fakeProjectID/network/private/pn-123456/subnet",
 		tdhttpmock.JSONBody(td.JSON(`
 			{
 				"dhcp": false,

--- a/internal/cmd/cloud_reference_test.go
+++ b/internal/cmd/cloud_reference_test.go
@@ -99,7 +99,7 @@ func (ms *MockSuite) TestCloudReferenceRancherPlansListCmdWithNil(assert, requir
 }
 
 func (ms *MockSuite) TestCloudReferenceDatabasesPlansListCmd(assert, require *td.T) {
-	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/1.0/cloud/project/fakeProjectID/database/capabilities",
+	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/v1/cloud/project/fakeProjectID/database/capabilities",
 		httpmock.NewStringResponder(200, `{
 			"plans": [
 				{
@@ -152,7 +152,7 @@ func (ms *MockSuite) TestCloudReferenceDatabasesPlansListCmd(assert, require *td
 }
 
 func (ms *MockSuite) TestCloudReferenceDatabasesFlavorsListCmd(assert, require *td.T) {
-	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/1.0/cloud/project/fakeProjectID/database/capabilities",
+	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/v1/cloud/project/fakeProjectID/database/capabilities",
 		httpmock.NewStringResponder(200, `{
 			"flavors": [
 				{
@@ -218,7 +218,7 @@ func (ms *MockSuite) TestCloudReferenceDatabasesFlavorsListCmd(assert, require *
 }
 
 func (ms *MockSuite) TestCloudReferenceDatabasesEnginesListCmd(assert, require *td.T) {
-	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/1.0/cloud/project/fakeProjectID/database/capabilities",
+	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/v1/cloud/project/fakeProjectID/database/capabilities",
 		httpmock.NewStringResponder(200, `{
 			"engines": [
 				{

--- a/internal/cmd/cloud_storage_s3_test.go
+++ b/internal/cmd/cloud_storage_s3_test.go
@@ -15,10 +15,10 @@ import (
 )
 
 func (ms *MockSuite) TestCloudStorageS3BulkDeletePrefixCmd(assert, require *td.T) {
-	httpmock.RegisterResponder(http.MethodGet, "https://eu.api.ovh.com/1.0/cloud/project/fakeProjectID/region",
+	httpmock.RegisterResponder(http.MethodGet, "https://eu.api.ovh.com/v1/cloud/project/fakeProjectID/region",
 		httpmock.NewStringResponder(200, `["BHS"]`))
 
-	httpmock.RegisterResponder(http.MethodGet, "https://eu.api.ovh.com/1.0/cloud/project/fakeProjectID/region/BHS",
+	httpmock.RegisterResponder(http.MethodGet, "https://eu.api.ovh.com/v1/cloud/project/fakeProjectID/region/BHS",
 		httpmock.NewStringResponder(200, `{
 			"name": "BHS",
 			"type": "region",
@@ -45,7 +45,7 @@ func (ms *MockSuite) TestCloudStorageS3BulkDeletePrefixCmd(assert, require *td.T
 		}`))
 
 	httpmock.RegisterResponder(http.MethodGet,
-		"https://eu.api.ovh.com/1.0/cloud/project/fakeProjectID/region/BHS/storage/fakeContainer",
+		"https://eu.api.ovh.com/v1/cloud/project/fakeProjectID/region/BHS/storage/fakeContainer",
 		httpmock.NewStringResponder(200, `{
 			"name": "fakeContainer",
 			"virtualHost": "https://fakeContainer.test.ovh.net/",
@@ -62,7 +62,7 @@ func (ms *MockSuite) TestCloudStorageS3BulkDeletePrefixCmd(assert, require *td.T
 		}`))
 
 	httpmock.RegisterResponder(http.MethodGet,
-		"https://eu.api.ovh.com/1.0/cloud/project/fakeProjectID/region/BHS/storage/fakeContainer/object?prefix=logs%2F",
+		"https://eu.api.ovh.com/v1/cloud/project/fakeProjectID/region/BHS/storage/fakeContainer/object?prefix=logs%2F",
 		httpmock.NewStringResponder(200, `[
 			{"key": "logs/log1.txt"},
 			{"key": "logs/log2.txt"}
@@ -70,7 +70,7 @@ func (ms *MockSuite) TestCloudStorageS3BulkDeletePrefixCmd(assert, require *td.T
 	)
 
 	httpmock.RegisterMatcherResponder(http.MethodPost,
-		"https://eu.api.ovh.com/1.0/cloud/project/fakeProjectID/region/BHS/storage/fakeContainer/bulkDeleteObjects",
+		"https://eu.api.ovh.com/v1/cloud/project/fakeProjectID/region/BHS/storage/fakeContainer/bulkDeleteObjects",
 		tdhttpmock.JSONBody(td.JSON(`
 			{
 				"objects": [
@@ -88,10 +88,10 @@ func (ms *MockSuite) TestCloudStorageS3BulkDeletePrefixCmd(assert, require *td.T
 }
 
 func (ms *MockSuite) TestCloudStorageS3BulkDeleteAllCmd(assert, require *td.T) {
-	httpmock.RegisterResponder(http.MethodGet, "https://eu.api.ovh.com/1.0/cloud/project/fakeProjectID/region",
+	httpmock.RegisterResponder(http.MethodGet, "https://eu.api.ovh.com/v1/cloud/project/fakeProjectID/region",
 		httpmock.NewStringResponder(200, `["BHS"]`))
 
-	httpmock.RegisterResponder(http.MethodGet, "https://eu.api.ovh.com/1.0/cloud/project/fakeProjectID/region/BHS",
+	httpmock.RegisterResponder(http.MethodGet, "https://eu.api.ovh.com/v1/cloud/project/fakeProjectID/region/BHS",
 		httpmock.NewStringResponder(200, `{
 			"name": "BHS",
 			"type": "region",
@@ -118,7 +118,7 @@ func (ms *MockSuite) TestCloudStorageS3BulkDeleteAllCmd(assert, require *td.T) {
 		}`))
 
 	httpmock.RegisterResponder(http.MethodGet,
-		"https://eu.api.ovh.com/1.0/cloud/project/fakeProjectID/region/BHS/storage/fakeContainer",
+		"https://eu.api.ovh.com/v1/cloud/project/fakeProjectID/region/BHS/storage/fakeContainer",
 		httpmock.NewStringResponder(200, `{
 			"name": "fakeContainer",
 			"virtualHost": "https://fakeContainer.test.ovh.net/",
@@ -135,7 +135,7 @@ func (ms *MockSuite) TestCloudStorageS3BulkDeleteAllCmd(assert, require *td.T) {
 		}`))
 
 	httpmock.RegisterResponder(http.MethodGet,
-		"https://eu.api.ovh.com/1.0/cloud/project/fakeProjectID/region/BHS/storage/fakeContainer/object",
+		"https://eu.api.ovh.com/v1/cloud/project/fakeProjectID/region/BHS/storage/fakeContainer/object",
 		httpmock.NewStringResponder(200, `[
 			{"key": "logs/log1.txt"},
 			{"key": "logs/log2.txt"},
@@ -144,7 +144,7 @@ func (ms *MockSuite) TestCloudStorageS3BulkDeleteAllCmd(assert, require *td.T) {
 	)
 
 	httpmock.RegisterMatcherResponder(http.MethodPost,
-		"https://eu.api.ovh.com/1.0/cloud/project/fakeProjectID/region/BHS/storage/fakeContainer/bulkDeleteObjects",
+		"https://eu.api.ovh.com/v1/cloud/project/fakeProjectID/region/BHS/storage/fakeContainer/bulkDeleteObjects",
 		tdhttpmock.JSONBody(td.JSON(`
 			{
 				"objects": [

--- a/internal/cmd/domainzone_test.go
+++ b/internal/cmd/domainzone_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func (ms *MockSuite) TestDomainZoneGetRecord(assert, require *td.T) {
-	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/1.0/domain/zone/example.com/record/1",
+	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/v1/domain/zone/example.com/record/1",
 		httpmock.NewStringResponder(200, `{
 				"fieldType": "A",
 				"id": 1,
@@ -38,7 +38,7 @@ func (ms *MockSuite) TestDomainZoneGetRecord(assert, require *td.T) {
 }
 
 func (ms *MockSuite) TestDomainZoneRefresh(assert, require *td.T) {
-	httpmock.RegisterResponder("POST", "https://eu.api.ovh.com/1.0/domain/zone/example.com/refresh",
+	httpmock.RegisterResponder("POST", "https://eu.api.ovh.com/v1/domain/zone/example.com/refresh",
 		httpmock.NewStringResponder(200, ``).Once())
 
 	out, err := cmd.Execute("domain-zone", "refresh", "example.com")
@@ -48,7 +48,7 @@ func (ms *MockSuite) TestDomainZoneRefresh(assert, require *td.T) {
 }
 
 func (ms *MockSuite) TestDomainZoneUpdateRecord(assert, require *td.T) {
-	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/1.0/domain/zone/example.com/record/1",
+	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/v1/domain/zone/example.com/record/1",
 		httpmock.NewStringResponder(200, `{
 				"fieldType": "A",
 				"id": 1,
@@ -58,7 +58,7 @@ func (ms *MockSuite) TestDomainZoneUpdateRecord(assert, require *td.T) {
 				"zone": "example.com"
 			}`).Once())
 
-	httpmock.RegisterMatcherResponder("PUT", "https://eu.api.ovh.com/1.0/domain/zone/example.com/record/1",
+	httpmock.RegisterMatcherResponder("PUT", "https://eu.api.ovh.com/v1/domain/zone/example.com/record/1",
 		tdhttpmock.JSONBody(td.JSON(`
 			{
 				"subDomain": "example-updated",

--- a/internal/cmd/iam_test.go
+++ b/internal/cmd/iam_test.go
@@ -14,11 +14,11 @@ import (
 )
 
 func (ms *MockSuite) TestIAMTokenListCmd(assert, require *td.T) {
-	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/1.0/me/identity/user/fakeUser/token",
+	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/v1/me/identity/user/fakeUser/token",
 		httpmock.NewStringResponder(200, `["token1","token2"]`),
 	)
 
-	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/1.0/me/identity/user/fakeUser/token/token1",
+	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/v1/me/identity/user/fakeUser/token/token1",
 		httpmock.NewStringResponder(200, `{
 			"name": "token1",
 			"description": "First token",
@@ -26,7 +26,7 @@ func (ms *MockSuite) TestIAMTokenListCmd(assert, require *td.T) {
 		}`),
 	)
 
-	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/1.0/me/identity/user/fakeUser/token/token2",
+	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/v1/me/identity/user/fakeUser/token/token2",
 		httpmock.NewStringResponder(200, `{
 			"name": "token2",
 			"description": "Second token",

--- a/internal/cmd/vps_test.go
+++ b/internal/cmd/vps_test.go
@@ -13,13 +13,13 @@ import (
 )
 
 func (ms *MockSuite) TestVpsListCmd(assert, require *td.T) {
-	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/1.0/vps",
+	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/v1/vps",
 		httpmock.NewStringResponder(200, `["vps-12345","vps-67890"]`).Once())
 
-	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/1.0/vps/vps-12345",
+	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/v1/vps/vps-12345",
 		httpmock.NewStringResponder(200, `{"name": "vps-12345", "displayName": "VPS 12345", "state": "running", "zone": "Region OpenStack: os-waw2"}`).Once())
 
-	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/1.0/vps/vps-67890",
+	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/v1/vps/vps-67890",
 		httpmock.NewStringResponder(200, `{"name": "vps-67890", "displayName": "VPS 67890", "state": "stopped", "zone": "Region OpenStack: os-gra1"}`).Once())
 
 	out, err := cmd.Execute("vps", "ls", "--json")
@@ -42,10 +42,10 @@ func (ms *MockSuite) TestVpsListCmd(assert, require *td.T) {
 }
 
 func (ms *MockSuite) TestVpsGetCmd(assert, require *td.T) {
-	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/1.0/vps/vps-67890",
+	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/v1/vps/vps-67890",
 		httpmock.NewStringResponder(200, `{"name": "vps-67890", "displayName": "VPS 67890", "state": "stopped", "zone": "Region OpenStack: os-gra1"}`).Once())
 
-	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/1.0/vps/vps-67890/datacenter",
+	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/v1/vps/vps-67890/datacenter",
 		httpmock.NewStringResponder(200, `{"country": "fr", "name": "os-gra1", "longName": "Region OpenStack: os-gra1"}`).Once())
 
 	out, err := cmd.Execute("vps", "get", "vps-67890", "--json")

--- a/internal/services/account/account.go
+++ b/internal/services/account/account.go
@@ -39,14 +39,14 @@ func GetMe(_ *cobra.Command, _ []string) {
 }
 
 func ListSSHKeys(_ *cobra.Command, _ []string) {
-	common.ManageListRequest("/me/sshKey", "", sshKeysColumnsToDisplay, flags.GenericFilters)
+	common.ManageListRequest("/v1/me/sshKey", "", sshKeysColumnsToDisplay, flags.GenericFilters)
 }
 
 func CreateOAuth2Client(cmd *cobra.Command, args []string) {
 	client, err := common.CreateResource(
 		cmd,
 		"/me/api/oauth2/client",
-		"/me/api/oauth2/client",
+		"/v1/me/api/oauth2/client",
 		Oauth2ClientCreateSample,
 		Oauth2ClientSpec,
 		assets.MeOpenapiSchema,
@@ -67,16 +67,16 @@ func CreateOAuth2Client(cmd *cobra.Command, args []string) {
 }
 
 func ListOAuth2Clients(_ *cobra.Command, _ []string) {
-	endpoint := "/me/api/oauth2/client"
+	endpoint := "/v1/me/api/oauth2/client"
 	common.ManageListRequest(endpoint, "", []string{"clientId", "name", "description", "flow", "createdAt"}, flags.GenericFilters)
 }
 
 func GetOauth2Client(cmd *cobra.Command, args []string) {
-	common.ManageObjectRequest("/me/api/oauth2/client", args[0], "")
+	common.ManageObjectRequest("/v1/me/api/oauth2/client", args[0], "")
 }
 
 func DeleteOauth2Client(_ *cobra.Command, args []string) {
-	endpoint := fmt.Sprintf("/me/api/oauth2/client/%s", url.PathEscape(args[0]))
+	endpoint := fmt.Sprintf("/v1/me/api/oauth2/client/%s", url.PathEscape(args[0]))
 
 	if err := httpLib.Client.Delete(endpoint, nil); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "failed to delete OAuth2 client: %s", err)
@@ -90,7 +90,7 @@ func EditOauth2Client(cmd *cobra.Command, args []string) {
 	if err := common.EditResource(
 		cmd,
 		"/me/api/oauth2/client/{clientId}",
-		fmt.Sprintf("/me/api/oauth2/client/%s", url.PathEscape(args[0])),
+		fmt.Sprintf("/v1/me/api/oauth2/client/%s", url.PathEscape(args[0])),
 		Oauth2ClientSpec,
 		assets.MeOpenapiSchema,
 	); err != nil {

--- a/internal/services/alldom/alldom.go
+++ b/internal/services/alldom/alldom.go
@@ -20,9 +20,9 @@ var (
 )
 
 func ListAllDom(_ *cobra.Command, _ []string) {
-	common.ManageListRequest("/allDom", "", alldomColumnsToDisplay, flags.GenericFilters)
+	common.ManageListRequest("/v1/allDom", "", alldomColumnsToDisplay, flags.GenericFilters)
 }
 
 func GetAllDom(_ *cobra.Command, args []string) {
-	common.ManageObjectRequest("/allDom", args[0], alldomTemplate)
+	common.ManageObjectRequest("/v1/allDom", args[0], alldomTemplate)
 }

--- a/internal/services/baremetal/baremetal.go
+++ b/internal/services/baremetal/baremetal.go
@@ -77,16 +77,16 @@ var (
 )
 
 func ListBaremetal(_ *cobra.Command, _ []string) {
-	common.ManageListRequest("/dedicated/server", "", baremetalColumnsToDisplay, flags.GenericFilters)
+	common.ManageListRequest("/v1/dedicated/server", "", baremetalColumnsToDisplay, flags.GenericFilters)
 }
 
 func ListBaremetalTasks(_ *cobra.Command, args []string) {
-	url := fmt.Sprintf("/dedicated/server/%s/task", args[0])
+	url := fmt.Sprintf("/v1/dedicated/server/%s/task", args[0])
 	common.ManageListRequest(url, "", []string{"taskId", "function", "status", "startDate", "doneDate"}, flags.GenericFilters)
 }
 
 func GetBaremetal(_ *cobra.Command, args []string) {
-	path := fmt.Sprintf("/dedicated/server/%s", url.PathEscape(args[0]))
+	path := fmt.Sprintf("/v1/dedicated/server/%s", url.PathEscape(args[0]))
 
 	// Fetch dedicated server
 	var object map[string]any
@@ -96,7 +96,7 @@ func GetBaremetal(_ *cobra.Command, args []string) {
 	}
 
 	// Fetch running tasks
-	path = fmt.Sprintf("/dedicated/server/%s/task", url.PathEscape(args[0]))
+	path = fmt.Sprintf("/v1/dedicated/server/%s/task", url.PathEscape(args[0]))
 	tasks, err := httpLib.FetchExpandedArray(path, "")
 	if err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "error fetching tasks for %s: %s", args[0], err)
@@ -105,7 +105,7 @@ func GetBaremetal(_ *cobra.Command, args []string) {
 	object["tasks"] = tasks
 
 	// Fetch network information
-	path = fmt.Sprintf("/dedicated/server/%s/specifications/network", url.PathEscape(args[0]))
+	path = fmt.Sprintf("/v1/dedicated/server/%s/specifications/network", url.PathEscape(args[0]))
 	var network map[string]any
 	if err := httpLib.Client.Get(path, &network); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "error fetching network specifications for %s: %s", args[0], err)
@@ -113,7 +113,7 @@ func GetBaremetal(_ *cobra.Command, args []string) {
 	}
 	object["network"] = network
 
-	path = fmt.Sprintf("/dedicated/server/%s/serviceInfos", url.PathEscape(args[0]))
+	path = fmt.Sprintf("/v1/dedicated/server/%s/serviceInfos", url.PathEscape(args[0]))
 	var serviceInfo map[string]any
 	if err := httpLib.Client.Get(path, &serviceInfo); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "error fetching billing information for %s: %s", args[0], err)
@@ -128,7 +128,7 @@ func EditBaremetal(cmd *cobra.Command, args []string) {
 	if err := common.EditResource(
 		cmd,
 		"/dedicated/server/{serviceName}",
-		fmt.Sprintf("/dedicated/server/%s", url.PathEscape(args[0])),
+		fmt.Sprintf("/v1/dedicated/server/%s", url.PathEscape(args[0])),
 		&EditBaremetalParams,
 		assets.BaremetalOpenapiSchema,
 	); err != nil {
@@ -138,7 +138,7 @@ func EditBaremetal(cmd *cobra.Command, args []string) {
 }
 
 func RebootBaremetal(_ *cobra.Command, args []string) {
-	url := fmt.Sprintf("/dedicated/server/%s/reboot", url.PathEscape(args[0]))
+	url := fmt.Sprintf("/v1/dedicated/server/%s/reboot", url.PathEscape(args[0]))
 
 	if err := httpLib.Client.Post(url, nil, nil); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "error rebooting server %s: %s", args[0], err)
@@ -149,7 +149,7 @@ func RebootBaremetal(_ *cobra.Command, args []string) {
 }
 
 func RebootRescueBaremetal(cmd *cobra.Command, args []string) {
-	endpoint := fmt.Sprintf("/dedicated/server/%s/boot?bootType=rescue", url.PathEscape(args[0]))
+	endpoint := fmt.Sprintf("/v1/dedicated/server/%s/boot?bootType=rescue", url.PathEscape(args[0]))
 
 	var boots []int
 	if err := httpLib.Client.Get(endpoint, &boots); err != nil {
@@ -163,7 +163,7 @@ func RebootRescueBaremetal(cmd *cobra.Command, args []string) {
 	}
 
 	// Update server with boot ID
-	endpoint = fmt.Sprintf("/dedicated/server/%s", url.PathEscape(args[0]))
+	endpoint = fmt.Sprintf("/v1/dedicated/server/%s", url.PathEscape(args[0]))
 	if err := httpLib.Client.Put(endpoint, map[string]any{
 		"bootId": boots[0],
 	}, nil); err != nil {
@@ -197,7 +197,7 @@ func RebootRescueBaremetal(cmd *cobra.Command, args []string) {
 }
 
 func waitForDedicatedServerTask(serviceName string, taskID any) error {
-	endpoint := fmt.Sprintf("/dedicated/server/%s/task/%s", url.PathEscape(serviceName), taskID)
+	endpoint := fmt.Sprintf("/v1/dedicated/server/%s/task/%s", url.PathEscape(serviceName), taskID)
 
 	for retry := 0; retry < 100; retry++ {
 		var task map[string]any
@@ -221,7 +221,7 @@ func waitForDedicatedServerTask(serviceName string, taskID any) error {
 }
 
 func BaremetalGetIPMIAccess(_ *cobra.Command, args []string) {
-	path := fmt.Sprintf("/dedicated/server/%s/features/ipmi/access", url.PathEscape(args[0]))
+	path := fmt.Sprintf("/v1/dedicated/server/%s/features/ipmi/access", url.PathEscape(args[0]))
 
 	parameters := map[string]any{
 		"type": BaremetalIpmiAccessType,
@@ -262,7 +262,7 @@ func BaremetalGetIPMIAccess(_ *cobra.Command, args []string) {
 }
 
 func ListBaremetalInterventions(_ *cobra.Command, args []string) {
-	path := fmt.Sprintf("/dedicated/server/%s/intervention", args[0])
+	path := fmt.Sprintf("/v1/dedicated/server/%s/intervention", args[0])
 
 	interventions, err := httpLib.FetchExpandedArray(path, "")
 	if err != nil {
@@ -274,7 +274,7 @@ func ListBaremetalInterventions(_ *cobra.Command, args []string) {
 		inter["status"] = "done"
 	}
 
-	path = fmt.Sprintf("/dedicated/server/%s/plannedIntervention", args[0])
+	path = fmt.Sprintf("/v1/dedicated/server/%s/plannedIntervention", args[0])
 	plannedInterventions, err := httpLib.FetchExpandedArray(path, "")
 	if err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "failed to fetch planned interventions: %s", err)
@@ -297,7 +297,7 @@ func ListBaremetalInterventions(_ *cobra.Command, args []string) {
 }
 
 func ListBaremetalBoots(_ *cobra.Command, args []string) {
-	path := fmt.Sprintf("/dedicated/server/%s/boot", url.PathEscape(args[0]))
+	path := fmt.Sprintf("/v1/dedicated/server/%s/boot", url.PathEscape(args[0]))
 
 	boots, err := httpLib.FetchExpandedArray(path, "")
 	if err != nil {
@@ -306,7 +306,7 @@ func ListBaremetalBoots(_ *cobra.Command, args []string) {
 	}
 
 	for _, boot := range boots {
-		path = fmt.Sprintf("/dedicated/server/%s/boot/%s/option", url.PathEscape(args[0]), boot["bootId"])
+		path = fmt.Sprintf("/v1/dedicated/server/%s/boot/%s/option", url.PathEscape(args[0]), boot["bootId"])
 
 		options, err := httpLib.FetchExpandedArray(path, "")
 		if err != nil {
@@ -333,7 +333,7 @@ func SetBaremetalBootId(_ *cobra.Command, args []string) {
 		return
 	}
 
-	url := fmt.Sprintf("/dedicated/server/%s", url.PathEscape(args[0]))
+	url := fmt.Sprintf("/v1/dedicated/server/%s", url.PathEscape(args[0]))
 	if err := httpLib.Client.Put(url, map[string]any{
 		"bootId": bootID,
 	}, nil); err != nil {
@@ -373,7 +373,7 @@ func SetBaremetalBootScript(_ *cobra.Command, args []string) {
 		}
 	}
 
-	url := fmt.Sprintf("/dedicated/server/%s", url.PathEscape(args[0]))
+	url := fmt.Sprintf("/v1/dedicated/server/%s", url.PathEscape(args[0]))
 	if err := httpLib.Client.Put(url, map[string]any{
 		"bootScript": string(script),
 	}, nil); err != nil {
@@ -385,12 +385,12 @@ func SetBaremetalBootScript(_ *cobra.Command, args []string) {
 }
 
 func ListBaremetalVNIs(_ *cobra.Command, args []string) {
-	url := fmt.Sprintf("/dedicated/server/%s/virtualNetworkInterface", args[0])
+	url := fmt.Sprintf("/v1/dedicated/server/%s/virtualNetworkInterface", args[0])
 	common.ManageListRequest(url, "", []string{"uuid", "name", "mode", "vrack", "enabled"}, flags.GenericFilters)
 }
 
 func CreateBaremetalOLAAggregation(_ *cobra.Command, args []string) {
-	url := fmt.Sprintf("/dedicated/server/%s/ola/aggregation", url.PathEscape(args[0]))
+	url := fmt.Sprintf("/v1/dedicated/server/%s/ola/aggregation", url.PathEscape(args[0]))
 	if err := httpLib.Client.Post(url, map[string]any{
 		"name":                     BaremetalOLAName,
 		"virtualNetworkInterfaces": BaremetalOLAInterfaces,
@@ -400,7 +400,7 @@ func CreateBaremetalOLAAggregation(_ *cobra.Command, args []string) {
 }
 
 func ResetBaremetalOLAAggregation(_ *cobra.Command, args []string) {
-	url := fmt.Sprintf("/dedicated/server/%s/ola/reset", url.PathEscape(args[0]))
+	url := fmt.Sprintf("/v1/dedicated/server/%s/ola/reset", url.PathEscape(args[0]))
 
 	for _, itf := range BaremetalOLAInterfaces {
 		if err := httpLib.Client.Post(url, map[string]string{
@@ -423,7 +423,7 @@ func ReinstallBaremetal(cmd *cobra.Command, args []string) {
 		return
 	}
 
-	endpoint := fmt.Sprintf("/dedicated/server/%s/reinstall", url.PathEscape(args[0]))
+	endpoint := fmt.Sprintf("/v1/dedicated/server/%s/reinstall", url.PathEscape(args[0]))
 	task, err := common.CreateResource(
 		cmd,
 		"/dedicated/server/{serviceName}/reinstall",
@@ -462,7 +462,7 @@ func ReinstallBaremetal(cmd *cobra.Command, args []string) {
 }
 
 func GetBaremetalRelatedIPs(_ *cobra.Command, args []string) {
-	path := fmt.Sprintf("/ip?routedTo.serviceName=%s", url.QueryEscape(args[0]))
+	path := fmt.Sprintf("/v1/ip?routedTo.serviceName=%s", url.QueryEscape(args[0]))
 
 	var ips []any
 	if err := httpLib.Client.Get(path, &ips); err != nil {
@@ -486,7 +486,7 @@ func GetBaremetalRelatedIPs(_ *cobra.Command, args []string) {
 }
 
 func GetBaremetalAuthenticationSecrets(_ *cobra.Command, args []string) {
-	path := fmt.Sprintf("/dedicated/server/%s/authenticationSecret", url.PathEscape(args[0]))
+	path := fmt.Sprintf("/v1/dedicated/server/%s/authenticationSecret", url.PathEscape(args[0]))
 
 	var allSecrets []map[string]any
 	if err := httpLib.Client.Post(path, nil, &allSecrets); err != nil {
@@ -497,7 +497,7 @@ func GetBaremetalAuthenticationSecrets(_ *cobra.Command, args []string) {
 	for _, secret := range allSecrets {
 		if secretID, ok := secret["password"]; ok {
 			var secretValue map[string]any
-			if err := httpLib.Client.Post("/secret/retrieve", map[string]any{
+			if err := httpLib.Client.Post("/v1/secret/retrieve", map[string]any{
 				"id": secretID,
 			}, &secretValue); err != nil {
 				display.OutputError(&flags.OutputFormatConfig, "failed to retrieve secret value: %s", err)
@@ -517,7 +517,7 @@ func GetBaremetalAuthenticationSecrets(_ *cobra.Command, args []string) {
 }
 
 func GetBaremetalCompatibleOses(_ *cobra.Command, args []string) {
-	path := fmt.Sprintf("/dedicated/server/%s/install/compatibleTemplates", url.PathEscape(args[0]))
+	path := fmt.Sprintf("/v1/dedicated/server/%s/install/compatibleTemplates", url.PathEscape(args[0]))
 
 	var oses map[string]any
 	if err := httpLib.Client.Get(path, &oses); err != nil {

--- a/internal/services/cdndedicated/cdndedicated.go
+++ b/internal/services/cdndedicated/cdndedicated.go
@@ -20,9 +20,9 @@ var (
 )
 
 func ListCdnDedicated(_ *cobra.Command, _ []string) {
-	common.ManageListRequest("/cdn/dedicated", "", cdndedicatedColumnsToDisplay, flags.GenericFilters)
+	common.ManageListRequest("/v1/cdn/dedicated", "", cdndedicatedColumnsToDisplay, flags.GenericFilters)
 }
 
 func GetCdnDedicated(_ *cobra.Command, args []string) {
-	common.ManageObjectRequest("/cdn/dedicated", args[0], cdndedicatedTemplate)
+	common.ManageObjectRequest("/v1/cdn/dedicated", args[0], cdndedicatedTemplate)
 }

--- a/internal/services/cloud/cloud_container_registry.go
+++ b/internal/services/cloud/cloud_container_registry.go
@@ -46,7 +46,7 @@ func ListContainerRegistries(_ *cobra.Command, _ []string) {
 	}
 
 	// Fetch registries
-	endpoint := fmt.Sprintf("/cloud/project/%s/containerRegistry", projectID)
+	endpoint := fmt.Sprintf("/v1/cloud/project/%s/containerRegistry", projectID)
 	body, err := httpLib.FetchArray(endpoint, "")
 	if err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "failed to fetch results: %s", err)
@@ -100,7 +100,7 @@ func GetContainerRegistry(_ *cobra.Command, args []string) {
 	}
 
 	// Fetch registry details
-	endpoint := fmt.Sprintf("/cloud/project/%s/containerRegistry/%s", projectID, url.PathEscape(args[0]))
+	endpoint := fmt.Sprintf("/v1/cloud/project/%s/containerRegistry/%s", projectID, url.PathEscape(args[0]))
 	var object map[string]any
 	if err := httpLib.Client.Get(endpoint, &object); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "error fetching %s: %s", endpoint, err)
@@ -146,7 +146,7 @@ func EditContainerRegistry(cmd *cobra.Command, args []string) {
 	if err := common.EditResource(
 		cmd,
 		"/cloud/project/{serviceName}/containerRegistry/{registryID}",
-		fmt.Sprintf("/cloud/project/%s/containerRegistry/%s", projectID, url.PathEscape(args[0])),
+		fmt.Sprintf("/v1/cloud/project/%s/containerRegistry/%s", projectID, url.PathEscape(args[0])),
 		map[string]any{"name": CloudContainerRegistryName},
 		assets.CloudOpenapiSchema,
 	); err != nil {
@@ -165,7 +165,7 @@ func CreateContainerRegistry(cmd *cobra.Command, args []string) {
 	registry, err := common.CreateResource(
 		cmd,
 		"/cloud/project/{serviceName}/containerRegistry",
-		fmt.Sprintf("/cloud/project/%s/containerRegistry", projectID),
+		fmt.Sprintf("/v1/cloud/project/%s/containerRegistry", projectID),
 		CloudContainerRegistryCreateSample,
 		CloudContainerRegistrySpec,
 		assets.CloudOpenapiSchema,
@@ -186,7 +186,7 @@ func DeleteContainerRegistry(_ *cobra.Command, args []string) {
 		return
 	}
 
-	endpoint := fmt.Sprintf("/cloud/project/%s/containerRegistry/%s", projectID, url.PathEscape(args[0]))
+	endpoint := fmt.Sprintf("/v1/cloud/project/%s/containerRegistry/%s", projectID, url.PathEscape(args[0]))
 	if err := httpLib.Client.Delete(endpoint, nil); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "failed to delete container registry: %s", err)
 		return

--- a/internal/services/cloud/cloud_database.go
+++ b/internal/services/cloud/cloud_database.go
@@ -87,7 +87,7 @@ func ListCloudDatabases(_ *cobra.Command, _ []string) {
 		return
 	}
 
-	common.ManageListRequest(fmt.Sprintf("/cloud/project/%s/database/service", projectID), "", cloudprojectDatabaseColumnsToDisplay, flags.GenericFilters)
+	common.ManageListRequest(fmt.Sprintf("/v1/cloud/project/%s/database/service", projectID), "", cloudprojectDatabaseColumnsToDisplay, flags.GenericFilters)
 }
 
 func GetCloudDatabase(_ *cobra.Command, args []string) {
@@ -97,7 +97,7 @@ func GetCloudDatabase(_ *cobra.Command, args []string) {
 		return
 	}
 
-	common.ManageObjectRequest(fmt.Sprintf("/cloud/project/%s/database/service", projectID), args[0], cloudDatabaseTemplate)
+	common.ManageObjectRequest(fmt.Sprintf("/v1/cloud/project/%s/database/service", projectID), args[0], cloudDatabaseTemplate)
 }
 
 func CreateDatabase(cmd *cobra.Command, args []string) {
@@ -125,7 +125,7 @@ func CreateDatabase(cmd *cobra.Command, args []string) {
 		})
 	}
 
-	endpoint := fmt.Sprintf("/cloud/project/%s/database/%s", projectID, url.PathEscape(DatabaseSpec.Engine))
+	endpoint := fmt.Sprintf("/v1/cloud/project/%s/database/%s", projectID, url.PathEscape(DatabaseSpec.Engine))
 	database, err := common.CreateResource(
 		cmd,
 		"/cloud/project/{serviceName}/database/"+url.PathEscape(DatabaseSpec.Engine),
@@ -151,13 +151,13 @@ func DeleteDatabase(cmd *cobra.Command, args []string) {
 
 	// Fetch database service to retrieve the engine
 	var databaseService map[string]any
-	if err := httpLib.Client.Get(fmt.Sprintf("/cloud/project/%s/database/service/%s", projectID, url.PathEscape(args[0])), &databaseService); err != nil {
+	if err := httpLib.Client.Get(fmt.Sprintf("/v1/cloud/project/%s/database/service/%s", projectID, url.PathEscape(args[0])), &databaseService); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "failed to fetch database service: %s", err)
 		return
 	}
 
 	// Delete the database
-	endpoint := fmt.Sprintf("/cloud/project/%s/database/%s/%s", projectID, url.PathEscape(databaseService["engine"].(string)), url.PathEscape(args[0]))
+	endpoint := fmt.Sprintf("/v1/cloud/project/%s/database/%s/%s", projectID, url.PathEscape(databaseService["engine"].(string)), url.PathEscape(args[0]))
 	if err := httpLib.Client.Delete(endpoint, nil); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "failed to delete database: %s", err)
 		return
@@ -175,7 +175,7 @@ func EditDatabase(cmd *cobra.Command, args []string) {
 
 	// Fetch database service to retrieve the engine
 	var databaseService map[string]any
-	if err := httpLib.Client.Get(fmt.Sprintf("/cloud/project/%s/database/service/%s", projectID, url.PathEscape(args[0])), &databaseService); err != nil {
+	if err := httpLib.Client.Get(fmt.Sprintf("/v1/cloud/project/%s/database/service/%s", projectID, url.PathEscape(args[0])), &databaseService); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "failed to fetch database service: %s", err)
 		return
 	}
@@ -189,7 +189,7 @@ func EditDatabase(cmd *cobra.Command, args []string) {
 	if err := common.EditResource(
 		cmd,
 		"/cloud/project/{serviceName}/database/"+url.PathEscape(databaseService["engine"].(string))+"/{clusterId}",
-		fmt.Sprintf("/cloud/project/%s/database/%s/%s", projectID, url.PathEscape(databaseService["engine"].(string)), url.PathEscape(args[0])),
+		fmt.Sprintf("/v1/cloud/project/%s/database/%s/%s", projectID, url.PathEscape(databaseService["engine"].(string)), url.PathEscape(args[0])),
 		DatabaseSpec,
 		assets.CloudOpenapiSchema,
 	); err != nil {
@@ -208,13 +208,13 @@ func CreateDatabaseInDatabase(_ *cobra.Command, args []string) {
 	// Fetch database service to retrieve the engine
 	var databaseService map[string]any
 	if err := httpLib.Client.Get(
-		fmt.Sprintf("/cloud/project/%s/database/service/%s", projectID, url.PathEscape(args[0])), &databaseService); err != nil {
+		fmt.Sprintf("/v1/cloud/project/%s/database/service/%s", projectID, url.PathEscape(args[0])), &databaseService); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "failed to fetch database service: %s", err)
 		return
 	}
 
 	endpoint := fmt.Sprintf(
-		"/cloud/project/%s/database/%s/%s/database",
+		"/v1/cloud/project/%s/database/%s/%s/database",
 		projectID,
 		url.PathEscape(databaseService["engine"].(string)),
 		url.PathEscape(args[0]),
@@ -239,14 +239,14 @@ func DeleteDatabaseInDatabase(_ *cobra.Command, args []string) {
 	// Fetch database service to retrieve the engine
 	var databaseService map[string]any
 	if err := httpLib.Client.Get(
-		fmt.Sprintf("/cloud/project/%s/database/service/%s", projectID, url.PathEscape(args[0])), &databaseService); err != nil {
+		fmt.Sprintf("/v1/cloud/project/%s/database/service/%s", projectID, url.PathEscape(args[0])), &databaseService); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "failed to fetch database service: %s", err)
 		return
 	}
 
 	// Delete the database in the given database cluster
 	endpoint := fmt.Sprintf(
-		"/cloud/project/%s/database/%s/%s/database/%s",
+		"/v1/cloud/project/%s/database/%s/%s/database/%s",
 		projectID,
 		url.PathEscape(databaseService["engine"].(string)),
 		url.PathEscape(args[0]),
@@ -270,13 +270,13 @@ func ListDatabasesInDatabase(_ *cobra.Command, args []string) {
 	// Fetch database service to retrieve the engine
 	var databaseService map[string]any
 	if err := httpLib.Client.Get(
-		fmt.Sprintf("/cloud/project/%s/database/service/%s", projectID, url.PathEscape(args[0])), &databaseService); err != nil {
+		fmt.Sprintf("/v1/cloud/project/%s/database/service/%s", projectID, url.PathEscape(args[0])), &databaseService); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "failed to fetch database service: %s", err)
 		return
 	}
 
 	common.ManageListRequest(
-		fmt.Sprintf("/cloud/project/%s/database/%s/%s/database", projectID, url.PathEscape(databaseService["engine"].(string)), url.PathEscape(args[0])),
+		fmt.Sprintf("/v1/cloud/project/%s/database/%s/%s/database", projectID, url.PathEscape(databaseService["engine"].(string)), url.PathEscape(args[0])),
 		"",
 		[]string{"id", "name", "default"},
 		flags.GenericFilters,
@@ -293,13 +293,13 @@ func GetDatabaseInDatabase(_ *cobra.Command, args []string) {
 	// Fetch database service to retrieve the engine
 	var databaseService map[string]any
 	if err := httpLib.Client.Get(
-		fmt.Sprintf("/cloud/project/%s/database/service/%s", projectID, url.PathEscape(args[0])), &databaseService); err != nil {
+		fmt.Sprintf("/v1/cloud/project/%s/database/service/%s", projectID, url.PathEscape(args[0])), &databaseService); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "failed to fetch database service: %s", err)
 		return
 	}
 
 	common.ManageObjectRequest(
-		fmt.Sprintf("/cloud/project/%s/database/%s/%s/database", projectID, url.PathEscape(databaseService["engine"].(string)), url.PathEscape(args[0])),
+		fmt.Sprintf("/v1/cloud/project/%s/database/%s/%s/database", projectID, url.PathEscape(databaseService["engine"].(string)), url.PathEscape(args[0])),
 		args[1],
 		"",
 	)

--- a/internal/services/cloud/cloud_instance.go
+++ b/internal/services/cloud/cloud_instance.go
@@ -129,7 +129,7 @@ func ListInstances(_ *cobra.Command, _ []string) {
 		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
-	common.ManageListRequest(fmt.Sprintf("/cloud/project/%s/instance", projectID), "id", cloudprojectInstanceColumnsToDisplay, flags.GenericFilters)
+	common.ManageListRequest(fmt.Sprintf("/v1/cloud/project/%s/instance", projectID), "id", cloudprojectInstanceColumnsToDisplay, flags.GenericFilters)
 }
 
 func GetInstance(_ *cobra.Command, args []string) {
@@ -138,7 +138,7 @@ func GetInstance(_ *cobra.Command, args []string) {
 		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
-	common.ManageObjectRequest(fmt.Sprintf("/cloud/project/%s/instance", projectID), args[0], cloudInstanceTemplate)
+	common.ManageObjectRequest(fmt.Sprintf("/v1/cloud/project/%s/instance", projectID), args[0], cloudInstanceTemplate)
 }
 
 func SetInstanceName(_ *cobra.Command, args []string) {
@@ -148,7 +148,7 @@ func SetInstanceName(_ *cobra.Command, args []string) {
 		return
 	}
 
-	endpoint := fmt.Sprintf("/cloud/project/%s/instance/%s", projectID, url.PathEscape(args[0]))
+	endpoint := fmt.Sprintf("/v1/cloud/project/%s/instance/%s", projectID, url.PathEscape(args[0]))
 	body := map[string]any{
 		"instanceName": args[1],
 	}
@@ -167,7 +167,7 @@ func StartInstance(_ *cobra.Command, args []string) {
 		return
 	}
 
-	endpoint := fmt.Sprintf("/cloud/project/%s/instance/%s/start", projectID, url.PathEscape(args[0]))
+	endpoint := fmt.Sprintf("/v1/cloud/project/%s/instance/%s/start", projectID, url.PathEscape(args[0]))
 
 	if err := httpLib.Client.Post(endpoint, nil, nil); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "error starting instance %q: %s", args[0], err)
@@ -184,7 +184,7 @@ func StopInstance(_ *cobra.Command, args []string) {
 		return
 	}
 
-	endpoint := fmt.Sprintf("/cloud/project/%s/instance/%s/stop", projectID, url.PathEscape(args[0]))
+	endpoint := fmt.Sprintf("/v1/cloud/project/%s/instance/%s/stop", projectID, url.PathEscape(args[0]))
 
 	if err := httpLib.Client.Post(endpoint, nil, nil); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "error stopping instance %q: %s", args[0], err)
@@ -201,7 +201,7 @@ func ShelveInstance(_ *cobra.Command, args []string) {
 		return
 	}
 
-	endpoint := fmt.Sprintf("/cloud/project/%s/instance/%s/shelve", projectID, url.PathEscape(args[0]))
+	endpoint := fmt.Sprintf("/v1/cloud/project/%s/instance/%s/shelve", projectID, url.PathEscape(args[0]))
 
 	if err := httpLib.Client.Post(endpoint, nil, nil); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "error shelving instance %q: %s", args[0], err)
@@ -218,7 +218,7 @@ func UnshelveInstance(_ *cobra.Command, args []string) {
 		return
 	}
 
-	endpoint := fmt.Sprintf("/cloud/project/%s/instance/%s/unshelve", projectID, url.PathEscape(args[0]))
+	endpoint := fmt.Sprintf("/v1/cloud/project/%s/instance/%s/unshelve", projectID, url.PathEscape(args[0]))
 
 	if err := httpLib.Client.Post(endpoint, nil, nil); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "error unshelving instance %q: %s", args[0], err)
@@ -235,7 +235,7 @@ func ResumeInstance(_ *cobra.Command, args []string) {
 		return
 	}
 
-	endpoint := fmt.Sprintf("/cloud/project/%s/instance/%s/resume", projectID, url.PathEscape(args[0]))
+	endpoint := fmt.Sprintf("/v1/cloud/project/%s/instance/%s/resume", projectID, url.PathEscape(args[0]))
 
 	if err := httpLib.Client.Post(endpoint, nil, nil); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "error resuming instance %q: %s", args[0], err)
@@ -257,7 +257,7 @@ func RebootInstance(_ *cobra.Command, args []string) {
 		return
 	}
 
-	endpoint := fmt.Sprintf("/cloud/project/%s/instance/%s/reboot", projectID, url.PathEscape(args[0]))
+	endpoint := fmt.Sprintf("/v1/cloud/project/%s/instance/%s/reboot", projectID, url.PathEscape(args[0]))
 	body := map[string]any{
 		"type": InstanceRebootType,
 	}
@@ -298,7 +298,7 @@ func CreateInstance(cmd *cobra.Command, args []string) {
 		}
 	}
 
-	endpoint := fmt.Sprintf("/cloud/project/%s/region/%s/instance", projectID, region)
+	endpoint := fmt.Sprintf("/v1/cloud/project/%s/region/%s/instance", projectID, region)
 	operation, err := common.CreateResource(
 		cmd,
 		"/cloud/project/{serviceName}/region/{regionName}/instance",
@@ -336,7 +336,7 @@ func DeleteInstance(_ *cobra.Command, args []string) {
 		return
 	}
 
-	endpoint := fmt.Sprintf("/cloud/project/%s/instance/%s", projectID, url.PathEscape(args[0]))
+	endpoint := fmt.Sprintf("/v1/cloud/project/%s/instance/%s", projectID, url.PathEscape(args[0]))
 
 	if err := httpLib.Client.Delete(endpoint, nil); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "error deleting instance %q: %s", args[0], err)
@@ -446,7 +446,7 @@ func ReinstallInstance(cmd *cobra.Command, args []string) {
 		log.Print("Flag --image-selector used, all other flags will be ignored")
 
 		// Fetch instance details to get its region
-		endpoint := fmt.Sprintf("/cloud/project/%s/instance/%s", projectID, url.PathEscape(args[0]))
+		endpoint := fmt.Sprintf("/v1/cloud/project/%s/instance/%s", projectID, url.PathEscape(args[0]))
 		var instance map[string]any
 		if err := httpLib.Client.Get(endpoint, &instance); err != nil {
 			display.OutputError(&flags.OutputFormatConfig, "failed to fetch instance details: %s", err)
@@ -542,7 +542,7 @@ func ReinstallInstance(cmd *cobra.Command, args []string) {
 	log.Println("Installation parameters: \n" + string(out))
 
 	var task map[string]any
-	endpoint := fmt.Sprintf("/cloud/project/%s/instance/%s/reinstall", projectID, url.PathEscape(args[0]))
+	endpoint := fmt.Sprintf("/v1/cloud/project/%s/instance/%s/reinstall", projectID, url.PathEscape(args[0]))
 	if err := httpLib.Client.Post(endpoint, parameters, &task); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "error reinstalling instance %q: %s", args[0], err)
 		return
@@ -564,7 +564,7 @@ func ReinstallInstance(cmd *cobra.Command, args []string) {
 }
 
 func waitForInstanceStatus(cloudProject, instanceID, targetStatus string) error {
-	endpoint := fmt.Sprintf("/cloud/project/%s/instance/%s", cloudProject, url.PathEscape(instanceID))
+	endpoint := fmt.Sprintf("/v1/cloud/project/%s/instance/%s", cloudProject, url.PathEscape(instanceID))
 
 	for range 100 {
 		var instance map[string]any
@@ -594,7 +594,7 @@ func ActivateMonthlyBilling(_ *cobra.Command, args []string) {
 		return
 	}
 
-	endpoint := fmt.Sprintf("/cloud/project/%s/instance/%s/activeMonthlyBilling", projectID, url.PathEscape(args[0]))
+	endpoint := fmt.Sprintf("/v1/cloud/project/%s/instance/%s/activeMonthlyBilling", projectID, url.PathEscape(args[0]))
 
 	if err := httpLib.Client.Post(endpoint, nil, nil); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "error activating monthly billing for instance %q: %s", args[0], err)
@@ -611,7 +611,7 @@ func ListInstanceInterfaces(_ *cobra.Command, args []string) {
 		return
 	}
 
-	endpoint := fmt.Sprintf("/cloud/project/%s/instance/%s/interface", projectID, url.PathEscape(args[0]))
+	endpoint := fmt.Sprintf("/v1/cloud/project/%s/instance/%s/interface", projectID, url.PathEscape(args[0]))
 
 	common.ManageListRequestNoExpand(endpoint, []string{"id", "type", "macAddress", "networkId", "state"}, flags.GenericFilters)
 }
@@ -623,7 +623,7 @@ func GetInstanceInterface(_ *cobra.Command, args []string) {
 		return
 	}
 
-	endpoint := fmt.Sprintf("/cloud/project/%s/instance/%s/interface", projectID, url.PathEscape(args[0]))
+	endpoint := fmt.Sprintf("/v1/cloud/project/%s/instance/%s/interface", projectID, url.PathEscape(args[0]))
 
 	common.ManageObjectRequest(endpoint, args[1], cloudInstanceInterfaceTemplate)
 }
@@ -635,7 +635,7 @@ func CreateInstanceInterface(_ *cobra.Command, args []string) {
 		return
 	}
 
-	endpoint := fmt.Sprintf("/cloud/project/%s/instance/%s/interface", projectID, url.PathEscape(args[0]))
+	endpoint := fmt.Sprintf("/v1/cloud/project/%s/instance/%s/interface", projectID, url.PathEscape(args[0]))
 	body := map[string]any{
 		"networkId": args[1],
 	}
@@ -660,7 +660,7 @@ func DeleteInstanceInterface(_ *cobra.Command, args []string) {
 		return
 	}
 
-	endpoint := fmt.Sprintf("/cloud/project/%s/instance/%s/interface/%s", projectID, url.PathEscape(args[0]), url.PathEscape(args[1]))
+	endpoint := fmt.Sprintf("/v1/cloud/project/%s/instance/%s/interface/%s", projectID, url.PathEscape(args[0]), url.PathEscape(args[1]))
 
 	if err := httpLib.Client.Delete(endpoint, nil); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "error deleting interface %s for instance %q: %s", args[1], args[0], err)
@@ -677,7 +677,7 @@ func EnableInstanceInRescueMode(_ *cobra.Command, args []string) {
 		return
 	}
 
-	endpoint := fmt.Sprintf("/cloud/project/%s/instance/%s/rescueMode", projectID, url.PathEscape(args[0]))
+	endpoint := fmt.Sprintf("/v1/cloud/project/%s/instance/%s/rescueMode", projectID, url.PathEscape(args[0]))
 	body := map[string]any{
 		"rescue": true,
 	}
@@ -713,7 +713,7 @@ func DisableInstanceRescueMode(_ *cobra.Command, args []string) {
 		return
 	}
 
-	endpoint := fmt.Sprintf("/cloud/project/%s/instance/%s/rescueMode", projectID, url.PathEscape(args[0]))
+	endpoint := fmt.Sprintf("/v1/cloud/project/%s/instance/%s/rescueMode", projectID, url.PathEscape(args[0]))
 	body := map[string]any{
 		"rescue": false,
 	}
@@ -751,7 +751,7 @@ func SetInstanceFlavor(_ *cobra.Command, args []string) {
 		log.Print("Flag --flavor-selector used, all other flags will be ignored")
 
 		// Fetch instance details to get its region
-		endpoint := fmt.Sprintf("/cloud/project/%s/instance/%s", projectID, url.PathEscape(args[0]))
+		endpoint := fmt.Sprintf("/v1/cloud/project/%s/instance/%s", projectID, url.PathEscape(args[0]))
 		var instance map[string]any
 		if err := httpLib.Client.Get(endpoint, &instance); err != nil {
 			display.OutputError(&flags.OutputFormatConfig, "failed to fetch instance details: %s", err)
@@ -781,7 +781,7 @@ func SetInstanceFlavor(_ *cobra.Command, args []string) {
 
 	log.Printf("Selected flavor %s", flavor)
 
-	endpoint := fmt.Sprintf("/cloud/project/%s/instance/%s/resize", projectID, url.PathEscape(args[0]))
+	endpoint := fmt.Sprintf("/v1/cloud/project/%s/instance/%s/resize", projectID, url.PathEscape(args[0]))
 	body := map[string]any{
 		"flavorId": flavor,
 	}
@@ -814,7 +814,7 @@ func CreateInstanceSnapshot(_ *cobra.Command, args []string) {
 	}
 
 	// Fetch instance details to get its region
-	endpoint := fmt.Sprintf("/cloud/project/%s/instance/%s", projectID, url.PathEscape(args[0]))
+	endpoint := fmt.Sprintf("/v1/cloud/project/%s/instance/%s", projectID, url.PathEscape(args[0]))
 	var instance map[string]any
 	if err := httpLib.Client.Get(endpoint, &instance); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "failed to fetch instance details: %s", err)
@@ -824,7 +824,7 @@ func CreateInstanceSnapshot(_ *cobra.Command, args []string) {
 
 	InstanceSnapshotSpec.SnapshotName = args[1]
 
-	endpoint = fmt.Sprintf("/cloud/project/%s/region/%s/instance/%s/snapshot", projectID, url.PathEscape(region), url.PathEscape(args[0]))
+	endpoint = fmt.Sprintf("/v1/cloud/project/%s/region/%s/instance/%s/snapshot", projectID, url.PathEscape(region), url.PathEscape(args[0]))
 	var response map[string]any
 	if err := httpLib.Client.Post(endpoint, InstanceSnapshotSpec, &response); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "error creating snapshot for instance %q: %s", args[0], err)
@@ -842,7 +842,7 @@ func AbortInstanceSnapshot(_ *cobra.Command, args []string) {
 	}
 
 	// Fetch instance details to get its region
-	endpoint := fmt.Sprintf("/cloud/project/%s/instance/%s", projectID, url.PathEscape(args[0]))
+	endpoint := fmt.Sprintf("/v1/cloud/project/%s/instance/%s", projectID, url.PathEscape(args[0]))
 	var instance map[string]any
 	if err := httpLib.Client.Get(endpoint, &instance); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "failed to fetch instance details: %s", err)
@@ -851,7 +851,7 @@ func AbortInstanceSnapshot(_ *cobra.Command, args []string) {
 	region := instance["region"].(string)
 
 	// Abort the snapshot
-	endpoint = fmt.Sprintf("/cloud/project/%s/region/%s/instance/%s/abortSnapshot", projectID, url.PathEscape(region), url.PathEscape(args[0]))
+	endpoint = fmt.Sprintf("/v1/cloud/project/%s/region/%s/instance/%s/abortSnapshot", projectID, url.PathEscape(region), url.PathEscape(args[0]))
 	if err := httpLib.Client.Post(endpoint, nil, nil); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "error aborting snapshot for instance %q: %s", args[0], err)
 		return
@@ -867,7 +867,7 @@ func ListInstanceSnapshots(_ *cobra.Command, _ []string) {
 		return
 	}
 
-	common.ManageListRequestNoExpand(fmt.Sprintf("/cloud/project/%s/snapshot", projectID), []string{"id", "name", "type", "status", "region"}, flags.GenericFilters)
+	common.ManageListRequestNoExpand(fmt.Sprintf("/v1/cloud/project/%s/snapshot", projectID), []string{"id", "name", "type", "status", "region"}, flags.GenericFilters)
 }
 
 func GetInstanceSnapshot(_ *cobra.Command, args []string) {
@@ -877,7 +877,7 @@ func GetInstanceSnapshot(_ *cobra.Command, args []string) {
 		return
 	}
 
-	common.ManageObjectRequest(fmt.Sprintf("/cloud/project/%s/snapshot", projectID), args[0], "")
+	common.ManageObjectRequest(fmt.Sprintf("/v1/cloud/project/%s/snapshot", projectID), args[0], "")
 }
 
 func DeleteInstanceSnapshot(_ *cobra.Command, args []string) {
@@ -887,7 +887,7 @@ func DeleteInstanceSnapshot(_ *cobra.Command, args []string) {
 		return
 	}
 
-	endpoint := fmt.Sprintf("/cloud/project/%s/snapshot/%s", projectID, url.PathEscape(args[0]))
+	endpoint := fmt.Sprintf("/v1/cloud/project/%s/snapshot/%s", projectID, url.PathEscape(args[0]))
 
 	if err := httpLib.Client.Delete(endpoint, nil); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "error deleting snapshot %q: %s", args[0], err)

--- a/internal/services/cloud/cloud_kube.go
+++ b/internal/services/cloud/cloud_kube.go
@@ -166,7 +166,7 @@ func ListKubes(_ *cobra.Command, _ []string) {
 		return
 	}
 
-	common.ManageListRequest(fmt.Sprintf("/cloud/project/%s/kube", projectID), "", cloudprojectKubeColumnsToDisplay, flags.GenericFilters)
+	common.ManageListRequest(fmt.Sprintf("/v1/cloud/project/%s/kube", projectID), "", cloudprojectKubeColumnsToDisplay, flags.GenericFilters)
 }
 
 func GetKube(_ *cobra.Command, args []string) {
@@ -176,7 +176,7 @@ func GetKube(_ *cobra.Command, args []string) {
 		return
 	}
 
-	endpoint := fmt.Sprintf("/cloud/project/%s/kube/%s", projectID, url.PathEscape(args[0]))
+	endpoint := fmt.Sprintf("/v1/cloud/project/%s/kube/%s", projectID, url.PathEscape(args[0]))
 
 	var object map[string]any
 	if err := httpLib.Client.Get(endpoint, &object); err != nil {
@@ -212,7 +212,7 @@ func CreateKube(cmd *cobra.Command, args []string) {
 		return
 	}
 
-	endpoint := fmt.Sprintf("/cloud/project/%s/kube", projectID)
+	endpoint := fmt.Sprintf("/v1/cloud/project/%s/kube", projectID)
 	cluster, err := common.CreateResource(
 		cmd,
 		"/cloud/project/{serviceName}/kube",
@@ -239,11 +239,8 @@ func EditKube(cmd *cobra.Command, args []string) {
 	if err := common.EditResource(
 		cmd,
 		"/cloud/project/{serviceName}/kube/{kubeId}",
-		fmt.Sprintf("/cloud/project/%s/kube/%s", projectID, url.PathEscape(args[0])),
-		map[string]any{
-			"name":         KubeSpec.Name,
-			"updatePolicy": KubeSpec.UpdatePolicy,
-		},
+		fmt.Sprintf("/v1/cloud/project/%s/kube/%s", projectID, url.PathEscape(args[0])),
+		KubeSpec,
 		assets.CloudOpenapiSchema,
 	); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "%s", err)
@@ -258,7 +255,7 @@ func DeleteKube(_ *cobra.Command, args []string) {
 		return
 	}
 
-	endpoint := fmt.Sprintf("/cloud/project/%s/kube/%s", projectID, url.PathEscape(args[0]))
+	endpoint := fmt.Sprintf("/v1/cloud/project/%s/kube/%s", projectID, url.PathEscape(args[0]))
 	if err := httpLib.Client.Delete(endpoint, nil); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "failed to delete MKS cluster: %s", err)
 		return
@@ -274,7 +271,7 @@ func GetKubeCustomization(cmd *cobra.Command, args []string) {
 		return
 	}
 
-	endpoint := fmt.Sprintf("/cloud/project/%s/kube/%s/customization", projectID, url.PathEscape(args[0]))
+	endpoint := fmt.Sprintf("/v1/cloud/project/%s/kube/%s/customization", projectID, url.PathEscape(args[0]))
 	var customization map[string]any
 	if err := httpLib.Client.Get(endpoint, &customization); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "failed to fetch MKS cluster customization: %s", err)
@@ -294,7 +291,7 @@ func EditKubeCustomization(cmd *cobra.Command, args []string) {
 	if err := common.EditResource(
 		cmd,
 		"/cloud/project/{serviceName}/kube/{kubeId}/customization",
-		fmt.Sprintf("/cloud/project/%s/kube/%s/customization", projectID, url.PathEscape(args[0])),
+		fmt.Sprintf("/v1/cloud/project/%s/kube/%s/customization", projectID, url.PathEscape(args[0])),
 		KubeSpec.Customization,
 		assets.CloudOpenapiSchema,
 	); err != nil {
@@ -310,7 +307,7 @@ func ListKubeIPRestrictions(_ *cobra.Command, args []string) {
 		return
 	}
 
-	endpoint := fmt.Sprintf("/cloud/project/%s/kube/%s/ipRestrictions", projectID, url.PathEscape(args[0]))
+	endpoint := fmt.Sprintf("/v1/cloud/project/%s/kube/%s/ipRestrictions", projectID, url.PathEscape(args[0]))
 
 	body, err := httpLib.FetchArray(endpoint, "")
 	if err != nil {
@@ -340,7 +337,7 @@ func EditKubeIPRestrictions(cmd *cobra.Command, args []string) {
 		return
 	}
 
-	endpoint := fmt.Sprintf("/cloud/project/%s/kube/%s/ipRestrictions", projectID, url.PathEscape(args[0]))
+	endpoint := fmt.Sprintf("/v1/cloud/project/%s/kube/%s/ipRestrictions", projectID, url.PathEscape(args[0]))
 
 	if flags.ParametersViaEditor {
 		// Fetch resource
@@ -394,7 +391,7 @@ func GenerateKubeConfig(cmd *cobra.Command, args []string) {
 		return
 	}
 
-	endpoint := fmt.Sprintf("/cloud/project/%s/kube/%s/kubeconfig", projectID, url.PathEscape(args[0]))
+	endpoint := fmt.Sprintf("/v1/cloud/project/%s/kube/%s/kubeconfig", projectID, url.PathEscape(args[0]))
 
 	var kubeConfig map[string]any
 	if err := httpLib.Client.Post(endpoint, nil, &kubeConfig); err != nil {
@@ -412,7 +409,7 @@ func ResetKubeConfig(cmd *cobra.Command, args []string) {
 		return
 	}
 
-	endpoint := fmt.Sprintf("/cloud/project/%s/kube/%s/kubeconfig/reset", projectID, url.PathEscape(args[0]))
+	endpoint := fmt.Sprintf("/v1/cloud/project/%s/kube/%s/kubeconfig/reset", projectID, url.PathEscape(args[0]))
 
 	if err := httpLib.Client.Post(endpoint, nil, nil); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "failed to reset kube config: %s", err)
@@ -429,7 +426,7 @@ func ListKubeNodes(_ *cobra.Command, args []string) {
 		return
 	}
 
-	endpoint := fmt.Sprintf("/cloud/project/%s/kube/%s/node", projectID, url.PathEscape(args[0]))
+	endpoint := fmt.Sprintf("/v1/cloud/project/%s/kube/%s/node", projectID, url.PathEscape(args[0]))
 
 	common.ManageListRequestNoExpand(endpoint, []string{"id", "name", "flavor", "version", "status"}, flags.GenericFilters)
 }
@@ -441,7 +438,7 @@ func GetKubeNode(_ *cobra.Command, args []string) {
 		return
 	}
 
-	endpoint := fmt.Sprintf("/cloud/project/%s/kube/%s/node", projectID, url.PathEscape(args[0]))
+	endpoint := fmt.Sprintf("/v1/cloud/project/%s/kube/%s/node", projectID, url.PathEscape(args[0]))
 
 	common.ManageObjectRequest(endpoint, args[1], cloudKubeNodeTemplate)
 }
@@ -453,7 +450,7 @@ func DeleteKubeNode(_ *cobra.Command, args []string) {
 		return
 	}
 
-	endpoint := fmt.Sprintf("/cloud/project/%s/kube/%s/node/%s", projectID, url.PathEscape(args[0]), url.PathEscape(args[1]))
+	endpoint := fmt.Sprintf("/v1/cloud/project/%s/kube/%s/node/%s", projectID, url.PathEscape(args[0]), url.PathEscape(args[1]))
 	if err := httpLib.Client.Delete(endpoint, nil); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "failed to delete MKS node: %s", err)
 		return
@@ -469,7 +466,7 @@ func ListKubeNodepools(_ *cobra.Command, args []string) {
 		return
 	}
 
-	endpoint := fmt.Sprintf("/cloud/project/%s/kube/%s/nodepool", projectID, url.PathEscape(args[0]))
+	endpoint := fmt.Sprintf("/v1/cloud/project/%s/kube/%s/nodepool", projectID, url.PathEscape(args[0]))
 
 	common.ManageListRequestNoExpand(endpoint, []string{"id", "name", "flavor", "currentNodes", "status"}, flags.GenericFilters)
 }
@@ -481,7 +478,7 @@ func GetKubeNodepool(_ *cobra.Command, args []string) {
 		return
 	}
 
-	endpoint := fmt.Sprintf("/cloud/project/%s/kube/%s/nodepool", projectID, url.PathEscape(args[0]))
+	endpoint := fmt.Sprintf("/v1/cloud/project/%s/kube/%s/nodepool", projectID, url.PathEscape(args[0]))
 
 	common.ManageObjectRequest(endpoint, args[1], cloudKubeNodepoolTemplate)
 }
@@ -496,7 +493,7 @@ func EditKubeNodepool(cmd *cobra.Command, args []string) {
 	if err := common.EditResource(
 		cmd,
 		"/cloud/project/{serviceName}/kube/{kubeId}/nodepool/{nodepoolId}",
-		fmt.Sprintf("/cloud/project/%s/kube/%s/nodepool/%s", projectID, url.PathEscape(args[0]), url.PathEscape(args[1])),
+		fmt.Sprintf("/v1/cloud/project/%s/kube/%s/nodepool/%s", projectID, url.PathEscape(args[0]), url.PathEscape(args[1])),
 		KubeNodepoolSpec,
 		assets.CloudOpenapiSchema,
 	); err != nil {
@@ -512,7 +509,7 @@ func DeleteKubeNodepool(_ *cobra.Command, args []string) {
 		return
 	}
 
-	endpoint := fmt.Sprintf("/cloud/project/%s/kube/%s/nodepool/%s", projectID, url.PathEscape(args[0]), url.PathEscape(args[1]))
+	endpoint := fmt.Sprintf("/v1/cloud/project/%s/kube/%s/nodepool/%s", projectID, url.PathEscape(args[0]), url.PathEscape(args[1]))
 	if err := httpLib.Client.Delete(endpoint, nil); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "failed to delete MKS node pool: %s", err)
 		return
@@ -566,7 +563,7 @@ func CreateKubeNodepool(cmd *cobra.Command, args []string) {
 		KubeNodepoolSpec.FlavorName = flavor["flavorName"].(string)
 	}
 
-	endpoint := fmt.Sprintf("/cloud/project/%s/kube/%s/nodepool", projectID, url.PathEscape(args[0]))
+	endpoint := fmt.Sprintf("/v1/cloud/project/%s/kube/%s/nodepool", projectID, url.PathEscape(args[0]))
 	nodepool, err := common.CreateResource(
 		cmd,
 		"/cloud/project/{serviceName}/kube/{kubeId}/nodepool",
@@ -601,7 +598,7 @@ func GetKubeFlavorInteractiveSelector(cmd *cobra.Command, args []string) (map[st
 
 	// Fetch MKS cluster to extract its region
 	var clusterDetails map[string]any
-	if err := httpLib.Client.Get(fmt.Sprintf("/cloud/project/%s/kube/%s", projectID, url.PathEscape(clusterID)), &clusterDetails); err != nil {
+	if err := httpLib.Client.Get(fmt.Sprintf("/v1/cloud/project/%s/kube/%s", projectID, url.PathEscape(clusterID)), &clusterDetails); err != nil {
 		return nil, fmt.Errorf("failed to fetch MKS cluster details: %w", err)
 	}
 	region := clusterDetails["region"].(string)
@@ -627,7 +624,7 @@ func GetKubeOIDCIntegration(_ *cobra.Command, args []string) {
 		return
 	}
 
-	endpoint := fmt.Sprintf("/cloud/project/%s/kube/%s/openIdConnect", projectID, url.PathEscape(args[0]))
+	endpoint := fmt.Sprintf("/v1/cloud/project/%s/kube/%s/openIdConnect", projectID, url.PathEscape(args[0]))
 
 	var oidcConfig map[string]any
 	if err := httpLib.Client.Get(endpoint, &oidcConfig); err != nil {
@@ -648,7 +645,7 @@ func EditKubeOIDCIntegration(cmd *cobra.Command, args []string) {
 	if err := common.EditResource(
 		cmd,
 		"/cloud/project/{serviceName}/kube/{kubeId}/openIdConnect",
-		fmt.Sprintf("/cloud/project/%s/kube/%s/openIdConnect", projectID, url.PathEscape(args[0])),
+		fmt.Sprintf("/v1/cloud/project/%s/kube/%s/openIdConnect", projectID, url.PathEscape(args[0])),
 		KubeOIDCConfig,
 		assets.CloudOpenapiSchema,
 	); err != nil {
@@ -664,7 +661,7 @@ func CreateKubeOIDCIntegration(cmd *cobra.Command, args []string) {
 		return
 	}
 
-	endpoint := fmt.Sprintf("/cloud/project/%s/kube/%s/openIdConnect", projectID, url.PathEscape(args[0]))
+	endpoint := fmt.Sprintf("/v1/cloud/project/%s/kube/%s/openIdConnect", projectID, url.PathEscape(args[0]))
 	if _, err := common.CreateResource(
 		cmd,
 		"/cloud/project/{serviceName}/kube/{kubeId}/openIdConnect",
@@ -687,7 +684,7 @@ func DeleteKubeOIDCIntegration(_ *cobra.Command, args []string) {
 		return
 	}
 
-	endpoint := fmt.Sprintf("/cloud/project/%s/kube/%s/openIdConnect", projectID, url.PathEscape(args[0]))
+	endpoint := fmt.Sprintf("/v1/cloud/project/%s/kube/%s/openIdConnect", projectID, url.PathEscape(args[0]))
 
 	if err := httpLib.Client.Delete(endpoint, nil); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "failed to delete OIDC integration: %s", err)
@@ -704,7 +701,7 @@ func GetKubePrivateNetworkConfiguration(_cmd *cobra.Command, args []string) {
 		return
 	}
 
-	endpoint := fmt.Sprintf("/cloud/project/%s/kube/%s/privateNetworkConfiguration", projectID, url.PathEscape(args[0]))
+	endpoint := fmt.Sprintf("/v1/cloud/project/%s/kube/%s/privateNetworkConfiguration", projectID, url.PathEscape(args[0]))
 
 	var privateNetworkConfig map[string]any
 	if err := httpLib.Client.Get(endpoint, &privateNetworkConfig); err != nil {
@@ -725,7 +722,7 @@ func EditKubePrivateNetworkConfiguration(cmd *cobra.Command, args []string) {
 	if err := common.EditResource(
 		cmd,
 		"/cloud/project/{serviceName}/kube/{kubeId}/privateNetworkConfiguration",
-		fmt.Sprintf("/cloud/project/%s/kube/%s/privateNetworkConfiguration", projectID, url.PathEscape(args[0])),
+		fmt.Sprintf("/v1/cloud/project/%s/kube/%s/privateNetworkConfiguration", projectID, url.PathEscape(args[0])),
 		KubeSpec.PrivateNetworkConfiguration,
 		assets.CloudOpenapiSchema,
 	); err != nil {
@@ -741,7 +738,7 @@ func ResetKubeCluster(cmd *cobra.Command, args []string) {
 		return
 	}
 
-	endpoint := fmt.Sprintf("/cloud/project/%s/kube/%s/reset", projectID, url.PathEscape(args[0]))
+	endpoint := fmt.Sprintf("/v1/cloud/project/%s/kube/%s/reset", projectID, url.PathEscape(args[0]))
 	_, err = common.CreateResource(
 		cmd,
 		"/cloud/project/{serviceName}/kube/{kubeId}/reset",
@@ -765,7 +762,7 @@ func RestartKubeCluster(_ *cobra.Command, args []string) {
 		return
 	}
 
-	if err := httpLib.Client.Post(fmt.Sprintf("/cloud/project/%s/kube/%s/restart", projectID, url.PathEscape(args[0])), map[string]any{
+	if err := httpLib.Client.Post(fmt.Sprintf("/v1/cloud/project/%s/kube/%s/restart", projectID, url.PathEscape(args[0])), map[string]any{
 		"force": KubeForceAction,
 	}, nil); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "failed to restart Kubernetes cluster: %s", err)
@@ -782,7 +779,7 @@ func UpdateKubeCluster(_ *cobra.Command, args []string) {
 		return
 	}
 
-	endpoint := fmt.Sprintf("/cloud/project/%s/kube/%s/update", projectID, url.PathEscape(args[0]))
+	endpoint := fmt.Sprintf("/v1/cloud/project/%s/kube/%s/update", projectID, url.PathEscape(args[0]))
 
 	body := map[string]any{
 		"force": KubeForceAction,
@@ -806,7 +803,7 @@ func UpdateKubeLoadBalancersSubnet(_ *cobra.Command, args []string) {
 		return
 	}
 
-	endpoint := fmt.Sprintf("/cloud/project/%s/kube/%s/updateLoadBalancersSubnetId", projectID, url.PathEscape(args[0]))
+	endpoint := fmt.Sprintf("/v1/cloud/project/%s/kube/%s/updateLoadBalancersSubnetId", projectID, url.PathEscape(args[0]))
 	body := map[string]any{
 		"loadBalancersSubnetId": args[1],
 	}

--- a/internal/services/cloud/cloud_loadbalancer.go
+++ b/internal/services/cloud/cloud_loadbalancer.go
@@ -40,7 +40,7 @@ func locateLoadbalancer(projectID, loadbalancerID string) (string, map[string]an
 
 	// Search for the given loadbalancer in all regions
 	for _, region := range regions {
-		endpoint := fmt.Sprintf("/cloud/project/%s/region/%s/loadbalancing/loadbalancer/%s",
+		endpoint := fmt.Sprintf("/v1/cloud/project/%s/region/%s/loadbalancing/loadbalancer/%s",
 			projectID, url.PathEscape(region.(string)), url.PathEscape(loadbalancerID))
 
 		var loadbalancer map[string]any
@@ -67,7 +67,7 @@ func ListCloudLoadbalancers(_ *cobra.Command, _ []string) {
 	}
 
 	// Fetch loadbalancers in all regions
-	endpoint := fmt.Sprintf("/cloud/project/%s/region", projectID)
+	endpoint := fmt.Sprintf("/v1/cloud/project/%s/region", projectID)
 	containers, err := httpLib.FetchObjectsParallel[[]map[string]any](endpoint+"/%s/loadbalancing/loadbalancer", regions, true)
 	if err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "failed to fetch loadbalancers: %s", err)
@@ -106,7 +106,7 @@ func GetCloudLoadbalancer(_ *cobra.Command, args []string) {
 
 	// Fetch details about the flavor
 	if flavorID, ok := lb["flavorId"].(string); ok && flavorID != "" {
-		endpoint := fmt.Sprintf("/cloud/project/%s/region/%s/loadbalancing/flavor/%s",
+		endpoint := fmt.Sprintf("/v1/cloud/project/%s/region/%s/loadbalancing/flavor/%s",
 			projectID, url.PathEscape(region), url.PathEscape(flavorID))
 
 		var flavor map[string]any
@@ -134,7 +134,7 @@ func EditCloudLoadbalancer(cmd *cobra.Command, args []string) {
 	if err := common.EditResource(
 		cmd,
 		"/cloud/project/{serviceName}/region/{regionName}/loadbalancing/loadbalancer/{loadBalancerId}",
-		fmt.Sprintf("/cloud/project/%s/region/%s/loadbalancing/loadbalancer/%s", projectID, url.PathEscape(region), url.PathEscape(args[0])),
+		fmt.Sprintf("/v1/cloud/project/%s/region/%s/loadbalancing/loadbalancer/%s", projectID, url.PathEscape(region), url.PathEscape(args[0])),
 		CloudLoadbalancerUpdateSpec,
 		assets.CloudOpenapiSchema,
 	); err != nil {

--- a/internal/services/cloud/cloud_network.go
+++ b/internal/services/cloud/cloud_network.go
@@ -146,7 +146,7 @@ func ListPrivateNetworks(_ *cobra.Command, _ []string) {
 		return
 	}
 
-	body, err := httpLib.FetchExpandedArray(fmt.Sprintf("/cloud/project/%s/network/private", projectID), "id")
+	body, err := httpLib.FetchExpandedArray(fmt.Sprintf("/v1/cloud/project/%s/network/private", projectID), "id")
 	if err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "failed to fetch results: %s", err)
 		return
@@ -187,7 +187,7 @@ func GetPrivateNetwork(_ *cobra.Command, args []string) {
 		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
-	path := fmt.Sprintf("/cloud/project/%s/network/private/%s", projectID, url.PathEscape(args[0]))
+	path := fmt.Sprintf("/v1/cloud/project/%s/network/private/%s", projectID, url.PathEscape(args[0]))
 
 	var object map[string]any
 	if err := httpLib.Client.Get(path, &object); err != nil {
@@ -204,7 +204,7 @@ func GetPrivateNetwork(_ *cobra.Command, args []string) {
 		}
 
 		// Fetch subnets of region network
-		path = fmt.Sprintf("/cloud/project/%s/region/%s/network/%s/subnet",
+		path = fmt.Sprintf("/v1/cloud/project/%s/region/%s/network/%s/subnet",
 			projectID,
 			url.PathEscape(region["region"].(string)),
 			url.PathEscape(region["openstackId"].(string)),
@@ -231,7 +231,7 @@ func EditPrivateNetwork(cmd *cobra.Command, args []string) {
 	if err := common.EditResource(
 		cmd,
 		"/cloud/project/{serviceName}/network/private/{networkId}",
-		fmt.Sprintf("/cloud/project/%s/network/private/%s", projectID, url.PathEscape(args[0])),
+		fmt.Sprintf("/v1/cloud/project/%s/network/private/%s", projectID, url.PathEscape(args[0])),
 		map[string]any{
 			"name": CloudNetworkName,
 		},
@@ -277,7 +277,7 @@ func CreatePrivateNetwork(cmd *cobra.Command, args []string) {
 
 	// Create resource
 	region := args[0]
-	endpoint := fmt.Sprintf("/cloud/project/%s/region/%s/network", projectID, url.PathEscape(region))
+	endpoint := fmt.Sprintf("/v1/cloud/project/%s/region/%s/network", projectID, url.PathEscape(region))
 	task, err := common.CreateResource(
 		cmd,
 		"/cloud/project/{serviceName}/region/{regionName}/network",
@@ -306,7 +306,7 @@ You can check the status of the operation with: 'ovhcloud cloud operation get %[
 
 	// Fetch all private networks
 	var networks []PrivateNetwork
-	if err := httpLib.Client.Get(fmt.Sprintf("/cloud/project/%s/network/private", projectID), &networks); err != nil {
+	if err := httpLib.Client.Get(fmt.Sprintf("/v1/cloud/project/%s/network/private", projectID), &networks); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "failed to fetch private networks: %s", err)
 		return
 	}
@@ -334,7 +334,7 @@ eachNetwork:
 	}
 
 	// Fetch subnets of created network
-	endpoint = fmt.Sprintf("/cloud/project/%s/region/%s/network/%s/subnet", projectID, url.PathEscape(region), url.PathEscape(foundRegionNetwork.OpenstackID))
+	endpoint = fmt.Sprintf("/v1/cloud/project/%s/region/%s/network/%s/subnet", projectID, url.PathEscape(region), url.PathEscape(foundRegionNetwork.OpenstackID))
 	var subnets []map[string]any
 	if err := httpLib.Client.Get(endpoint, &subnets); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "failed to fetch subnets of created network: %s", err)
@@ -344,7 +344,7 @@ eachNetwork:
 	// Fetch gateway of created subnets and prepare output
 	var outputSubnets []map[string]any
 	for _, subnet := range subnets {
-		endpoint = fmt.Sprintf("/cloud/project/%s/region/%s/gateway?subnetId=%s",
+		endpoint = fmt.Sprintf("/v1/cloud/project/%s/region/%s/gateway?subnetId=%s",
 			projectID,
 			url.PathEscape(region),
 			url.PathEscape(subnet["id"].(string)),
@@ -389,7 +389,7 @@ func DeletePrivateNetwork(_ *cobra.Command, args []string) {
 		return
 	}
 
-	endpoint := fmt.Sprintf("/cloud/project/%s/network/private/%s", projectID, url.PathEscape(args[0]))
+	endpoint := fmt.Sprintf("/v1/cloud/project/%s/network/private/%s", projectID, url.PathEscape(args[0]))
 	if err := httpLib.Client.Delete(endpoint, nil); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "failed to delete private network: %s", err)
 		return
@@ -405,7 +405,7 @@ func DeletePrivateNetworkRegion(_ *cobra.Command, args []string) {
 		return
 	}
 
-	endpoint := fmt.Sprintf("/cloud/project/%s/network/private/%s/region/%s", projectID, url.PathEscape(args[0]), url.PathEscape(args[1]))
+	endpoint := fmt.Sprintf("/v1/cloud/project/%s/network/private/%s/region/%s", projectID, url.PathEscape(args[0]), url.PathEscape(args[1]))
 	if err := httpLib.Client.Delete(endpoint, nil); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "failed to delete private network region: %s", err)
 		return
@@ -421,7 +421,7 @@ func AddPrivateNetworkRegion(_ *cobra.Command, args []string) {
 		return
 	}
 
-	endpoint := fmt.Sprintf("/cloud/project/%s/network/private/%s/region", projectID, url.PathEscape(args[0]))
+	endpoint := fmt.Sprintf("/v1/cloud/project/%s/network/private/%s/region", projectID, url.PathEscape(args[0]))
 	if err := httpLib.Client.Post(endpoint, map[string]string{"region": args[1]}, nil); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "failed to add private network region: %s", err)
 		return
@@ -437,7 +437,7 @@ func ListPrivateNetworkSubnets(_ *cobra.Command, args []string) {
 		return
 	}
 
-	endpoint := fmt.Sprintf("/cloud/project/%s/network/private/%s/subnet", projectID, url.PathEscape(args[0]))
+	endpoint := fmt.Sprintf("/v1/cloud/project/%s/network/private/%s/subnet", projectID, url.PathEscape(args[0]))
 
 	common.ManageListRequestNoExpand(endpoint, []string{"id", "cidr", "gatewayIp", "dhcpEnabled"}, flags.GenericFilters)
 }
@@ -449,7 +449,7 @@ func GetPrivateNetworkSubnet(_ *cobra.Command, args []string) {
 		return
 	}
 
-	endpoint := fmt.Sprintf("/cloud/project/%s/network/private/%s/subnet", projectID, url.PathEscape(args[0]))
+	endpoint := fmt.Sprintf("/v1/cloud/project/%s/network/private/%s/subnet", projectID, url.PathEscape(args[0]))
 	common.ManageObjectRequest(endpoint, args[1], "")
 }
 
@@ -463,7 +463,7 @@ func CreatePrivateNetworkSubnet(cmd *cobra.Command, args []string) {
 	subnet, err := common.CreateResource(
 		cmd,
 		"/cloud/project/{serviceName}/network/private/{networkId}/subnet",
-		fmt.Sprintf("/cloud/project/%s/network/private/%s/subnet", projectID, url.PathEscape(args[0])),
+		fmt.Sprintf("/v1/cloud/project/%s/network/private/%s/subnet", projectID, url.PathEscape(args[0])),
 		PrivateNetworkSubnetCreationExample,
 		CloudNetworkSubnetSpec,
 		assets.CloudOpenapiSchema,
@@ -483,7 +483,7 @@ func EditPrivateNetworkSubnet(cmd *cobra.Command, args []string) {
 		return
 	}
 
-	endpoint := fmt.Sprintf("/cloud/project/%s/network/private/%s/subnet/%s", projectID, url.PathEscape(args[0]), url.PathEscape(args[1]))
+	endpoint := fmt.Sprintf("/v1/cloud/project/%s/network/private/%s/subnet/%s", projectID, url.PathEscape(args[0]), url.PathEscape(args[1]))
 
 	if err := common.EditResource(
 		cmd,
@@ -504,7 +504,7 @@ func DeletePrivateNetworkSubnet(_ *cobra.Command, args []string) {
 		return
 	}
 
-	endpoint := fmt.Sprintf("/cloud/project/%s/network/private/%s/subnet/%s", projectID, url.PathEscape(args[0]), url.PathEscape(args[1]))
+	endpoint := fmt.Sprintf("/v1/cloud/project/%s/network/private/%s/subnet/%s", projectID, url.PathEscape(args[0]), url.PathEscape(args[1]))
 	if err := httpLib.Client.Delete(endpoint, nil); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "failed to delete private network subnet: %s", err)
 		return
@@ -521,7 +521,7 @@ func ListPublicNetworks(_ *cobra.Command, _ []string) {
 	}
 
 	var body []map[string]any
-	err = httpLib.Client.Get(fmt.Sprintf("/cloud/project/%s/network/public", projectID), &body)
+	err = httpLib.Client.Get(fmt.Sprintf("/v1/cloud/project/%s/network/public", projectID), &body)
 	if err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "failed to fetch results: %s", err)
 		return
@@ -564,7 +564,7 @@ func GetPublicNetwork(_ *cobra.Command, args []string) {
 	}
 
 	var allNetworks []map[string]any
-	err = httpLib.Client.Get(fmt.Sprintf("/cloud/project/%s/network/public", projectID), &allNetworks)
+	err = httpLib.Client.Get(fmt.Sprintf("/v1/cloud/project/%s/network/public", projectID), &allNetworks)
 	if err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "failed to fetch public networks: %s", err)
 		return
@@ -588,7 +588,7 @@ func GetPublicNetwork(_ *cobra.Command, args []string) {
 		region := region.(map[string]any)
 
 		// Fetch subnets of region network
-		path := fmt.Sprintf("/cloud/project/%s/region/%s/network/%s/subnet",
+		path := fmt.Sprintf("/v1/cloud/project/%s/region/%s/network/%s/subnet",
 			projectID,
 			url.PathEscape(region["region"].(string)),
 			url.PathEscape(region["openstackId"].(string)),
@@ -620,7 +620,7 @@ func ListGateways(_ *cobra.Command, _ []string) {
 	}
 
 	// Fetch gateways in all regions
-	url := fmt.Sprintf("/cloud/project/%s/region", projectID)
+	url := fmt.Sprintf("/v1/cloud/project/%s/region", projectID)
 	gateways, err := httpLib.FetchObjectsParallel[[]map[string]any](url+"/%s/gateway", regions, true)
 	if err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "failed to fetch gateways: %s", err)
@@ -660,7 +660,7 @@ func findGateway(gatewayId string) (string, map[string]any, error) {
 	for _, region := range regions {
 		var (
 			gateway  map[string]any
-			endpoint = fmt.Sprintf("/cloud/project/%s/region/%s/gateway/%s",
+			endpoint = fmt.Sprintf("/v1/cloud/project/%s/region/%s/gateway/%s",
 				projectID, url.PathEscape(region.(string)), url.PathEscape(gatewayId))
 		)
 		if err := httpLib.Client.Get(endpoint, &gateway); err == nil {
@@ -738,12 +738,12 @@ func CreateGateway(cmd *cobra.Command, args []string) {
 	if CloudGatewaySpec.ExistingNetworkID != "" {
 		path = "/cloud/project/{serviceName}/region/{regionName}/network/{networkId}/subnet/{subnetId}/gateway"
 		endpoint = fmt.Sprintf(
-			"/cloud/project/%s/region/%s/network/%s/subnet/%s/gateway",
+			"/v1/cloud/project/%s/region/%s/network/%s/subnet/%s/gateway",
 			projectID, url.PathEscape(region), url.PathEscape(CloudGatewaySpec.ExistingNetworkID),
 			url.PathEscape(CloudGatewaySpec.ExistingSubnetID))
 	} else {
 		path = "/cloud/project/{serviceName}/region/{regionName}/gateway"
-		endpoint = fmt.Sprintf("/cloud/project/%s/region/%s/gateway", projectID, url.PathEscape(region))
+		endpoint = fmt.Sprintf("/v1/cloud/project/%s/region/%s/gateway", projectID, url.PathEscape(region))
 	}
 
 	// Create resource

--- a/internal/services/cloud/cloud_operation.go
+++ b/internal/services/cloud/cloud_operation.go
@@ -31,7 +31,7 @@ func ListCloudOperations(_ *cobra.Command, _ []string) {
 	}
 
 	var operations []map[string]any
-	err = httpLib.Client.Get(fmt.Sprintf("/cloud/project/%s/operation", projectID), &operations)
+	err = httpLib.Client.Get(fmt.Sprintf("/v1/cloud/project/%s/operation", projectID), &operations)
 	if err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "failed to fetch results: %s", err)
 		return
@@ -53,5 +53,5 @@ func GetCloudOperation(_ *cobra.Command, args []string) {
 		return
 	}
 
-	common.ManageObjectRequest(fmt.Sprintf("/cloud/project/%s/operation", projectID), args[0], cloudOperationTemplate)
+	common.ManageObjectRequest(fmt.Sprintf("/v1/cloud/project/%s/operation", projectID), args[0], cloudOperationTemplate)
 }

--- a/internal/services/cloud/cloud_project.go
+++ b/internal/services/cloud/cloud_project.go
@@ -37,18 +37,18 @@ var (
 )
 
 func ListCloudProject(_ *cobra.Command, _ []string) {
-	common.ManageListRequest("/cloud/project", "", cloudprojectColumnsToDisplay, flags.GenericFilters)
+	common.ManageListRequest("/v1/cloud/project", "", cloudprojectColumnsToDisplay, flags.GenericFilters)
 }
 
 func GetCloudProject(_ *cobra.Command, args []string) {
-	common.ManageObjectRequest("/cloud/project", args[0], cloudProjectTemplate)
+	common.ManageObjectRequest("/v1/cloud/project", args[0], cloudProjectTemplate)
 }
 
 func EditCloudProject(cmd *cobra.Command, args []string) {
 	if err := common.EditResource(
 		cmd,
 		"/cloud/project/{serviceName}",
-		fmt.Sprintf("/cloud/project/%s", url.PathEscape(args[0])),
+		fmt.Sprintf("/v1/cloud/project/%s", url.PathEscape(args[0])),
 		CloudProjectSpec,
 		assets.CloudOpenapiSchema,
 	); err != nil {
@@ -111,7 +111,7 @@ func getCloudRegionsWithFeatureAvailable(projectID string, features ...string) (
 }
 
 func fetchProjectRegions(projectID string) ([]map[string]any, error) {
-	endpoint := fmt.Sprintf("/cloud/project/%s/region", projectID)
+	endpoint := fmt.Sprintf("/v1/cloud/project/%s/region", projectID)
 
 	regions, err := httpLib.FetchExpandedArray(endpoint, "")
 	if err != nil {

--- a/internal/services/cloud/cloud_quota.go
+++ b/internal/services/cloud/cloud_quota.go
@@ -26,7 +26,7 @@ func GetCloudQuota(_ *cobra.Command, args []string) {
 		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
-	url := fmt.Sprintf("/cloud/project/%s/region/%s/quota", projectID, url.PathEscape(args[0]))
+	url := fmt.Sprintf("/v1/cloud/project/%s/region/%s/quota", projectID, url.PathEscape(args[0]))
 
 	var object map[string]any
 	if err := httpLib.Client.Get(url, &object); err != nil {

--- a/internal/services/cloud/cloud_reference.go
+++ b/internal/services/cloud/cloud_reference.go
@@ -24,7 +24,7 @@ func GetFlavors(region string) {
 		return
 	}
 
-	endpoint := fmt.Sprintf("/cloud/project/%s/flavor", projectID)
+	endpoint := fmt.Sprintf("/v1/cloud/project/%s/flavor", projectID)
 	if region != "" {
 		endpoint += "?region=" + url.QueryEscape(region)
 	}
@@ -47,7 +47,7 @@ func GetImages(region, osType string) {
 		query.Add("osType", osType)
 	}
 
-	endpoint := fmt.Sprintf("/cloud/project/%s/image?%s", projectID, query.Encode())
+	endpoint := fmt.Sprintf("/v1/cloud/project/%s/image?%s", projectID, query.Encode())
 
 	common.ManageListRequestNoExpand(endpoint, []string{"id", "name", "region", "type", "status"}, flags.GenericFilters)
 }
@@ -58,7 +58,7 @@ func ListContainerRegistryPlans(_ *cobra.Command, _ []string) {
 		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
-	path := fmt.Sprintf("/cloud/project/%s/capabilities/containerRegistry", projectID)
+	path := fmt.Sprintf("/v1/cloud/project/%s/capabilities/containerRegistry", projectID)
 
 	var body []map[string]any
 	if err := httpLib.Client.Get(path, &body); err != nil {
@@ -133,7 +133,7 @@ func ListDatabasesPlans(_ *cobra.Command, _ []string) {
 		return
 	}
 
-	endpoint := fmt.Sprintf("/cloud/project/%s/database/capabilities", projectID)
+	endpoint := fmt.Sprintf("/v1/cloud/project/%s/database/capabilities", projectID)
 	var body map[string]any
 	if err := httpLib.Client.Get(endpoint, &body); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "failed to fetch database plans: %s", err)
@@ -161,7 +161,7 @@ func ListDatabasesNodeFlavors(_ *cobra.Command, _ []string) {
 		return
 	}
 
-	endpoint := fmt.Sprintf("/cloud/project/%s/database/capabilities", projectID)
+	endpoint := fmt.Sprintf("/v1/cloud/project/%s/database/capabilities", projectID)
 	var body map[string]any
 	if err := httpLib.Client.Get(endpoint, &body); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "failed to fetch database plans: %s", err)
@@ -198,7 +198,7 @@ func ListDatabaseEngines(_ *cobra.Command, _ []string) {
 		return
 	}
 
-	endpoint := fmt.Sprintf("/cloud/project/%s/database/capabilities", projectID)
+	endpoint := fmt.Sprintf("/v1/cloud/project/%s/database/capabilities", projectID)
 	var body map[string]any
 	if err := httpLib.Client.Get(endpoint, &body); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "failed to fetch database engines: %s", err)
@@ -238,6 +238,6 @@ func ListLoadbalancerFlavors(cmd *cobra.Command, args []string) {
 		return
 	}
 
-	endpoint := fmt.Sprintf("/cloud/project/%s/region/%s/loadbalancing/flavor", projectID, url.PathEscape(args[0]))
+	endpoint := fmt.Sprintf("/v1/cloud/project/%s/region/%s/loadbalancing/flavor", projectID, url.PathEscape(args[0]))
 	common.ManageListRequestNoExpand(endpoint, []string{"id", "name", "region"}, flags.GenericFilters)
 }

--- a/internal/services/cloud/cloud_region.go
+++ b/internal/services/cloud/cloud_region.go
@@ -28,7 +28,7 @@ func ListCloudRegions(_ *cobra.Command, _ []string) {
 		return
 	}
 
-	common.ManageListRequest(fmt.Sprintf("/cloud/project/%s/region", projectID), "", cloudprojectRegionColumnsToDisplay, flags.GenericFilters)
+	common.ManageListRequest(fmt.Sprintf("/v1/cloud/project/%s/region", projectID), "", cloudprojectRegionColumnsToDisplay, flags.GenericFilters)
 }
 
 func GetCloudRegion(_ *cobra.Command, args []string) {
@@ -38,5 +38,5 @@ func GetCloudRegion(_ *cobra.Command, args []string) {
 		return
 	}
 
-	common.ManageObjectRequest(fmt.Sprintf("/cloud/project/%s/region", projectID), args[0], cloudRegionTemplate)
+	common.ManageObjectRequest(fmt.Sprintf("/v1/cloud/project/%s/region", projectID), args[0], cloudRegionTemplate)
 }

--- a/internal/services/cloud/cloud_ssh_key.go
+++ b/internal/services/cloud/cloud_ssh_key.go
@@ -29,7 +29,7 @@ func ListCloudSSHKeys(_ *cobra.Command, _ []string) {
 		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
-	path := fmt.Sprintf("/cloud/project/%s/sshkey", projectID)
+	path := fmt.Sprintf("/v1/cloud/project/%s/sshkey", projectID)
 
 	var body []map[string]any
 	if err := httpLib.Client.Get(path, &body); err != nil {
@@ -53,5 +53,5 @@ func GetCloudSSHKey(_ *cobra.Command, args []string) {
 		return
 	}
 
-	common.ManageObjectRequest(fmt.Sprintf("/cloud/project/%s/sshkey", projectID), args[0], cloudSSHKeyTemplate)
+	common.ManageObjectRequest(fmt.Sprintf("/v1/cloud/project/%s/sshkey", projectID), args[0], cloudSSHKeyTemplate)
 }

--- a/internal/services/cloud/cloud_storage_block.go
+++ b/internal/services/cloud/cloud_storage_block.go
@@ -55,7 +55,7 @@ func ListCloudVolumes(_ *cobra.Command, _ []string) {
 		return
 	}
 
-	common.ManageListRequestNoExpand(fmt.Sprintf("/cloud/project/%s/volume", projectID), volumeColumnsToDisplay, flags.GenericFilters)
+	common.ManageListRequestNoExpand(fmt.Sprintf("/v1/cloud/project/%s/volume", projectID), volumeColumnsToDisplay, flags.GenericFilters)
 }
 
 func GetVolume(_ *cobra.Command, args []string) {
@@ -65,7 +65,7 @@ func GetVolume(_ *cobra.Command, args []string) {
 		return
 	}
 
-	common.ManageObjectRequest(fmt.Sprintf("/cloud/project/%s/volume", projectID), args[0], volumeTemplate)
+	common.ManageObjectRequest(fmt.Sprintf("/v1/cloud/project/%s/volume", projectID), args[0], volumeTemplate)
 }
 
 func EditVolume(cmd *cobra.Command, args []string) {
@@ -78,7 +78,7 @@ func EditVolume(cmd *cobra.Command, args []string) {
 	if err := common.EditResource(
 		cmd,
 		"/cloud/project/{serviceName}/volume/{volumeId}",
-		fmt.Sprintf("/cloud/project/%s/volume/%s", projectID, url.PathEscape(args[0])),
+		fmt.Sprintf("/v1/cloud/project/%s/volume/%s", projectID, url.PathEscape(args[0])),
 		VolumeSpec,
 		assets.CloudOpenapiSchema,
 	); err != nil {
@@ -94,7 +94,7 @@ func CreateVolume(cmd *cobra.Command, args []string) {
 		return
 	}
 
-	endpoint := fmt.Sprintf("/cloud/project/%s/region/%s/volume", projectID, url.PathEscape(args[0]))
+	endpoint := fmt.Sprintf("/v1/cloud/project/%s/region/%s/volume", projectID, url.PathEscape(args[0]))
 	task, err := common.CreateResource(
 		cmd,
 		"/cloud/project/{serviceName}/region/{regionName}/volume",
@@ -131,7 +131,7 @@ func DeleteVolume(_ *cobra.Command, args []string) {
 		return
 	}
 
-	endpoint := fmt.Sprintf("/cloud/project/%s/volume/%s", projectID, url.PathEscape(args[0]))
+	endpoint := fmt.Sprintf("/v1/cloud/project/%s/volume/%s", projectID, url.PathEscape(args[0]))
 	if err := httpLib.Client.Delete(endpoint, nil); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "failed to delete volume: %s", err)
 		return
@@ -148,7 +148,7 @@ func AttachVolumeToInstance(_ *cobra.Command, args []string) {
 	}
 
 	if err := httpLib.Client.Post(
-		fmt.Sprintf("/cloud/project/%s/volume/%s/attach", projectID, url.PathEscape(args[0])),
+		fmt.Sprintf("/v1/cloud/project/%s/volume/%s/attach", projectID, url.PathEscape(args[0])),
 		map[string]string{"instanceId": args[1]},
 		nil,
 	); err != nil {
@@ -167,7 +167,7 @@ func DetachVolumeFromInstance(_ *cobra.Command, args []string) {
 	}
 
 	if err := httpLib.Client.Post(
-		fmt.Sprintf("/cloud/project/%s/volume/%s/detach", projectID, url.PathEscape(args[0])),
+		fmt.Sprintf("/v1/cloud/project/%s/volume/%s/detach", projectID, url.PathEscape(args[0])),
 		map[string]string{"instanceId": args[1]},
 		nil,
 	); err != nil {
@@ -186,7 +186,7 @@ func CreateVolumeSnapshot(_ *cobra.Command, args []string) {
 	}
 
 	var (
-		endpoint = fmt.Sprintf("/cloud/project/%s/volume/%s/snapshot", projectID, url.PathEscape(args[0]))
+		endpoint = fmt.Sprintf("/v1/cloud/project/%s/volume/%s/snapshot", projectID, url.PathEscape(args[0]))
 		response map[string]any
 	)
 
@@ -205,7 +205,7 @@ func ListVolumeSnapshots(cmd *cobra.Command, args []string) {
 		return
 	}
 
-	endpoint := fmt.Sprintf("/cloud/project/%s/volume/snapshot", projectID)
+	endpoint := fmt.Sprintf("/v1/cloud/project/%s/volume/snapshot", projectID)
 
 	volume, err := cmd.Flags().GetString("volume-id")
 	if err != nil {
@@ -226,7 +226,7 @@ func DeleteVolumeSnapshot(_ *cobra.Command, args []string) {
 		return
 	}
 
-	endpoint := fmt.Sprintf("/cloud/project/%s/volume/snapshot/%s", projectID, url.PathEscape(args[0]))
+	endpoint := fmt.Sprintf("/v1/cloud/project/%s/volume/snapshot/%s", projectID, url.PathEscape(args[0]))
 	if err := httpLib.Client.Delete(endpoint, nil); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "failed to delete snapshot: %s", err)
 		return
@@ -252,7 +252,7 @@ func UpsizeVolume(cmd *cobra.Command, args []string) {
 		return
 	}
 
-	endpoint := fmt.Sprintf("/cloud/project/%s/volume/%s/upsize", projectID, url.PathEscape(args[0]))
+	endpoint := fmt.Sprintf("/v1/cloud/project/%s/volume/%s/upsize", projectID, url.PathEscape(args[0]))
 	if err := httpLib.Client.Post(
 		endpoint,
 		map[string]int{"size": size},
@@ -282,7 +282,7 @@ func findVolumeBackup(backupId string) (string, map[string]any, error) {
 	for _, region := range regions {
 		var (
 			volumeBackup map[string]any
-			endpoint     = fmt.Sprintf("/cloud/project/%s/region/%s/volumeBackup/%s",
+			endpoint     = fmt.Sprintf("/v1/cloud/project/%s/region/%s/volumeBackup/%s",
 				projectID, url.PathEscape(region.(string)), url.PathEscape(backupId))
 		)
 		if err := httpLib.Client.Get(endpoint, &volumeBackup); err == nil {
@@ -308,7 +308,7 @@ func ListVolumeBackups(_ *cobra.Command, args []string) {
 	}
 
 	// Fetch volumes in all regions
-	endpoint := fmt.Sprintf("/cloud/project/%s/region", projectID)
+	endpoint := fmt.Sprintf("/v1/cloud/project/%s/region", projectID)
 	volumeBackups, err := httpLib.FetchObjectsParallel[[]map[string]any](endpoint+"/%s/volumeBackup", regions, true)
 	if err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "failed to fetch volume backups: %s", err)
@@ -366,14 +366,14 @@ func CreateVolumeBackup(cmd *cobra.Command, args []string) {
 	// Fetch volume to get its region
 	var volume map[string]any
 	if err := httpLib.Client.Get(
-		fmt.Sprintf("/cloud/project/%s/volume/%s", projectID, url.PathEscape(args[0])),
+		fmt.Sprintf("/v1/cloud/project/%s/volume/%s", projectID, url.PathEscape(args[0])),
 		&volume,
 	); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "failed to fetch volume: %s", err)
 		return
 	}
 
-	endpoint := fmt.Sprintf("/cloud/project/%s/region/%s/volumeBackup", projectID, url.PathEscape(volume["region"].(string)))
+	endpoint := fmt.Sprintf("/v1/cloud/project/%s/region/%s/volumeBackup", projectID, url.PathEscape(volume["region"].(string)))
 
 	var (
 		response map[string]any

--- a/internal/services/cloud/cloud_storage_s3.go
+++ b/internal/services/cloud/cloud_storage_s3.go
@@ -112,7 +112,7 @@ func locateStorageS3Container(projectID, containerName string) (string, map[stri
 
 	// Search for the given container in all regions
 	for _, region := range regions {
-		endpoint := fmt.Sprintf("/cloud/project/%s/region/%s/storage/%s",
+		endpoint := fmt.Sprintf("/v1/cloud/project/%s/region/%s/storage/%s",
 			projectID, url.PathEscape(region.(string)), url.PathEscape(containerName))
 
 		var container map[string]any
@@ -139,7 +139,7 @@ func ListCloudStorageS3(_ *cobra.Command, _ []string) {
 	}
 
 	// Fetch containers in all regions
-	url := fmt.Sprintf("/cloud/project/%s/region", projectID)
+	url := fmt.Sprintf("/v1/cloud/project/%s/region", projectID)
 	containers, err := httpLib.FetchObjectsParallel[[]map[string]any](url+"/%s/storage", regions, true)
 	if err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "failed to fetch storage containers: %s", err)
@@ -223,7 +223,7 @@ func CreateStorageS3(cmd *cobra.Command, args []string) {
 		return
 	}
 
-	endpoint := fmt.Sprintf("/cloud/project/%s/region/%s/storage", projectID, url.PathEscape(args[0]))
+	endpoint := fmt.Sprintf("/v1/cloud/project/%s/region/%s/storage", projectID, url.PathEscape(args[0]))
 	container, err := common.CreateResource(
 		cmd,
 		"/cloud/project/{serviceName}/region/{regionName}/storage",
@@ -619,7 +619,7 @@ func ListStorageS3Credentials(_ *cobra.Command, args []string) {
 		return
 	}
 
-	endpoint := fmt.Sprintf("/cloud/project/%s/user/%s/s3Credentials", projectID, url.PathEscape(args[0]))
+	endpoint := fmt.Sprintf("/v1/cloud/project/%s/user/%s/s3Credentials", projectID, url.PathEscape(args[0]))
 	common.ManageListRequestNoExpand(endpoint, []string{"access", "userId", "tenantId"}, flags.GenericFilters)
 }
 
@@ -631,7 +631,7 @@ func CreateStorageS3Credentials(cmd *cobra.Command, args []string) {
 	}
 
 	credentials := map[string]any{}
-	endpoint := fmt.Sprintf("/cloud/project/%s/user/%s/s3Credentials", projectID, url.PathEscape(args[0]))
+	endpoint := fmt.Sprintf("/v1/cloud/project/%s/user/%s/s3Credentials", projectID, url.PathEscape(args[0]))
 	if err := httpLib.Client.Post(endpoint, nil, &credentials); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "failed to create S3 credentials: %s", err)
 		return
@@ -647,7 +647,7 @@ func DeleteStorageS3Credentials(_ *cobra.Command, args []string) {
 		return
 	}
 
-	endpoint := fmt.Sprintf("/cloud/project/%s/user/%s/s3Credentials/%s", projectID, url.PathEscape(args[0]), url.PathEscape(args[1]))
+	endpoint := fmt.Sprintf("/v1/cloud/project/%s/user/%s/s3Credentials/%s", projectID, url.PathEscape(args[0]), url.PathEscape(args[1]))
 	if err := httpLib.Client.Delete(endpoint, nil); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "failed to delete S3 credentials: %s", err)
 		return
@@ -663,7 +663,7 @@ func GetStorageS3Credentials(_ *cobra.Command, args []string) {
 		return
 	}
 
-	endpoint := fmt.Sprintf("/cloud/project/%s/user/%s/s3Credentials/%s", projectID, url.PathEscape(args[0]), url.PathEscape(args[1]))
+	endpoint := fmt.Sprintf("/v1/cloud/project/%s/user/%s/s3Credentials/%s", projectID, url.PathEscape(args[0]), url.PathEscape(args[1]))
 	var credentials map[string]any
 	if err := httpLib.Client.Get(endpoint, &credentials); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "failed to get S3 credentials: %s", err)
@@ -671,7 +671,7 @@ func GetStorageS3Credentials(_ *cobra.Command, args []string) {
 	}
 
 	// Fetch credentials secret
-	secretEndpoint := fmt.Sprintf("/cloud/project/%s/user/%s/s3Credentials/%s/secret", projectID, url.PathEscape(args[0]), url.PathEscape(args[1]))
+	secretEndpoint := fmt.Sprintf("/v1/cloud/project/%s/user/%s/s3Credentials/%s/secret", projectID, url.PathEscape(args[0]), url.PathEscape(args[1]))
 	if err := httpLib.Client.Post(secretEndpoint, nil, &credentials); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "failed to get S3 credentials secret: %s", err)
 		return

--- a/internal/services/cloud/cloud_storage_swift.go
+++ b/internal/services/cloud/cloud_storage_swift.go
@@ -33,7 +33,7 @@ func ListCloudStorageSwift(_ *cobra.Command, _ []string) {
 		return
 	}
 
-	common.ManageListRequestNoExpand(fmt.Sprintf("/cloud/project/%s/storage", projectID), cloudprojectStorageSwiftColumnsToDisplay, flags.GenericFilters)
+	common.ManageListRequestNoExpand(fmt.Sprintf("/v1/cloud/project/%s/storage", projectID), cloudprojectStorageSwiftColumnsToDisplay, flags.GenericFilters)
 }
 
 func GetStorageSwift(_ *cobra.Command, args []string) {
@@ -43,7 +43,7 @@ func GetStorageSwift(_ *cobra.Command, args []string) {
 		return
 	}
 
-	common.ManageObjectRequest(fmt.Sprintf("/cloud/project/%s/storage", projectID), args[0], cloudStorageSwiftTemplate)
+	common.ManageObjectRequest(fmt.Sprintf("/v1/cloud/project/%s/storage", projectID), args[0], cloudStorageSwiftTemplate)
 }
 
 func EditStorageSwift(cmd *cobra.Command, args []string) {
@@ -56,7 +56,7 @@ func EditStorageSwift(cmd *cobra.Command, args []string) {
 	if err := common.EditResource(
 		cmd,
 		"/cloud/project/{serviceName}/storage/{containerId}",
-		fmt.Sprintf("/cloud/project/%s/storage/%s", projectID, url.PathEscape(args[0])),
+		fmt.Sprintf("/v1/cloud/project/%s/storage/%s", projectID, url.PathEscape(args[0])),
 		map[string]any{
 			"containerType": CloudSwiftContainerType,
 		},

--- a/internal/services/cloud/cloud_user.go
+++ b/internal/services/cloud/cloud_user.go
@@ -53,7 +53,7 @@ func ListCloudUsers(_ *cobra.Command, _ []string) {
 		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
-	path := fmt.Sprintf("/cloud/project/%s/user", projectID)
+	path := fmt.Sprintf("/v1/cloud/project/%s/user", projectID)
 
 	var body []map[string]any
 	if err := httpLib.Client.Get(path, &body); err != nil {
@@ -77,7 +77,7 @@ func GetCloudUser(_ *cobra.Command, args []string) {
 		return
 	}
 
-	common.ManageObjectRequest(fmt.Sprintf("/cloud/project/%s/user", projectID), args[0], cloudUserTemplate)
+	common.ManageObjectRequest(fmt.Sprintf("/v1/cloud/project/%s/user", projectID), args[0], cloudUserTemplate)
 }
 
 func CreateCloudUser(cmd *cobra.Command, args []string) {
@@ -90,7 +90,7 @@ func CreateCloudUser(cmd *cobra.Command, args []string) {
 	client, err := common.CreateResource(
 		cmd,
 		"/cloud/project/{serviceName}/user",
-		fmt.Sprintf("/cloud/project/%s/user", projectID),
+		fmt.Sprintf("/v1/cloud/project/%s/user", projectID),
 		UserCreateExample,
 		UserSpec,
 		assets.CloudOpenapiSchema,
@@ -111,7 +111,7 @@ func DeleteCloudUser(_ *cobra.Command, args []string) {
 		return
 	}
 
-	endpoint := fmt.Sprintf("/cloud/project/%s/user/%s", projectID, url.PathEscape(args[0]))
+	endpoint := fmt.Sprintf("/v1/cloud/project/%s/user/%s", projectID, url.PathEscape(args[0]))
 
 	if err := httpLib.Client.Delete(endpoint, nil); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "failed to delete user: %s", err)
@@ -212,7 +212,7 @@ func CreateUserS3Policy(cmd *cobra.Command, args []string) {
 
 	log.Println("Final parameters: \n" + string(out))
 
-	endpoint := fmt.Sprintf("/cloud/project/%s/user/%s/policy", projectID, url.PathEscape(args[0]))
+	endpoint := fmt.Sprintf("/v1/cloud/project/%s/user/%s/policy", projectID, url.PathEscape(args[0]))
 	if err := httpLib.Client.Post(endpoint, parameters, nil); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "error creating resource: %s", err)
 		return
@@ -228,5 +228,5 @@ func GetUserS3Policy(_ *cobra.Command, args []string) {
 		return
 	}
 
-	common.ManageObjectRequest(fmt.Sprintf("/cloud/project/%s/user/%s/policy", projectID, args[0]), "", "")
+	common.ManageObjectRequest(fmt.Sprintf("/v1/cloud/project/%s/user/%s/policy", projectID, args[0]), "", "")
 }

--- a/internal/services/cloud/utils.go
+++ b/internal/services/cloud/utils.go
@@ -36,7 +36,7 @@ type CloudProjectSubOperation struct {
 
 func getAvailableImages(projectID string, region string) (map[string]string, error) {
 	// Fetch available images for the project
-	endpoint := fmt.Sprintf("/cloud/project/%s/image", projectID)
+	endpoint := fmt.Sprintf("/v1/cloud/project/%s/image", projectID)
 	if region != "" {
 		endpoint += "?region=" + url.QueryEscape(region)
 	}
@@ -79,7 +79,7 @@ func runImageSelector(projectID string, region string) (string, string, error) {
 
 func getAvailableFlavors(projectID string, region string) (map[string]string, error) {
 	// Fetch available flavors for the project
-	endpoint := fmt.Sprintf("/cloud/project/%s/flavor", projectID)
+	endpoint := fmt.Sprintf("/v1/cloud/project/%s/flavor", projectID)
 	if region != "" {
 		endpoint += "?region=" + url.QueryEscape(region)
 	}
@@ -117,7 +117,7 @@ func runFlavorSelector(projectID string, region string) (string, string, error) 
 }
 
 func waitForCloudOperation(projectID, operationID, action string, retryDuration time.Duration) (string, error) {
-	endpoint := fmt.Sprintf("/cloud/project/%s/operation/%s", url.PathEscape(projectID), url.PathEscape(operationID))
+	endpoint := fmt.Sprintf("/v1/cloud/project/%s/operation/%s", url.PathEscape(projectID), url.PathEscape(operationID))
 	resourceID := ""
 
 	ctx, cancel := context.WithTimeout(context.Background(), retryDuration)

--- a/internal/services/dedicatedceph/dedicatedceph.go
+++ b/internal/services/dedicatedceph/dedicatedceph.go
@@ -29,18 +29,18 @@ var (
 )
 
 func ListDedicatedCeph(_ *cobra.Command, _ []string) {
-	common.ManageListRequest("/dedicated/ceph", "", dedicatedcephColumnsToDisplay, flags.GenericFilters)
+	common.ManageListRequest("/v1/dedicated/ceph", "", dedicatedcephColumnsToDisplay, flags.GenericFilters)
 }
 
 func GetDedicatedCeph(_ *cobra.Command, args []string) {
-	common.ManageObjectRequest("/dedicated/ceph", args[0], dedicatedcephTemplate)
+	common.ManageObjectRequest("/v1/dedicated/ceph", args[0], dedicatedcephTemplate)
 }
 
 func EditDedicatedCeph(cmd *cobra.Command, args []string) {
 	if err := common.EditResource(
 		cmd,
 		"/dedicated/ceph/{serviceName}",
-		fmt.Sprintf("/dedicated/ceph/%s", url.PathEscape(args[0])),
+		fmt.Sprintf("/v1/dedicated/ceph/%s", url.PathEscape(args[0])),
 		DedicatedCephSpec,
 		assets.DedicatedcephOpenapiSchema,
 	); err != nil {

--- a/internal/services/dedicatedcloud/dedicatedcloud.go
+++ b/internal/services/dedicatedcloud/dedicatedcloud.go
@@ -20,9 +20,9 @@ var (
 )
 
 func ListDedicatedCloud(_ *cobra.Command, _ []string) {
-	common.ManageListRequest("/dedicatedCloud", "", dedicatedcloudColumnsToDisplay, flags.GenericFilters)
+	common.ManageListRequest("/v1/dedicatedCloud", "", dedicatedcloudColumnsToDisplay, flags.GenericFilters)
 }
 
 func GetDedicatedCloud(_ *cobra.Command, args []string) {
-	common.ManageObjectRequest("/dedicatedCloud", args[0], dedicatedcloudTemplate)
+	common.ManageObjectRequest("/v1/dedicatedCloud", args[0], dedicatedcloudTemplate)
 }

--- a/internal/services/dedicatedcluster/dedicatedcluster.go
+++ b/internal/services/dedicatedcluster/dedicatedcluster.go
@@ -20,9 +20,9 @@ var (
 )
 
 func ListDedicatedCluster(_ *cobra.Command, _ []string) {
-	common.ManageListRequest("/dedicated/cluster", "", dedicatedclusterColumnsToDisplay, flags.GenericFilters)
+	common.ManageListRequest("/v1/dedicated/cluster", "", dedicatedclusterColumnsToDisplay, flags.GenericFilters)
 }
 
 func GetDedicatedCluster(_ *cobra.Command, args []string) {
-	common.ManageObjectRequest("/dedicated/cluster", args[0], dedicatedclusterTemplate)
+	common.ManageObjectRequest("/v1/dedicated/cluster", args[0], dedicatedclusterTemplate)
 }

--- a/internal/services/dedicatednasha/dedicatednasha.go
+++ b/internal/services/dedicatednasha/dedicatednasha.go
@@ -29,18 +29,18 @@ var (
 )
 
 func ListDedicatedNasHA(_ *cobra.Command, _ []string) {
-	common.ManageListRequest("/dedicated/nasha", "", dedicatednashaColumnsToDisplay, flags.GenericFilters)
+	common.ManageListRequest("/v1/dedicated/nasha", "", dedicatednashaColumnsToDisplay, flags.GenericFilters)
 }
 
 func GetDedicatedNasHA(_ *cobra.Command, args []string) {
-	common.ManageObjectRequest("/dedicated/nasha", args[0], dedicatednashaTemplate)
+	common.ManageObjectRequest("/v1/dedicated/nasha", args[0], dedicatednashaTemplate)
 }
 
 func EditDedicatedNasHA(cmd *cobra.Command, args []string) {
 	if err := common.EditResource(
 		cmd,
 		"/dedicated/nasha/{serviceName}",
-		fmt.Sprintf("/dedicated/nasha/%s", url.PathEscape(args[0])),
+		fmt.Sprintf("/v1/dedicated/nasha/%s", url.PathEscape(args[0])),
 		DedicatedNasHASpec,
 		assets.DedicatednashaOpenapiSchema,
 	); err != nil {

--- a/internal/services/domainname/domainname.go
+++ b/internal/services/domainname/domainname.go
@@ -29,18 +29,18 @@ var (
 )
 
 func ListDomainName(_ *cobra.Command, _ []string) {
-	common.ManageListRequest("/domain", "", domainnameColumnsToDisplay, flags.GenericFilters)
+	common.ManageListRequest("/v1/domain", "", domainnameColumnsToDisplay, flags.GenericFilters)
 }
 
 func GetDomainName(_ *cobra.Command, args []string) {
-	common.ManageObjectRequest("/domain", args[0], domainnameTemplate)
+	common.ManageObjectRequest("/v1/domain", args[0], domainnameTemplate)
 }
 
 func EditDomainName(cmd *cobra.Command, args []string) {
 	if err := common.EditResource(
 		cmd,
 		"/domain/{serviceName}",
-		fmt.Sprintf("/domain/%s", url.PathEscape(args[0])),
+		fmt.Sprintf("/v1/domain/%s", url.PathEscape(args[0])),
 		DomainSpec,
 		assets.DomainOpenapiSchema,
 	); err != nil {

--- a/internal/services/domainzone/domainzone.go
+++ b/internal/services/domainzone/domainzone.go
@@ -34,11 +34,11 @@ var (
 )
 
 func ListDomainZone(_ *cobra.Command, _ []string) {
-	common.ManageListRequest("/domain/zone", "", domainzoneColumnsToDisplay, flags.GenericFilters)
+	common.ManageListRequest("/v1/domain/zone", "", domainzoneColumnsToDisplay, flags.GenericFilters)
 }
 
 func GetDomainZone(_ *cobra.Command, args []string) {
-	path := fmt.Sprintf("/domain/zone/%s", url.PathEscape(args[0]))
+	path := fmt.Sprintf("/v1/domain/zone/%s", url.PathEscape(args[0]))
 
 	// Fetch domain zone
 	var object map[string]any
@@ -48,7 +48,7 @@ func GetDomainZone(_ *cobra.Command, args []string) {
 	}
 
 	// Fetch running tasks
-	path = fmt.Sprintf("/domain/zone/%s/record", url.PathEscape(args[0]))
+	path = fmt.Sprintf("/v1/domain/zone/%s/record", url.PathEscape(args[0]))
 	records, err := httpLib.FetchExpandedArray(path, "")
 	if err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "error fetching records for %s: %s", args[0], err)
@@ -60,12 +60,12 @@ func GetDomainZone(_ *cobra.Command, args []string) {
 }
 
 func GetRecord(_ *cobra.Command, args []string) {
-	path := fmt.Sprintf("/domain/zone/%s/record", url.PathEscape(args[0]))
+	path := fmt.Sprintf("/v1/domain/zone/%s/record", url.PathEscape(args[0]))
 	common.ManageObjectRequest(path, args[1], "")
 }
 
 func RefreshZone(_ *cobra.Command, args []string) {
-	path := fmt.Sprintf("/domain/zone/%s/refresh", url.PathEscape(args[0]))
+	path := fmt.Sprintf("/v1/domain/zone/%s/refresh", url.PathEscape(args[0]))
 
 	if err := httpLib.Client.Post(path, nil, nil); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "error refreshing zone %s: %s", path, err)
@@ -83,7 +83,7 @@ func UpdateRecord(cmd *cobra.Command, args []string) {
 	if err := common.EditResource(
 		cmd,
 		"/domain/zone/{zoneName}/record/{id}",
-		fmt.Sprintf("/domain/zone/%s/record/%s", url.PathEscape(args[0]), url.PathEscape(args[1])),
+		fmt.Sprintf("/v1/domain/zone/%s/record/%s", url.PathEscape(args[0]), url.PathEscape(args[1])),
 		UpdateRecordSpec,
 		assets.DomainOpenapiSchema,
 	); err != nil {

--- a/internal/services/emaildomain/emaildomain.go
+++ b/internal/services/emaildomain/emaildomain.go
@@ -20,9 +20,9 @@ var (
 )
 
 func ListEmailDomain(_ *cobra.Command, _ []string) {
-	common.ManageListRequest("/email/domain", "", emaildomainColumnsToDisplay, flags.GenericFilters)
+	common.ManageListRequest("/v1/email/domain", "", emaildomainColumnsToDisplay, flags.GenericFilters)
 }
 
 func GetEmailDomain(_ *cobra.Command, args []string) {
-	common.ManageObjectRequest("/email/domain", args[0], emaildomainTemplate)
+	common.ManageObjectRequest("/v1/email/domain", args[0], emaildomainTemplate)
 }

--- a/internal/services/emailmxplan/emailmxplan.go
+++ b/internal/services/emailmxplan/emailmxplan.go
@@ -46,18 +46,18 @@ var (
 )
 
 func ListEmailMXPlan(_ *cobra.Command, _ []string) {
-	common.ManageListRequest("/email/mxplan", "", emailmxplanColumnsToDisplay, flags.GenericFilters)
+	common.ManageListRequest("/v1/email/mxplan", "", emailmxplanColumnsToDisplay, flags.GenericFilters)
 }
 
 func GetEmailMXPlan(_ *cobra.Command, args []string) {
-	common.ManageObjectRequest("/email/mxplan", args[0], emailmxplanTemplate)
+	common.ManageObjectRequest("/v1/email/mxplan", args[0], emailmxplanTemplate)
 }
 
 func EditEmailMXPlan(cmd *cobra.Command, args []string) {
 	if err := common.EditResource(
 		cmd,
 		"/email/mxplan/{service}",
-		fmt.Sprintf("/email/mxplan/%s", url.PathEscape(args[0])),
+		fmt.Sprintf("/v1/email/mxplan/%s", url.PathEscape(args[0])),
 		EmailMXPlanSpec,
 		assets.EmailmxplanOpenapiSchema,
 	); err != nil {

--- a/internal/services/emailpro/emailpro.go
+++ b/internal/services/emailpro/emailpro.go
@@ -46,18 +46,18 @@ var (
 )
 
 func ListEmailPro(_ *cobra.Command, _ []string) {
-	common.ManageListRequest("/email/pro", "", emailproColumnsToDisplay, flags.GenericFilters)
+	common.ManageListRequest("/v1/email/pro", "", emailproColumnsToDisplay, flags.GenericFilters)
 }
 
 func GetEmailPro(_ *cobra.Command, args []string) {
-	common.ManageObjectRequest("/email/pro", args[0], emailproTemplate)
+	common.ManageObjectRequest("/v1/email/pro", args[0], emailproTemplate)
 }
 
 func EditEmailPro(cmd *cobra.Command, args []string) {
 	if err := common.EditResource(
 		cmd,
 		"/email/pro/{service}",
-		fmt.Sprintf("/email/pro/%s", url.PathEscape(args[0])),
+		fmt.Sprintf("/v1/email/pro/%s", url.PathEscape(args[0])),
 		EmailProSpec,
 		assets.EmailproOpenapiSchema,
 	); err != nil {

--- a/internal/services/hostingprivatedatabase/hostingprivatedatabase.go
+++ b/internal/services/hostingprivatedatabase/hostingprivatedatabase.go
@@ -27,18 +27,18 @@ var (
 )
 
 func ListHostingPrivateDatabase(_ *cobra.Command, _ []string) {
-	common.ManageListRequest("/hosting/privateDatabase", "", hostingprivatedatabaseColumnsToDisplay, flags.GenericFilters)
+	common.ManageListRequest("/v1/hosting/privateDatabase", "", hostingprivatedatabaseColumnsToDisplay, flags.GenericFilters)
 }
 
 func GetHostingPrivateDatabase(_ *cobra.Command, args []string) {
-	common.ManageObjectRequest("/hosting/privateDatabase", args[0], hostingprivatedatabaseTemplate)
+	common.ManageObjectRequest("/v1/hosting/privateDatabase", args[0], hostingprivatedatabaseTemplate)
 }
 
 func EditHostingPrivateDatabase(cmd *cobra.Command, args []string) {
 	if err := common.EditResource(
 		cmd,
 		"/hosting/privateDatabase/{serviceName}",
-		fmt.Sprintf("/hosting/privateDatabase/%s", url.PathEscape(args[0])),
+		fmt.Sprintf("/v1/hosting/privateDatabase/%s", url.PathEscape(args[0])),
 		map[string]any{
 			"displayName": HostingPrivateDatabaseDisplayName,
 		},

--- a/internal/services/iam/iam.go
+++ b/internal/services/iam/iam.go
@@ -249,18 +249,18 @@ func prepareIAMPermissionsFromCLI() {
 }
 
 func ListUsers(_ *cobra.Command, _ []string) {
-	common.ManageListRequest("/me/identity/user", "", []string{"login", "group", "description"}, flags.GenericFilters)
+	common.ManageListRequest("/v1/me/identity/user", "", []string{"login", "group", "description"}, flags.GenericFilters)
 }
 
 func GetUser(_ *cobra.Command, args []string) {
-	common.ManageObjectRequest("/me/identity/user", args[0], "")
+	common.ManageObjectRequest("/v1/me/identity/user", args[0], "")
 }
 
 func CreateUser(cmd *cobra.Command, _ []string) {
 	_, err := common.CreateResource(
 		cmd,
 		"/me/identity/user",
-		"/me/identity/user",
+		"/v1/me/identity/user",
 		UserCreateExample,
 		UserSpec,
 		assets.MeOpenapiSchema,
@@ -277,7 +277,7 @@ func EditUser(cmd *cobra.Command, args []string) {
 	if err := common.EditResource(
 		cmd,
 		"/me/identity/user/{user}",
-		fmt.Sprintf("/me/identity/user/%s", url.PathEscape(args[0])),
+		fmt.Sprintf("/v1/me/identity/user/%s", url.PathEscape(args[0])),
 		UserSpec,
 		assets.MeOpenapiSchema,
 	); err != nil {
@@ -287,7 +287,7 @@ func EditUser(cmd *cobra.Command, args []string) {
 }
 
 func DeleteUser(_ *cobra.Command, args []string) {
-	endpoint := fmt.Sprintf("/me/identity/user/%s", url.PathEscape(args[0]))
+	endpoint := fmt.Sprintf("/v1/me/identity/user/%s", url.PathEscape(args[0]))
 	if err := httpLib.Client.Delete(endpoint, nil); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "failed to delete user %s: %s", args[0], err)
 		return
@@ -297,12 +297,12 @@ func DeleteUser(_ *cobra.Command, args []string) {
 }
 
 func ListUserTokens(_ *cobra.Command, args []string) {
-	endpoint := fmt.Sprintf("/me/identity/user/%s/token", url.PathEscape(args[0]))
+	endpoint := fmt.Sprintf("/v1/me/identity/user/%s/token", url.PathEscape(args[0]))
 	common.ManageListRequest(endpoint, "", []string{"name", "description", "expiresAt"}, flags.GenericFilters)
 }
 
 func GetUserToken(_ *cobra.Command, args []string) {
-	endpoint := fmt.Sprintf("/me/identity/user/%s/token", url.PathEscape(args[0]))
+	endpoint := fmt.Sprintf("/v1/me/identity/user/%s/token", url.PathEscape(args[0]))
 	common.ManageObjectRequest(endpoint, args[1], "")
 }
 
@@ -310,7 +310,7 @@ func CreateUserToken(cmd *cobra.Command, args []string) {
 	token, err := common.CreateResource(
 		cmd,
 		"/me/identity/user/{user}/token",
-		fmt.Sprintf("/me/identity/user/%s/token", url.PathEscape(args[0])),
+		fmt.Sprintf("/v1/me/identity/user/%s/token", url.PathEscape(args[0])),
 		TokenCreateExample,
 		TokenSpec,
 		assets.MeOpenapiSchema,
@@ -324,7 +324,7 @@ func CreateUserToken(cmd *cobra.Command, args []string) {
 }
 
 func DeleteUserToken(_ *cobra.Command, args []string) {
-	endpoint := fmt.Sprintf("/me/identity/user/%s/token/%s", url.PathEscape(args[0]), url.PathEscape(args[1]))
+	endpoint := fmt.Sprintf("/v1/me/identity/user/%s/token/%s", url.PathEscape(args[0]), url.PathEscape(args[1]))
 	if err := httpLib.Client.Delete(endpoint, nil); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "failed to delete token %s for user %s: %s", args[1], args[0], err)
 		return

--- a/internal/services/ip/ip.go
+++ b/internal/services/ip/ip.go
@@ -29,18 +29,18 @@ var (
 )
 
 func ListIp(_ *cobra.Command, _ []string) {
-	common.ManageListRequest("/ip", "", ipColumnsToDisplay, flags.GenericFilters)
+	common.ManageListRequest("/v1/ip", "", ipColumnsToDisplay, flags.GenericFilters)
 }
 
 func GetIp(_ *cobra.Command, args []string) {
-	common.ManageObjectRequest("/ip", args[0], ipTemplate)
+	common.ManageObjectRequest("/v1/ip", args[0], ipTemplate)
 }
 
 func EditIp(cmd *cobra.Command, args []string) {
 	if err := common.EditResource(
 		cmd,
 		"/ip/{ip}",
-		fmt.Sprintf("/ip/%s", url.PathEscape(args[0])),
+		fmt.Sprintf("/v1/ip/%s", url.PathEscape(args[0])),
 		IPSpec,
 		assets.IpOpenapiSchema,
 	); err != nil {
@@ -50,7 +50,7 @@ func EditIp(cmd *cobra.Command, args []string) {
 }
 
 func IpSetReverse(_ *cobra.Command, args []string) {
-	url := fmt.Sprintf("/ip/%s/reverse", url.PathEscape(args[0]))
+	url := fmt.Sprintf("/v1/ip/%s/reverse", url.PathEscape(args[0]))
 	if err := httpLib.Client.Post(url, map[string]string{
 		"ipReverse": args[1],
 		"reverse":   args[2],
@@ -63,12 +63,12 @@ func IpSetReverse(_ *cobra.Command, args []string) {
 }
 
 func IpGetReverse(_ *cobra.Command, args []string) {
-	url := fmt.Sprintf("/ip/%s/reverse", url.PathEscape(args[0]))
+	url := fmt.Sprintf("/v1/ip/%s/reverse", url.PathEscape(args[0]))
 	common.ManageListRequest(url, "", []string{"ipReverse", "reverse"}, flags.GenericFilters)
 }
 
 func IpDeleteReverse(_ *cobra.Command, args []string) {
-	url := fmt.Sprintf("/ip/%s/reverse/%s", url.PathEscape(args[0]), url.PathEscape(args[1]))
+	url := fmt.Sprintf("/v1/ip/%s/reverse/%s", url.PathEscape(args[0]), url.PathEscape(args[1]))
 	if err := httpLib.Client.Delete(url, nil); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return

--- a/internal/services/iploadbalancing/iploadbalancing.go
+++ b/internal/services/iploadbalancing/iploadbalancing.go
@@ -29,18 +29,18 @@ var (
 )
 
 func ListIpLoadbalancing(_ *cobra.Command, _ []string) {
-	common.ManageListRequest("/ipLoadbalancing", "", iploadbalancingColumnsToDisplay, flags.GenericFilters)
+	common.ManageListRequest("/v1/ipLoadbalancing", "", iploadbalancingColumnsToDisplay, flags.GenericFilters)
 }
 
 func GetIpLoadbalancing(_ *cobra.Command, args []string) {
-	common.ManageObjectRequest("/ipLoadbalancing", args[0], iploadbalancingTemplate)
+	common.ManageObjectRequest("/v1/ipLoadbalancing", args[0], iploadbalancingTemplate)
 }
 
 func EditIpLoadbalancing(cmd *cobra.Command, args []string) {
 	if err := common.EditResource(
 		cmd,
 		"/ipLoadbalancing/{serviceName}",
-		fmt.Sprintf("/ipLoadbalancing/%s", url.PathEscape(args[0])),
+		fmt.Sprintf("/v1/ipLoadbalancing/%s", url.PathEscape(args[0])),
 		IPLoadbalancingSpec,
 		assets.IploadbalancingOpenapiSchema,
 	); err != nil {

--- a/internal/services/ldp/ldp.go
+++ b/internal/services/ldp/ldp.go
@@ -29,18 +29,18 @@ var (
 )
 
 func ListLdp(_ *cobra.Command, _ []string) {
-	common.ManageListRequest("/dbaas/logs", "", ldpColumnsToDisplay, flags.GenericFilters)
+	common.ManageListRequest("/v1/dbaas/logs", "", ldpColumnsToDisplay, flags.GenericFilters)
 }
 
 func GetLdp(_ *cobra.Command, args []string) {
-	common.ManageObjectRequest("/dbaas/logs", args[0], ldpTemplate)
+	common.ManageObjectRequest("/v1/dbaas/logs", args[0], ldpTemplate)
 }
 
 func EditLdp(cmd *cobra.Command, args []string) {
 	if err := common.EditResource(
 		cmd,
 		"/dbaas/logs/{serviceName}",
-		fmt.Sprintf("/dbaas/logs/%s", url.PathEscape(args[0])),
+		fmt.Sprintf("/v1/dbaas/logs/%s", url.PathEscape(args[0])),
 		LdpSpec,
 		assets.LdpOpenapiSchema,
 	); err != nil {

--- a/internal/services/nutanix/nutanix.go
+++ b/internal/services/nutanix/nutanix.go
@@ -20,9 +20,9 @@ var (
 )
 
 func ListNutanix(_ *cobra.Command, _ []string) {
-	common.ManageListRequest("/nutanix", "", nutanixColumnsToDisplay, flags.GenericFilters)
+	common.ManageListRequest("/v1/nutanix", "", nutanixColumnsToDisplay, flags.GenericFilters)
 }
 
 func GetNutanix(_ *cobra.Command, args []string) {
-	common.ManageObjectRequest("/nutanix", args[0], nutanixTemplate)
+	common.ManageObjectRequest("/v1/nutanix", args[0], nutanixTemplate)
 }

--- a/internal/services/overthebox/overthebox.go
+++ b/internal/services/overthebox/overthebox.go
@@ -30,18 +30,18 @@ var (
 )
 
 func ListOverTheBox(_ *cobra.Command, _ []string) {
-	common.ManageListRequest("/overTheBox", "", overtheboxColumnsToDisplay, flags.GenericFilters)
+	common.ManageListRequest("/v1/overTheBox", "", overtheboxColumnsToDisplay, flags.GenericFilters)
 }
 
 func GetOverTheBox(_ *cobra.Command, args []string) {
-	common.ManageObjectRequest("/overTheBox", args[0], overtheboxTemplate)
+	common.ManageObjectRequest("/v1/overTheBox", args[0], overtheboxTemplate)
 }
 
 func EditOverTheBox(cmd *cobra.Command, args []string) {
 	if err := common.EditResource(
 		cmd,
 		"/overTheBox/{serviceName}",
-		fmt.Sprintf("/overTheBox/%s", url.PathEscape(args[0])),
+		fmt.Sprintf("/v1/overTheBox/%s", url.PathEscape(args[0])),
 		OverTheBoxSpec,
 		assets.OvertheboxOpenapiSchema,
 	); err != nil {

--- a/internal/services/ovhcloudconnect/ovhcloudconnect.go
+++ b/internal/services/ovhcloudconnect/ovhcloudconnect.go
@@ -28,18 +28,18 @@ var (
 )
 
 func ListOvhCloudConnect(_ *cobra.Command, _ []string) {
-	common.ManageListRequest("/ovhCloudConnect", "", ovhcloudconnectColumnsToDisplay, flags.GenericFilters)
+	common.ManageListRequest("/v1/ovhCloudConnect", "", ovhcloudconnectColumnsToDisplay, flags.GenericFilters)
 }
 
 func GetOvhCloudConnect(_ *cobra.Command, args []string) {
-	common.ManageObjectRequest("/ovhCloudConnect", args[0], ovhcloudconnectTemplate)
+	common.ManageObjectRequest("/v1/ovhCloudConnect", args[0], ovhcloudconnectTemplate)
 }
 
 func EditOvhCloudConnect(cmd *cobra.Command, args []string) {
 	if err := common.EditResource(
 		cmd,
 		"/ovhCloudConnect/{serviceName}",
-		fmt.Sprintf("/ovhCloudConnect/%s", url.PathEscape(args[0])),
+		fmt.Sprintf("/v1/ovhCloudConnect/%s", url.PathEscape(args[0])),
 		OvhCloudConnectSpec,
 		assets.OvhcloudconnectOpenapiSchema,
 	); err != nil {

--- a/internal/services/packxdsl/packxdsl.go
+++ b/internal/services/packxdsl/packxdsl.go
@@ -28,18 +28,18 @@ var (
 )
 
 func ListPackXDSL(_ *cobra.Command, _ []string) {
-	common.ManageListRequest("/pack/xdsl", "", packxdslColumnsToDisplay, flags.GenericFilters)
+	common.ManageListRequest("/v1/pack/xdsl", "", packxdslColumnsToDisplay, flags.GenericFilters)
 }
 
 func GetPackXDSL(_ *cobra.Command, args []string) {
-	common.ManageObjectRequest("/pack/xdsl", args[0], packxdslTemplate)
+	common.ManageObjectRequest("/v1/pack/xdsl", args[0], packxdslTemplate)
 }
 
 func EditPackXDSL(cmd *cobra.Command, args []string) {
 	if err := common.EditResource(
 		cmd,
 		"/pack/xdsl/{packName}",
-		fmt.Sprintf("/pack/xdsl/%s", url.PathEscape(args[0])),
+		fmt.Sprintf("/v1/pack/xdsl/%s", url.PathEscape(args[0])),
 		PackXDSLSpec,
 		assets.PackxdslOpenapiSchema,
 	); err != nil {

--- a/internal/services/sms/sms.go
+++ b/internal/services/sms/sms.go
@@ -46,18 +46,18 @@ var (
 )
 
 func ListSms(_ *cobra.Command, _ []string) {
-	common.ManageListRequest("/sms", "", smsColumnsToDisplay, flags.GenericFilters)
+	common.ManageListRequest("/v1/sms", "", smsColumnsToDisplay, flags.GenericFilters)
 }
 
 func GetSms(_ *cobra.Command, args []string) {
-	common.ManageObjectRequest("/sms", args[0], smsTemplate)
+	common.ManageObjectRequest("/v1/sms", args[0], smsTemplate)
 }
 
 func EditSms(cmd *cobra.Command, args []string) {
 	if err := common.EditResource(
 		cmd,
 		"/sms/{serviceName}",
-		fmt.Sprintf("/sms/%s", url.PathEscape(args[0])),
+		fmt.Sprintf("/v1/sms/%s", url.PathEscape(args[0])),
 		SmsSpec,
 		assets.SmsOpenapiSchema,
 	); err != nil {

--- a/internal/services/ssl/ssl.go
+++ b/internal/services/ssl/ssl.go
@@ -20,9 +20,9 @@ var (
 )
 
 func ListSsl(_ *cobra.Command, _ []string) {
-	common.ManageListRequest("/ssl", "", sslColumnsToDisplay, flags.GenericFilters)
+	common.ManageListRequest("/v1/ssl", "", sslColumnsToDisplay, flags.GenericFilters)
 }
 
 func GetSsl(_ *cobra.Command, args []string) {
-	common.ManageObjectRequest("/ssl", args[0], sslTemplate)
+	common.ManageObjectRequest("/v1/ssl", args[0], sslTemplate)
 }

--- a/internal/services/sslgateway/sslgateway.go
+++ b/internal/services/sslgateway/sslgateway.go
@@ -34,18 +34,18 @@ var (
 )
 
 func ListSslGateway(_ *cobra.Command, _ []string) {
-	common.ManageListRequest("/sslGateway", "", sslgatewayColumnsToDisplay, flags.GenericFilters)
+	common.ManageListRequest("/v1/sslGateway", "", sslgatewayColumnsToDisplay, flags.GenericFilters)
 }
 
 func GetSslGateway(_ *cobra.Command, args []string) {
-	common.ManageObjectRequest("/sslGateway", args[0], sslgatewayTemplate)
+	common.ManageObjectRequest("/v1/sslGateway", args[0], sslgatewayTemplate)
 }
 
 func EditSslGateway(cmd *cobra.Command, args []string) {
 	if err := common.EditResource(
 		cmd,
 		"/sslGateway/{serviceName}",
-		fmt.Sprintf("/sslGateway/%s", url.PathEscape(args[0])),
+		fmt.Sprintf("/v1/sslGateway/%s", url.PathEscape(args[0])),
 		SSLGatewaySpec,
 		assets.SslgatewayOpenapiSchema,
 	); err != nil {

--- a/internal/services/storagenetapp/storagenetapp.go
+++ b/internal/services/storagenetapp/storagenetapp.go
@@ -28,18 +28,18 @@ var (
 )
 
 func ListStorageNetApp(_ *cobra.Command, _ []string) {
-	common.ManageListRequestNoExpand("/storage/netapp", storagenetappColumnsToDisplay, flags.GenericFilters)
+	common.ManageListRequestNoExpand("/v1/storage/netapp", storagenetappColumnsToDisplay, flags.GenericFilters)
 }
 
 func GetStorageNetApp(_ *cobra.Command, args []string) {
-	common.ManageObjectRequest("/storage/netapp", args[0], storagenetappTemplate)
+	common.ManageObjectRequest("/v1/storage/netapp", args[0], storagenetappTemplate)
 }
 
 func EditStorageNetApp(cmd *cobra.Command, args []string) {
 	if err := common.EditResource(
 		cmd,
 		"/storage/netapp/{serviceName}",
-		fmt.Sprintf("/storage/netapp/%s", url.PathEscape(args[0])),
+		fmt.Sprintf("/v1/storage/netapp/%s", url.PathEscape(args[0])),
 		StorageNetAppSpec,
 		assets.SmsOpenapiSchema,
 	); err != nil {

--- a/internal/services/supporttickets/supporttickets.go
+++ b/internal/services/supporttickets/supporttickets.go
@@ -20,9 +20,9 @@ var (
 )
 
 func ListSupportTickets(_ *cobra.Command, _ []string) {
-	common.ManageListRequest("/support/tickets", "", supportticketsColumnsToDisplay, flags.GenericFilters)
+	common.ManageListRequest("/v1/support/tickets", "", supportticketsColumnsToDisplay, flags.GenericFilters)
 }
 
 func GetSupportTickets(_ *cobra.Command, args []string) {
-	common.ManageObjectRequest("/support/tickets", args[0], supportticketsTemplate)
+	common.ManageObjectRequest("/v1/support/tickets", args[0], supportticketsTemplate)
 }

--- a/internal/services/telephony/telephony.go
+++ b/internal/services/telephony/telephony.go
@@ -35,18 +35,18 @@ var (
 )
 
 func ListTelephony(_ *cobra.Command, _ []string) {
-	common.ManageListRequest("/telephony", "", telephonyColumnsToDisplay, flags.GenericFilters)
+	common.ManageListRequest("/v1/telephony", "", telephonyColumnsToDisplay, flags.GenericFilters)
 }
 
 func GetTelephony(_ *cobra.Command, args []string) {
-	common.ManageObjectRequest("/telephony", args[0], telephonyTemplate)
+	common.ManageObjectRequest("/v1/telephony", args[0], telephonyTemplate)
 }
 
 func EditTelephony(cmd *cobra.Command, args []string) {
 	if err := common.EditResource(
 		cmd,
 		"/telephony/{billingAccount}",
-		fmt.Sprintf("/telephony/%s", url.PathEscape(args[0])),
+		fmt.Sprintf("/v1/telephony/%s", url.PathEscape(args[0])),
 		TelephonySpec,
 		assets.TelephonyOpenapiSchema,
 	); err != nil {

--- a/internal/services/veeamcloudconnect/veeamcloudconnect.go
+++ b/internal/services/veeamcloudconnect/veeamcloudconnect.go
@@ -20,9 +20,9 @@ var (
 )
 
 func ListVeeamCloudConnect(_ *cobra.Command, _ []string) {
-	common.ManageListRequest("/veeamCloudConnect", "", veeamcloudconnectColumnsToDisplay, flags.GenericFilters)
+	common.ManageListRequest("/v1/veeamCloudConnect", "", veeamcloudconnectColumnsToDisplay, flags.GenericFilters)
 }
 
 func GetVeeamCloudConnect(_ *cobra.Command, args []string) {
-	common.ManageObjectRequest("/veeamCloudConnect", args[0], veeamcloudconnectTemplate)
+	common.ManageObjectRequest("/v1/veeamCloudConnect", args[0], veeamcloudconnectTemplate)
 }

--- a/internal/services/veeamenterprise/veeamenterprise.go
+++ b/internal/services/veeamenterprise/veeamenterprise.go
@@ -20,9 +20,9 @@ var (
 )
 
 func ListVeeamEnterprise(_ *cobra.Command, _ []string) {
-	common.ManageListRequest("/veeam/veeamEnterprise", "", veeamenterpriseColumnsToDisplay, flags.GenericFilters)
+	common.ManageListRequest("/v1/veeam/veeamEnterprise", "", veeamenterpriseColumnsToDisplay, flags.GenericFilters)
 }
 
 func GetVeeamEnterprise(_ *cobra.Command, args []string) {
-	common.ManageObjectRequest("/veeam/veeamEnterprise", args[0], veeamenterpriseTemplate)
+	common.ManageObjectRequest("/v1/veeam/veeamEnterprise", args[0], veeamenterpriseTemplate)
 }

--- a/internal/services/vps/utils.go
+++ b/internal/services/vps/utils.go
@@ -28,7 +28,7 @@ func waitForVpsTask(serviceName string, taskInput map[string]any, retryDuration 
 		return nil, fmt.Errorf("task ID is not a valid JSON number: %v", id)
 	}
 
-	endpoint := fmt.Sprintf("/vps/%s/tasks/%s", url.PathEscape(serviceName), url.PathEscape(string(taskID)))
+	endpoint := fmt.Sprintf("/v1/vps/%s/tasks/%s", url.PathEscape(serviceName), url.PathEscape(string(taskID)))
 
 	ctx, cancel := context.WithTimeout(context.Background(), retryDuration)
 	defer cancel()
@@ -60,7 +60,7 @@ func waitForVpsTask(serviceName string, taskInput map[string]any, retryDuration 
 }
 
 func getAvailableImages(serviceName string) (map[string]string, error) {
-	endpoint := fmt.Sprintf("/vps/%s/images/available", url.PathEscape(serviceName))
+	endpoint := fmt.Sprintf("/v1/vps/%s/images/available", url.PathEscape(serviceName))
 
 	images, err := httpLib.FetchExpandedArray(endpoint, "")
 	if err != nil {
@@ -95,7 +95,7 @@ func runImageSelector(serviceName string) (string, string, error) {
 }
 
 func runSSHKeySelector() (string, string, error) {
-	endpoint := "/me/sshKey"
+	endpoint := "/v1/me/sshKey"
 
 	keys, err := httpLib.FetchExpandedArray(endpoint, "")
 	if err != nil {

--- a/internal/services/vps/vps.go
+++ b/internal/services/vps/vps.go
@@ -82,11 +82,11 @@ var (
 )
 
 func ListVps(_ *cobra.Command, _ []string) {
-	common.ManageListRequest("/vps", "", vpsColumnsToDisplay, flags.GenericFilters)
+	common.ManageListRequest("/v1/vps", "", vpsColumnsToDisplay, flags.GenericFilters)
 }
 
 func GetVps(_ *cobra.Command, args []string) {
-	endpoint := fmt.Sprintf("/vps/%s", url.PathEscape(args[0]))
+	endpoint := fmt.Sprintf("/v1/vps/%s", url.PathEscape(args[0]))
 
 	var object map[string]any
 	if err := httpLib.Client.Get(endpoint, &object); err != nil {
@@ -109,7 +109,7 @@ func EditVps(cmd *cobra.Command, args []string) {
 	if err := common.EditResource(
 		cmd,
 		"/vps/{serviceName}",
-		fmt.Sprintf("/vps/%s", url.PathEscape(args[0])),
+		fmt.Sprintf("/v1/vps/%s", url.PathEscape(args[0])),
 		VpsSpec,
 		assets.VpsOpenapiSchema,
 	); err != nil {
@@ -119,7 +119,7 @@ func EditVps(cmd *cobra.Command, args []string) {
 }
 
 func GetVpsSnapshot(_ *cobra.Command, args []string) {
-	endpoint := fmt.Sprintf("/vps/%s/snapshot", url.PathEscape(args[0]))
+	endpoint := fmt.Sprintf("/v1/vps/%s/snapshot", url.PathEscape(args[0]))
 
 	var object map[string]any
 	if err := httpLib.Client.Get(endpoint, &object); err != nil {
@@ -138,7 +138,7 @@ func EditVpsSnapshot(cmd *cobra.Command, args []string) {
 	if err := common.EditResource(
 		cmd,
 		"/vps/{serviceName}/snapshot",
-		fmt.Sprintf("/vps/%s/snapshot", url.PathEscape(args[0])),
+		fmt.Sprintf("/v1/vps/%s/snapshot", url.PathEscape(args[0])),
 		VpsSnapshotSpec,
 		assets.VpsOpenapiSchema,
 	); err != nil {
@@ -148,7 +148,7 @@ func EditVpsSnapshot(cmd *cobra.Command, args []string) {
 }
 
 func CreateVpsSnapshot(_ *cobra.Command, args []string) {
-	endpoint := fmt.Sprintf("/vps/%s/createSnapshot", url.PathEscape(args[0]))
+	endpoint := fmt.Sprintf("/v1/vps/%s/createSnapshot", url.PathEscape(args[0]))
 
 	if err := httpLib.Client.Post(endpoint, VpsSnapshotSpec, nil); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "error creating snapshot for %s: %s", args[0], err)
@@ -159,7 +159,7 @@ func CreateVpsSnapshot(_ *cobra.Command, args []string) {
 }
 
 func DeleteVpsSnapshot(_ *cobra.Command, args []string) {
-	endpoint := fmt.Sprintf("/vps/%s/snapshot", url.PathEscape(args[0]))
+	endpoint := fmt.Sprintf("/v1/vps/%s/snapshot", url.PathEscape(args[0]))
 
 	if err := httpLib.Client.Delete(endpoint, nil); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "error deleting snapshot for %s: %s", args[0], err)
@@ -170,7 +170,7 @@ func DeleteVpsSnapshot(_ *cobra.Command, args []string) {
 }
 
 func AbortVpsSnapshot(_ *cobra.Command, args []string) {
-	endpoint := fmt.Sprintf("/vps/%s/abortSnapshot", url.PathEscape(args[0]))
+	endpoint := fmt.Sprintf("/v1/vps/%s/abortSnapshot", url.PathEscape(args[0]))
 
 	if err := httpLib.Client.Post(endpoint, nil, nil); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "error aborting snapshot for %s: %s", args[0], err)
@@ -181,7 +181,7 @@ func AbortVpsSnapshot(_ *cobra.Command, args []string) {
 }
 
 func RestoreVpsSnapshot(_ *cobra.Command, args []string) {
-	endpoint := fmt.Sprintf("/vps/%s/snapshot/revert", url.PathEscape(args[0]))
+	endpoint := fmt.Sprintf("/v1/vps/%s/snapshot/revert", url.PathEscape(args[0]))
 
 	if err := httpLib.Client.Post(endpoint, nil, nil); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "error restoring snapshot for %s: %s", args[0], err)
@@ -192,7 +192,7 @@ func RestoreVpsSnapshot(_ *cobra.Command, args []string) {
 }
 
 func DownloadVpsSnapshot(_ *cobra.Command, args []string) {
-	endpoint := fmt.Sprintf("/vps/%s/snapshot/download", url.PathEscape(args[0]))
+	endpoint := fmt.Sprintf("/v1/vps/%s/snapshot/download", url.PathEscape(args[0]))
 
 	var response map[string]any
 	if err := httpLib.Client.Get(endpoint, &response); err != nil {
@@ -204,7 +204,7 @@ func DownloadVpsSnapshot(_ *cobra.Command, args []string) {
 }
 
 func GetVpsAutomatedBackup(_ *cobra.Command, args []string) {
-	endpoint := fmt.Sprintf("/vps/%s/automatedBackup", url.PathEscape(args[0]))
+	endpoint := fmt.Sprintf("/v1/vps/%s/automatedBackup", url.PathEscape(args[0]))
 
 	var object map[string]any
 	if err := httpLib.Client.Get(endpoint, &object); err != nil {
@@ -220,12 +220,12 @@ func GetVpsAutomatedBackup(_ *cobra.Command, args []string) {
 }
 
 func ListVpsAutomatedBackups(_ *cobra.Command, args []string) {
-	endpoint := fmt.Sprintf("/vps/%s/automatedBackup/attachedBackup", url.PathEscape(args[0]))
+	endpoint := fmt.Sprintf("/v1/vps/%s/automatedBackup/attachedBackup", url.PathEscape(args[0]))
 	common.ManageListRequestNoExpand(endpoint, []string{"restorePoint"}, flags.GenericFilters)
 }
 
 func DetachVpsAutomatedBackup(_ *cobra.Command, args []string) {
-	endpoint := fmt.Sprintf("/vps/%s/automatedBackup/detachBackup", url.PathEscape(args[0]))
+	endpoint := fmt.Sprintf("/v1/vps/%s/automatedBackup/detachBackup", url.PathEscape(args[0]))
 	body := map[string]any{
 		"restorePoint": args[1],
 	}
@@ -239,7 +239,7 @@ func DetachVpsAutomatedBackup(_ *cobra.Command, args []string) {
 }
 
 func RescheduleVpsAutomatedBackup(_ *cobra.Command, args []string) {
-	endpoint := fmt.Sprintf("/vps/%s/automatedBackup/reschedule", url.PathEscape(args[0]))
+	endpoint := fmt.Sprintf("/v1/vps/%s/automatedBackup/reschedule", url.PathEscape(args[0]))
 	body := map[string]any{
 		"schedule": args[1],
 	}
@@ -253,7 +253,7 @@ func RescheduleVpsAutomatedBackup(_ *cobra.Command, args []string) {
 }
 
 func RestoreVpsAutomatedBackup(_ *cobra.Command, args []string) {
-	endpoint := fmt.Sprintf("/vps/%s/automatedBackup/restore", url.PathEscape(args[0]))
+	endpoint := fmt.Sprintf("/v1/vps/%s/automatedBackup/restore", url.PathEscape(args[0]))
 	if err := httpLib.Client.Post(endpoint, VpsSnapshotRestoreSpec, nil); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "error restoring automated backup for %s: %s", args[0], err)
 		return
@@ -263,7 +263,7 @@ func RestoreVpsAutomatedBackup(_ *cobra.Command, args []string) {
 }
 
 func ListVpsAutomatedBackupRestorePoints(_ *cobra.Command, args []string) {
-	endpoint := fmt.Sprintf("/vps/%s/automatedBackup/restorePoints?state=%s", url.PathEscape(args[0]), url.QueryEscape(VpsBackupRestorePointsState))
+	endpoint := fmt.Sprintf("/v1/vps/%s/automatedBackup/restorePoints?state=%s", url.PathEscape(args[0]), url.QueryEscape(VpsBackupRestorePointsState))
 
 	var restorePoints []string
 	if err := httpLib.Client.Get(endpoint, &restorePoints); err != nil {
@@ -282,12 +282,12 @@ func ListVpsAutomatedBackupRestorePoints(_ *cobra.Command, args []string) {
 }
 
 func ListVpsAvailableUpgrades(_ *cobra.Command, args []string) {
-	endpoint := fmt.Sprintf("/vps/%s/availableUpgrade", url.PathEscape(args[0]))
+	endpoint := fmt.Sprintf("/v1/vps/%s/availableUpgrade", url.PathEscape(args[0]))
 	common.ManageListRequestNoExpand(endpoint, []string{"name", "offer", "vcore", "memory", "disk"}, flags.GenericFilters)
 }
 
 func ChangeVpsContacts(_ *cobra.Command, args []string) {
-	endpoint := fmt.Sprintf("/vps/%s/changeContact", url.PathEscape(args[0]))
+	endpoint := fmt.Sprintf("/v1/vps/%s/changeContact", url.PathEscape(args[0]))
 
 	if err := httpLib.Client.Post(endpoint, VpsContacts, nil); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "error changing contacts for %s: %s", args[0], err)
@@ -298,7 +298,7 @@ func ChangeVpsContacts(_ *cobra.Command, args []string) {
 }
 
 func GetVpsServiceInfo(_ *cobra.Command, args []string) {
-	endpoint := fmt.Sprintf("/vps/%s/serviceInfos", url.PathEscape(args[0]))
+	endpoint := fmt.Sprintf("/v1/vps/%s/serviceInfos", url.PathEscape(args[0]))
 
 	var object map[string]any
 	if err := httpLib.Client.Get(endpoint, &object); err != nil {
@@ -313,7 +313,7 @@ func EditVpsServiceInfo(cmd *cobra.Command, args []string) {
 	if err := common.EditResource(
 		cmd,
 		"/vps/{serviceName}/serviceInfos",
-		fmt.Sprintf("/vps/%s/serviceInfos", url.PathEscape(args[0])),
+		fmt.Sprintf("/v1/vps/%s/serviceInfos", url.PathEscape(args[0])),
 		common.ServiceInfoSpec,
 		assets.VpsOpenapiSchema,
 	); err != nil {
@@ -323,7 +323,7 @@ func EditVpsServiceInfo(cmd *cobra.Command, args []string) {
 }
 
 func TerminateVps(_ *cobra.Command, args []string) {
-	endpoint := fmt.Sprintf("/vps/%s/terminate", url.PathEscape(args[0]))
+	endpoint := fmt.Sprintf("/v1/vps/%s/terminate", url.PathEscape(args[0]))
 
 	var response string
 	if err := httpLib.Client.Post(endpoint, nil, &response); err != nil {
@@ -335,7 +335,7 @@ func TerminateVps(_ *cobra.Command, args []string) {
 }
 
 func ConfirmVpsTermination(_ *cobra.Command, args []string) {
-	endpoint := fmt.Sprintf("/vps/%s/confirmTermination", url.PathEscape(args[0]))
+	endpoint := fmt.Sprintf("/v1/vps/%s/confirmTermination", url.PathEscape(args[0]))
 
 	body := map[string]any{
 		"token": args[1],
@@ -350,19 +350,19 @@ func ConfirmVpsTermination(_ *cobra.Command, args []string) {
 }
 
 func ListVpsDisks(_ *cobra.Command, args []string) {
-	endpoint := fmt.Sprintf("/vps/%s/disks", url.PathEscape(args[0]))
+	endpoint := fmt.Sprintf("/v1/vps/%s/disks", url.PathEscape(args[0]))
 	common.ManageListRequest(endpoint, "", []string{"id", "serviceName", "size", "type", "state"}, flags.GenericFilters)
 }
 
 func GetVpsDisk(_ *cobra.Command, args []string) {
-	common.ManageObjectRequest(fmt.Sprintf("/vps/%s/disks", url.PathEscape(args[0])), args[1], "")
+	common.ManageObjectRequest(fmt.Sprintf("/v1/vps/%s/disks", url.PathEscape(args[0])), args[1], "")
 }
 
 func EditVpsDisk(cmd *cobra.Command, args []string) {
 	if err := common.EditResource(
 		cmd,
 		"/vps/{serviceName}/disks/{id}",
-		fmt.Sprintf("/vps/%s/disks/%s", url.PathEscape(args[0]), url.PathEscape(args[1])),
+		fmt.Sprintf("/v1/vps/%s/disks/%s", url.PathEscape(args[0]), url.PathEscape(args[1])),
 		VpsDiskSpec,
 		assets.VpsOpenapiSchema,
 	); err != nil {
@@ -372,7 +372,7 @@ func EditVpsDisk(cmd *cobra.Command, args []string) {
 }
 
 func VpsGetConsoleURL(_ *cobra.Command, args []string) {
-	endpoint := fmt.Sprintf("/vps/%s/getConsoleUrl", url.PathEscape(args[0]))
+	endpoint := fmt.Sprintf("/v1/vps/%s/getConsoleUrl", url.PathEscape(args[0]))
 
 	var consoleURL string
 	if err := httpLib.Client.Post(endpoint, nil, &consoleURL); err != nil {
@@ -384,7 +384,7 @@ func VpsGetConsoleURL(_ *cobra.Command, args []string) {
 }
 
 func GetVpsImages(_ *cobra.Command, args []string) {
-	endpoint := fmt.Sprintf("/vps/%s/images/available", url.PathEscape(args[0]))
+	endpoint := fmt.Sprintf("/v1/vps/%s/images/available", url.PathEscape(args[0]))
 
 	// Fetch available images
 	body, err := httpLib.FetchExpandedArray(endpoint, "")
@@ -404,7 +404,7 @@ func GetVpsImages(_ *cobra.Command, args []string) {
 
 	// Fetch current image
 	var current map[string]any
-	endpoint = fmt.Sprintf("/vps/%s/images/current", url.PathEscape(args[0]))
+	endpoint = fmt.Sprintf("/v1/vps/%s/images/current", url.PathEscape(args[0]))
 	if err := httpLib.Client.Get(endpoint, &current); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "failed to fetch current image: %s", err)
 		return
@@ -418,12 +418,12 @@ func GetVpsImages(_ *cobra.Command, args []string) {
 }
 
 func ListVpsIPs(_ *cobra.Command, args []string) {
-	endpoint := fmt.Sprintf("/vps/%s/ips", url.PathEscape(args[0]))
+	endpoint := fmt.Sprintf("/v1/vps/%s/ips", url.PathEscape(args[0]))
 	common.ManageListRequest(endpoint, "", []string{"ipAddress", "reverse", "type", "geolocation", "gateway", "macAddress"}, flags.GenericFilters)
 }
 
 func SetVpsIPReverse(_ *cobra.Command, args []string) {
-	endpoint := fmt.Sprintf("/vps/%s/ips/%s", url.PathEscape(args[0]), url.PathEscape(args[1]))
+	endpoint := fmt.Sprintf("/v1/vps/%s/ips/%s", url.PathEscape(args[0]), url.PathEscape(args[1]))
 
 	body := map[string]any{
 		"reverse": args[2],
@@ -438,7 +438,7 @@ func SetVpsIPReverse(_ *cobra.Command, args []string) {
 }
 
 func ReleaseVpsIP(_ *cobra.Command, args []string) {
-	endpoint := fmt.Sprintf("/vps/%s/ips/%s", url.PathEscape(args[0]), url.PathEscape(args[1]))
+	endpoint := fmt.Sprintf("/v1/vps/%s/ips/%s", url.PathEscape(args[0]), url.PathEscape(args[1]))
 
 	if err := httpLib.Client.Delete(endpoint, nil); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "error releasing IP %s: %s", args[1], err)
@@ -449,12 +449,12 @@ func ReleaseVpsIP(_ *cobra.Command, args []string) {
 }
 
 func ListVPSOptions(_ *cobra.Command, args []string) {
-	endpoint := fmt.Sprintf("/vps/%s/option", url.PathEscape(args[0]))
+	endpoint := fmt.Sprintf("/v1/vps/%s/option", url.PathEscape(args[0]))
 	common.ManageListRequest(endpoint, "", []string{"option", "state"}, flags.GenericFilters)
 }
 
 func StartVps(_ *cobra.Command, args []string) {
-	endpoint := fmt.Sprintf("/vps/%s/start", url.PathEscape(args[0]))
+	endpoint := fmt.Sprintf("/v1/vps/%s/start", url.PathEscape(args[0]))
 
 	var response map[string]any
 	if err := httpLib.Client.Post(endpoint, nil, &response); err != nil {
@@ -479,7 +479,7 @@ func StartVps(_ *cobra.Command, args []string) {
 }
 
 func StopVps(_ *cobra.Command, args []string) {
-	endpoint := fmt.Sprintf("/vps/%s/stop", url.PathEscape(args[0]))
+	endpoint := fmt.Sprintf("/v1/vps/%s/stop", url.PathEscape(args[0]))
 
 	var response map[string]any
 	if err := httpLib.Client.Post(endpoint, nil, &response); err != nil {
@@ -504,7 +504,7 @@ func StopVps(_ *cobra.Command, args []string) {
 }
 
 func RebootVps(_ *cobra.Command, args []string) {
-	endpoint := fmt.Sprintf("/vps/%s/reboot", url.PathEscape(args[0]))
+	endpoint := fmt.Sprintf("/v1/vps/%s/reboot", url.PathEscape(args[0]))
 
 	var response map[string]any
 	if err := httpLib.Client.Post(endpoint, nil, &response); err != nil {
@@ -529,7 +529,7 @@ func RebootVps(_ *cobra.Command, args []string) {
 }
 
 func ReinstallVps(cmd *cobra.Command, args []string) {
-	endpoint := fmt.Sprintf("/vps/%s/rebuild", url.PathEscape(args[0]))
+	endpoint := fmt.Sprintf("/v1/vps/%s/rebuild", url.PathEscape(args[0]))
 
 	if VpsImageViaInteractiveSelector {
 		_, id, err := runImageSelector(args[0])
@@ -580,12 +580,12 @@ func ReinstallVps(cmd *cobra.Command, args []string) {
 }
 
 func ListVpsSecondaryDNSDomains(_ *cobra.Command, args []string) {
-	endpoint := fmt.Sprintf("/vps/%s/secondaryDnsDomains", url.PathEscape(args[0]))
+	endpoint := fmt.Sprintf("/v1/vps/%s/secondaryDnsDomains", url.PathEscape(args[0]))
 	common.ManageListRequest(endpoint, "", []string{"domain", "dns", "ipMaster", "creationDate"}, flags.GenericFilters)
 }
 
 func AddVpsSecondaryDNSDomain(cmd *cobra.Command, args []string) {
-	endpoint := fmt.Sprintf("/vps/%s/secondaryDnsDomains", url.PathEscape(args[0]))
+	endpoint := fmt.Sprintf("/v1/vps/%s/secondaryDnsDomains", url.PathEscape(args[0]))
 
 	if _, err := common.CreateResource(
 		cmd,
@@ -604,7 +604,7 @@ func AddVpsSecondaryDNSDomain(cmd *cobra.Command, args []string) {
 }
 
 func DeleteVpsSecondaryDNSDomain(_ *cobra.Command, args []string) {
-	endpoint := fmt.Sprintf("/vps/%s/secondaryDnsDomains/%s", url.PathEscape(args[0]), url.PathEscape(args[1]))
+	endpoint := fmt.Sprintf("/v1/vps/%s/secondaryDnsDomains/%s", url.PathEscape(args[0]), url.PathEscape(args[1]))
 
 	if err := httpLib.Client.Delete(endpoint, nil); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "error deleting secondary DNS domain %s: %s", args[1], err)
@@ -615,7 +615,7 @@ func DeleteVpsSecondaryDNSDomain(_ *cobra.Command, args []string) {
 }
 
 func ChangeVpsPassword(_ *cobra.Command, args []string) {
-	endpoint := fmt.Sprintf("/vps/%s/setPassword", url.PathEscape(args[0]))
+	endpoint := fmt.Sprintf("/v1/vps/%s/setPassword", url.PathEscape(args[0]))
 
 	var response map[string]any
 	if err := httpLib.Client.Post(endpoint, nil, &response); err != nil {
@@ -640,6 +640,6 @@ func ChangeVpsPassword(_ *cobra.Command, args []string) {
 }
 
 func ListVpsTasks(_ *cobra.Command, args []string) {
-	endpoint := fmt.Sprintf("/vps/%s/tasks", url.PathEscape(args[0]))
+	endpoint := fmt.Sprintf("/v1/vps/%s/tasks", url.PathEscape(args[0]))
 	common.ManageListRequest(endpoint, "", []string{"id", "type", "state", "date", "progress"}, flags.GenericFilters)
 }

--- a/internal/services/vrack/vrack.go
+++ b/internal/services/vrack/vrack.go
@@ -29,18 +29,18 @@ var (
 )
 
 func ListVrack(_ *cobra.Command, _ []string) {
-	common.ManageListRequest("/vrack", "", vrackColumnsToDisplay, flags.GenericFilters)
+	common.ManageListRequest("/v1/vrack", "", vrackColumnsToDisplay, flags.GenericFilters)
 }
 
 func GetVrack(_ *cobra.Command, args []string) {
-	common.ManageObjectRequest("/vrack", args[0], vrackTemplate)
+	common.ManageObjectRequest("/v1/vrack", args[0], vrackTemplate)
 }
 
 func EditVrack(cmd *cobra.Command, args []string) {
 	if err := common.EditResource(
 		cmd,
 		"/vrack/{serviceName}",
-		fmt.Sprintf("/vrack/%s", url.PathEscape(args[0])),
+		fmt.Sprintf("/v1/vrack/%s", url.PathEscape(args[0])),
 		VrackSpec,
 		assets.VrackOpenapiSchema,
 	); err != nil {

--- a/internal/services/webhosting/webhosting.go
+++ b/internal/services/webhosting/webhosting.go
@@ -28,18 +28,18 @@ var (
 )
 
 func ListWebHosting(_ *cobra.Command, _ []string) {
-	common.ManageListRequest("/hosting/web", "", webhostingColumnsToDisplay, flags.GenericFilters)
+	common.ManageListRequest("/v1/hosting/web", "", webhostingColumnsToDisplay, flags.GenericFilters)
 }
 
 func GetWebHosting(_ *cobra.Command, args []string) {
-	common.ManageObjectRequest("/hosting/web", args[0], webhostingTemplate)
+	common.ManageObjectRequest("/v1/hosting/web", args[0], webhostingTemplate)
 }
 
 func EditWebHosting(cmd *cobra.Command, args []string) {
 	if err := common.EditResource(
 		cmd,
 		"/hosting/web/{serviceName}",
-		fmt.Sprintf("/hosting/web/%s", url.PathEscape(args[0])),
+		fmt.Sprintf("/v1/hosting/web/%s", url.PathEscape(args[0])),
 		WebHostingSpec,
 		assets.WebhostingOpenapiSchema,
 	); err != nil {

--- a/internal/services/xdsl/xdsl.go
+++ b/internal/services/xdsl/xdsl.go
@@ -30,18 +30,18 @@ var (
 )
 
 func ListXdsl(_ *cobra.Command, _ []string) {
-	common.ManageListRequest("/xdsl", "", xdslColumnsToDisplay, flags.GenericFilters)
+	common.ManageListRequest("/v1/xdsl", "", xdslColumnsToDisplay, flags.GenericFilters)
 }
 
 func GetXdsl(_ *cobra.Command, args []string) {
-	common.ManageObjectRequest("/xdsl", args[0], xdslTemplate)
+	common.ManageObjectRequest("/v1/xdsl", args[0], xdslTemplate)
 }
 
 func EditXdsl(cmd *cobra.Command, args []string) {
 	if err := common.EditResource(
 		cmd,
 		"/xdsl/{serviceName}",
-		fmt.Sprintf("/xdsl/%s", url.PathEscape(args[0])),
+		fmt.Sprintf("/v1/xdsl/%s", url.PathEscape(args[0])),
 		XdslSpec,
 		assets.XdslOpenapiSchema,
 	); err != nil {


### PR DESCRIPTION
# Description

Add `/v1` prefix to all API calls towards API v1, to fix the CloudShell.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have commented my code
- [x] I updated the documentation by running `make doc`
- [x] I ran `go mod tidy`
- [x] I have added tests that prove my fix is effective or that my feature works
