### PR TITLE
Add notarization for macOS

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,11 @@ jobs:
           args: release --clean
         env:
           # GitHub sets the GITHUB_TOKEN secret automatically.
-          GITHUB_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
           TAP_GITHUB_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}
+          MACOS_SIGN_P12: ${{ secrets.MACOS_SIGN_P12 }}
+          MACOS_SIGN_PASSWORD: ${{ secrets.MACOS_SIGN_PASSWORD }}
+          MACOS_NOTARY_ISSUER_ID: ${{ secrets.MACOS_NOTARY_ISSUER_ID }}
+          MACOS_NOTARY_KEY_ID: ${{ secrets.MACOS_NOTARY_KEY_ID }}
+          MACOS_NOTARY_KEY: ${{ secrets.MACOS_NOTARY_KEY }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -57,6 +57,19 @@ archives:
       - goos: windows
         formats: [zip]
 
+notarize:
+  macos:
+    - enabled: '{{ isEnvSet "MACOS_SIGN_P12" }}'
+      ids:
+        - ovh-cli
+      sign:
+        certificate: "{{ .Env.MACOS_SIGN_P12 }}"
+        password: "{{ .Env.MACOS_SIGN_PASSWORD }}"
+      notarize:
+        issuer_id: "{{ .Env.MACOS_NOTARY_ISSUER_ID }}"
+        key_id: "{{ .Env.MACOS_NOTARY_KEY_ID }}"
+        key: "{{ .Env.MACOS_NOTARY_KEY }}"
+
 changelog:
   sort: asc
   filters:
@@ -70,12 +83,13 @@ release:
 
 homebrew_casks:
   - name: ovhcloud-cli
-    binary: ovhcloud
+    binaries: [ovhcloud]
     url:
       template: "https://github.com/ovh/ovhcloud-cli/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
     repository:
       owner: ovh
       name: homebrew-tap
+      token: "{{ .Env.TAP_GITHUB_TOKEN }}"
     commit_author:
       name: "ovh-cds"
       email: "ovh-cds@users.noreply.github.com"


### PR DESCRIPTION
# Description

Adds notarization
Needs adding of relevant secrets, see https://goreleaser.com/customization/notarize/#getting-the-keys
See [here](https://github.com/pdesgarets/ovhcloud-cli/releases/tag/v0.10.0-illuin) for an example of working binary (runs out of the box without warning, `codesign -dvvv /path/to/binary` shows a signature and an authority)

Fixes #91 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code
- [ ] I ran `go mod tidy`
- [ ] I have added tests that prove my fix is effective or that my feature works
