### PR TITLE
feat(baremetal): add ipmi reset-sessions command

### DIFF
--- a/doc/ovhcloud_baremetal_ipmi_reset-sessions.md
+++ b/doc/ovhcloud_baremetal_ipmi_reset-sessions.md
@@ -1,11 +1,15 @@
-## ovhcloud baremetal ipmi
+## ovhcloud baremetal ipmi reset-sessions
 
-Manage IPMI on your baremetal
+Reset IPMI sessions on a baremetal server
+
+```
+ovhcloud baremetal ipmi reset-sessions <service_name> [flags]
+```
 
 ### Options
 
 ```
-  -h, --help   help for ipmi
+  -h, --help   help for reset-sessions
 ```
 
 ### Options inherited from parent commands
@@ -29,7 +33,5 @@ Manage IPMI on your baremetal
 
 ### SEE ALSO
 
-* [ovhcloud baremetal](ovhcloud_baremetal.md)	 - Retrieve information and manage your Bare Metal services
-* [ovhcloud baremetal ipmi get-access](ovhcloud_baremetal_ipmi_get-access.md)	 - Request an acces on KVM IPMI interface
-* [ovhcloud baremetal ipmi reset-sessions](ovhcloud_baremetal_ipmi_reset-sessions.md)	 - Reset IPMI sessions on a baremetal server
+* [ovhcloud baremetal ipmi](ovhcloud_baremetal_ipmi.md)	 - Manage IPMI on your baremetal
 

--- a/internal/cmd/baremetal.go
+++ b/internal/cmd/baremetal.go
@@ -268,5 +268,12 @@ Please note that all parameters are not compatible with all OSes.
 	baremetalIPMIGetAccessCmd.Flags().StringVar(&baremetal.BaremetalIpmiSshKey, "ssh-key", "", "Public SSH key for Serial Over Lan SSH access")
 	baremetalIPMICmd.AddCommand(baremetalIPMIGetAccessCmd)
 
+	baremetalIPMICmd.AddCommand(&cobra.Command{
+		Use:   "reset-sessions <service_name>",
+		Short: "Reset IPMI sessions on a baremetal server",
+		Args:  cobra.ExactArgs(1),
+		Run:   baremetal.BaremetalResetIPMISessions,
+	})
+
 	rootCmd.AddCommand(baremetalCmd)
 }

--- a/internal/cmd/baremetal_test.go
+++ b/internal/cmd/baremetal_test.go
@@ -10,6 +10,17 @@ import (
 	"github.com/ovh/ovhcloud-cli/internal/cmd"
 )
 
+func (ms *MockSuite) TestBaremetalIPMIResetSessionsCmd(assert, require *td.T) {
+	httpmock.RegisterResponder("POST", "https://eu.api.ovh.com/v1/dedicated/server/fakeBaremetal/features/ipmi/resetSessions",
+		httpmock.NewStringResponder(200, `{}`),
+	)
+
+	out, err := cmd.Execute("baremetal", "ipmi", "reset-sessions", "fakeBaremetal")
+
+	require.CmpNoError(err)
+	assert.Contains(out, "IPMI sessions reset")
+}
+
 func (ms *MockSuite) TestBaremetalListCompatibleOSCmd(assert, require *td.T) {
 	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/v1/dedicated/server/fakeBaremetal/install/compatibleTemplates",
 		httpmock.NewStringResponder(200, `{

--- a/internal/services/baremetal/baremetal.go
+++ b/internal/services/baremetal/baremetal.go
@@ -261,6 +261,17 @@ func BaremetalGetIPMIAccess(_ *cobra.Command, args []string) {
 	display.OutputInfo(&flags.OutputFormatConfig, accessDetails, "%s", output)
 }
 
+func BaremetalResetIPMISessions(_ *cobra.Command, args []string) {
+	path := fmt.Sprintf("/v1/dedicated/server/%s/features/ipmi/resetSessions", url.PathEscape(args[0]))
+
+	if err := httpLib.Client.Post(path, nil, nil); err != nil {
+		display.OutputError(&flags.OutputFormatConfig, "failed to reset IPMI sessions for %s: %s", args[0], err)
+		return
+	}
+
+	display.OutputInfo(&flags.OutputFormatConfig, nil, "✅ IPMI sessions reset for %s", args[0])
+}
+
 func ListBaremetalInterventions(_ *cobra.Command, args []string) {
 	path := fmt.Sprintf("/v1/dedicated/server/%s/intervention", args[0])
 


### PR DESCRIPTION
# Description

Adds a new CLI command to reset IPMI sessions on a baremetal server.

`ovhcloud baremetal ipmi reset-sessions <service_name>`

This maps to the OVH API endpoint:
`POST /v1/dedicated/server/{serviceName}/features/ipmi/resetSessions`

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (improvement of existing commands)
- [ ] Breaking change (fix or feature that can break a current behavior)
- [x] Documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have commented my code
- [x] I ran `go mod tidy`
- [x] I have added tests that prove my fix is effective or that my feature works
