### PR TITLE
fix: safe wrappers for MarkFlagsMutuallyExclusive to prevent WASM panics

### DIFF
--- a/internal/cmd/cloud_managed_analytics.go
+++ b/internal/cmd/cloud_managed_analytics.go
@@ -338,7 +338,6 @@ There are two ways to define the creation parameters:
 	managedAnalyticsCreateCmd.Flags().IntVar(&cloud.ManagedAnalyticsSpec.Disk.Size, "disk-size", 0, "Disk size (GB)")
 	managedAnalyticsCreateCmd.Flags().StringVar(&cloud.ManagedAnalyticsSpec.ForkFrom.BackupID, "fork-from.backup-id", "", "Backup ID (not compatible with fork-from.point-in-time)")
 	managedAnalyticsCreateCmd.Flags().StringVar(&cloud.ManagedAnalyticsSpec.ForkFrom.PointInTime, "fork-from.point-in-time", "", "Point in time to restore from (not compatible with fork-from.backup-id)")
-	managedAnalyticsCreateCmd.MarkFlagsMutuallyExclusive("fork-from.backup-id", "fork-from.point-in-time")
 	markFlagsMutuallyExclusive(managedAnalyticsCreateCmd, "fork-from.backup-id", "fork-from.point-in-time")
 	managedAnalyticsCreateCmd.Flags().StringVar(&cloud.ManagedAnalyticsSpec.ForkFrom.ServiceID, "fork-from.service-id", "", "Service ID that owns the backups")
 	managedAnalyticsCreateCmd.Flags().StringVar(&cloud.ManagedAnalyticsSpec.MaintenanceTime, "maintenance-time", "", "Time on which maintenances can start every day")

--- a/internal/cmd/cloud_storage_file.go
+++ b/internal/cmd/cloud_storage_file.go
@@ -162,7 +162,7 @@ func getShareCreateCmd() *cobra.Command {
 
 	addParameterFileFlags(shareCreateCmd, false, assets.CloudOpenapiSchema, "/cloud/project/{serviceName}/region/{regionName}/share", "post", cloud.ShareCreateExample, nil)
 	addInteractiveEditorFlag(shareCreateCmd)
-	shareCreateCmd.MarkFlagsMutuallyExclusive("from-file", "editor")
+	markFlagsMutuallyExclusive(shareCreateCmd, "from-file", "editor")
 
 	return shareCreateCmd
 }

--- a/internal/cmd/ip.go
+++ b/internal/cmd/ip.go
@@ -187,7 +187,7 @@ There are three ways to define the creation parameters:
 	ipFirewallRuleCreateCmd.Flags().StringVar(&ip.FirewallRuleSpec.TCPOption, "tcp-option", "", "TCP option: established or syn (TCP only)")
 	addParameterFileFlags(ipFirewallRuleCreateCmd, false, assets.IpOpenapiSchema, "/ip/{ip}/firewall/{ipOnFirewall}/rule", "post", ip.FirewallRuleCreateExample, nil)
 	addInteractiveEditorFlag(ipFirewallRuleCreateCmd)
-	ipFirewallRuleCreateCmd.MarkFlagsMutuallyExclusive("from-file", "editor")
+	markFlagsMutuallyExclusive(ipFirewallRuleCreateCmd, "from-file", "editor")
 	ipFirewallRuleCmd.AddCommand(ipFirewallRuleCreateCmd)
 
 	ipFirewallRuleCmd.AddCommand(&cobra.Command{


### PR DESCRIPTION
Added cobra wrappers to newly added features in the CLI
