### PR TITLE
feat: Inject schemas version header to /v2 API requests

### DIFF
--- a/internal/http/client.go
+++ b/internal/http/client.go
@@ -60,7 +60,9 @@ func InitClientWithProfile(cfg *ini.File, profileOverride string) {
 	if err != nil {
 		log.Printf(`OVHcloud API client not initialized, please run "ovhcloud login" to authenticate (%s)`, err)
 	} else if Client != nil {
-		Client.Client.Transport = NewTransport("OVH", http.DefaultTransport)
+		// Chain transports: schemasVersion (adds X-Schemas-Version for /v2/ paths)
+		// → debug logging (logs request/response) → default transport (sends over the wire).
+		Client.Client.Transport = newSchemasVersionTransport(NewTransport("OVH", http.DefaultTransport))
 	}
 }
 

--- a/internal/http/schemas_version_transport.go
+++ b/internal/http/schemas_version_transport.go
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: 2025 OVH SAS <opensource@ovh.net>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package http
+
+import (
+	"net/http"
+	"strings"
+)
+
+// schemasVersionHeader is the HTTP header to select a specific
+// API schema version when processing the request.
+const schemasVersionHeader = "X-Schemas-Version"
+
+// schemasVersion is the schema version requested by this client.
+// Bump this value when a new schema version is released and the CLI
+// has been updated to match.
+const schemasVersion = "1.0"
+
+// schemasVersionTransport is an http.RoundTripper middleware that injects the
+// X-Schemas-Version header on every request whose path starts with "/v2/".
+// Requests targeting v1 endpoints are left untouched because v1 instances do
+// not support multi-version schemas.
+type schemasVersionTransport struct {
+	next http.RoundTripper
+}
+
+func (t *schemasVersionTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if strings.HasPrefix(req.URL.Path, "/v2/") {
+		// Clone the request so we don't mutate the caller's original.
+		req = req.Clone(req.Context())
+		req.Header.Set(schemasVersionHeader, schemasVersion)
+	}
+	return t.next.RoundTrip(req)
+}
+
+// newSchemasVersionTransport wraps the given RoundTripper with schema version
+// header injection for v2 API calls.
+func newSchemasVersionTransport(next http.RoundTripper) http.RoundTripper {
+	return &schemasVersionTransport{next: next}
+}

--- a/internal/http/schemas_version_transport.go
+++ b/internal/http/schemas_version_transport.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 OVH SAS <opensource@ovh.net>
+// SPDX-FileCopyrightText: 2026 OVH SAS <opensource@ovh.net>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -16,7 +16,7 @@ const schemasVersionHeader = "X-Schemas-Version"
 // schemasVersion is the schema version requested by this client.
 // Bump this value when a new schema version is released and the CLI
 // has been updated to match.
-const schemasVersion = "1.0"
+const schemasVersion = "0.0"
 
 // schemasVersionTransport is an http.RoundTripper middleware that injects the
 // X-Schemas-Version header on every request whose path starts with "/v2/".

--- a/internal/http/schemas_version_transport_test.go
+++ b/internal/http/schemas_version_transport_test.go
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: 2025 OVH SAS <opensource@ovh.net>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package http
+
+import (
+	"net/http"
+	"testing"
+
+	td "github.com/maxatome/go-testdeep"
+)
+
+type recordingTransport struct {
+	req *http.Request
+}
+
+func (t *recordingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	t.req = req
+	return &http.Response{StatusCode: http.StatusOK}, nil
+}
+
+func TestSchemasVersionTransport_V2Path(t *testing.T) {
+	recorder := &recordingTransport{}
+	transport := newSchemasVersionTransport(recorder)
+
+	req, _ := http.NewRequest(http.MethodGet, "https://eu.api.ovh.com/v2/vrackServices/resource/abc", nil)
+	_, err := transport.RoundTrip(req)
+	td.Require(t).CmpNoError(err)
+	td.Cmp(t, recorder.req.Header.Get(schemasVersionHeader), schemasVersion)
+}
+
+func TestSchemasVersionTransport_V1Path(t *testing.T) {
+	recorder := &recordingTransport{}
+	transport := newSchemasVersionTransport(recorder)
+
+	req, _ := http.NewRequest(http.MethodGet, "https://eu.api.ovh.com/v1/dedicated/server/abc", nil)
+	_, err := transport.RoundTrip(req)
+	td.Require(t).CmpNoError(err)
+	td.Cmp(t, recorder.req.Header.Get(schemasVersionHeader), "")
+}
+
+func TestSchemasVersionTransport_NoPrefix(t *testing.T) {
+	recorder := &recordingTransport{}
+	transport := newSchemasVersionTransport(recorder)
+
+	req, _ := http.NewRequest(http.MethodGet, "https://eu.api.ovh.com/dedicated/server/abc", nil)
+	_, err := transport.RoundTrip(req)
+	td.Require(t).CmpNoError(err)
+	td.Cmp(t, recorder.req.Header.Get(schemasVersionHeader), "")
+}
+
+func TestSchemasVersionTransport_DoesNotMutateOriginal(t *testing.T) {
+	recorder := &recordingTransport{}
+	transport := newSchemasVersionTransport(recorder)
+
+	req, _ := http.NewRequest(http.MethodGet, "https://eu.api.ovh.com/v2/vrackServices/resource/abc", nil)
+	_, err := transport.RoundTrip(req)
+	td.Require(t).CmpNoError(err)
+	// The original request must not have been mutated.
+	td.Cmp(t, req.Header.Get(schemasVersionHeader), "")
+}

--- a/internal/http/schemas_version_transport_test.go
+++ b/internal/http/schemas_version_transport_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 OVH SAS <opensource@ovh.net>
+// SPDX-FileCopyrightText: 2026 OVH SAS <opensource@ovh.net>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -8,7 +8,7 @@ import (
 	"net/http"
 	"testing"
 
-	td "github.com/maxatome/go-testdeep"
+	"github.com/maxatome/go-testdeep/td"
 )
 
 type recordingTransport struct {


### PR DESCRIPTION
# Description

Add a `X-Schemas-Version` HTTP header to all API requests targeting `/v2/` endpoints.

This is implemented as an `http.RoundTripper` middleware (`schemasVersionTransport`) chained
before the existing debug logging transport. When the request path starts with `/v2/`, the
transport clones the request and injects `X-Schemas-Version: 1.0`. Requests to v1 endpoints
are left untouched.

This allows OVHcloud API to deterministically select the correct API schema
version when processing the request, instead of relying on a server-side default.

## Type of change

- [X] New feature (non-breaking change which adds functionality)


# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have commented my code
- [X] I ran `go mod tidy`
- [X] I have added tests that prove my fix is effective or that my feature works
