### PR TITLE
chore: Rename instance snapshot to instance backup

### DIFF
--- a/doc/ovhcloud_cloud_instance.md
+++ b/doc/ovhcloud_cloud_instance.md
@@ -34,6 +34,7 @@ Manage instances in the given cloud project
 * [ovhcloud cloud instance activate-monthly-billing](ovhcloud_cloud_instance_activate-monthly-billing.md)	 - Activate monthly billing for the given instance
 * [ovhcloud cloud instance application-access](ovhcloud_cloud_instance_application-access.md)	 - Get application access credentials for the given instance
 * [ovhcloud cloud instance autobackup](ovhcloud_cloud_instance_autobackup.md)	 - Manage automatic backup workflows for instances
+* [ovhcloud cloud instance backup](ovhcloud_cloud_instance_backup.md)	 - Manage backups of the given instance
 * [ovhcloud cloud instance create](ovhcloud_cloud_instance_create.md)	 - Create a new instance
 * [ovhcloud cloud instance delete](ovhcloud_cloud_instance_delete.md)	 - Delete the given instance
 * [ovhcloud cloud instance exit-rescue](ovhcloud_cloud_instance_exit-rescue.md)	 - Exit the given instance from rescue mode
@@ -48,7 +49,6 @@ Manage instances in the given cloud project
 * [ovhcloud cloud instance set-flavor](ovhcloud_cloud_instance_set-flavor.md)	 - Migrate the given instance to the specified flavor
 * [ovhcloud cloud instance set-name](ovhcloud_cloud_instance_set-name.md)	 - Set the name of the given instance
 * [ovhcloud cloud instance shelve](ovhcloud_cloud_instance_shelve.md)	 - Shelve the given instance
-* [ovhcloud cloud instance snapshot](ovhcloud_cloud_instance_snapshot.md)	 - Manage snapshots of the given instance
 * [ovhcloud cloud instance start](ovhcloud_cloud_instance_start.md)	 - Start the given instance
 * [ovhcloud cloud instance stop](ovhcloud_cloud_instance_stop.md)	 - Stop the given instance
 * [ovhcloud cloud instance unshelve](ovhcloud_cloud_instance_unshelve.md)	 - Unshelve the given instance

--- a/doc/ovhcloud_cloud_instance_backup.md
+++ b/doc/ovhcloud_cloud_instance_backup.md
@@ -1,11 +1,11 @@
-## ovhcloud cloud instance snapshot
+## ovhcloud cloud instance backup
 
-Manage snapshots of the given instance
+Manage backups of the given instance
 
 ### Options
 
 ```
-  -h, --help   help for snapshot
+  -h, --help   help for backup
 ```
 
 ### Options inherited from parent commands
@@ -31,9 +31,9 @@ Manage snapshots of the given instance
 ### SEE ALSO
 
 * [ovhcloud cloud instance](ovhcloud_cloud_instance.md)	 - Manage instances in the given cloud project
-* [ovhcloud cloud instance snapshot abort](ovhcloud_cloud_instance_snapshot_abort.md)	 - Abort the snapshot creation of the given instance
-* [ovhcloud cloud instance snapshot create](ovhcloud_cloud_instance_snapshot_create.md)	 - Create a snapshot of the given instance
-* [ovhcloud cloud instance snapshot delete](ovhcloud_cloud_instance_snapshot_delete.md)	 - Delete a specific instance snapshot in the current cloud project
-* [ovhcloud cloud instance snapshot get](ovhcloud_cloud_instance_snapshot_get.md)	 - Get a specific instance snapshot in the current cloud project
-* [ovhcloud cloud instance snapshot list](ovhcloud_cloud_instance_snapshot_list.md)	 - List all instance snapshots in the current cloud project
+* [ovhcloud cloud instance backup abort](ovhcloud_cloud_instance_backup_abort.md)	 - Abort the backup creation of the given instance
+* [ovhcloud cloud instance backup create](ovhcloud_cloud_instance_backup_create.md)	 - Create a backup of the given instance
+* [ovhcloud cloud instance backup delete](ovhcloud_cloud_instance_backup_delete.md)	 - Delete a specific instance backup in the current cloud project
+* [ovhcloud cloud instance backup get](ovhcloud_cloud_instance_backup_get.md)	 - Get a specific instance backup in the current cloud project
+* [ovhcloud cloud instance backup list](ovhcloud_cloud_instance_backup_list.md)	 - List all instance backups in the current cloud project
 

--- a/doc/ovhcloud_cloud_instance_backup_abort.md
+++ b/doc/ovhcloud_cloud_instance_backup_abort.md
@@ -1,22 +1,15 @@
-## ovhcloud cloud instance snapshot list
+## ovhcloud cloud instance backup abort
 
-List all instance snapshots in the current cloud project
+Abort the backup creation of the given instance
 
 ```
-ovhcloud cloud instance snapshot list [flags]
+ovhcloud cloud instance backup abort <instance_id> [flags]
 ```
 
 ### Options
 
 ```
-      --filter stringArray   Filter results by any property using https://github.com/PaesslerAG/gval syntax
-                             Examples:
-                               --filter 'state=="running"'
-                               --filter 'name=~"^my.*"'
-                               --filter 'nested.property.subproperty>10'
-                               --filter 'startDate>="2023-12-01"'
-                               --filter 'name=~"something" && nbField>10'
-  -h, --help                 help for list
+  -h, --help   help for abort
 ```
 
 ### Options inherited from parent commands
@@ -41,5 +34,5 @@ ovhcloud cloud instance snapshot list [flags]
 
 ### SEE ALSO
 
-* [ovhcloud cloud instance snapshot](ovhcloud_cloud_instance_snapshot.md)	 - Manage snapshots of the given instance
+* [ovhcloud cloud instance backup](ovhcloud_cloud_instance_backup.md)	 - Manage backups of the given instance
 

--- a/doc/ovhcloud_cloud_instance_backup_create.md
+++ b/doc/ovhcloud_cloud_instance_backup_create.md
@@ -1,15 +1,17 @@
-## ovhcloud cloud instance snapshot get
+## ovhcloud cloud instance backup create
 
-Get a specific instance snapshot in the current cloud project
+Create a backup of the given instance
 
 ```
-ovhcloud cloud instance snapshot get <snapshot_id> [flags]
+ovhcloud cloud instance backup create <instance_id> <backup_name> [flags]
 ```
 
 ### Options
 
 ```
-  -h, --help   help for get
+      --distant-backup-name string   Name of the backup in the distant region (for cross region backup)
+      --distant-region-name string   Name of the distant region (for cross region backup)
+  -h, --help                         help for create
 ```
 
 ### Options inherited from parent commands
@@ -34,5 +36,5 @@ ovhcloud cloud instance snapshot get <snapshot_id> [flags]
 
 ### SEE ALSO
 
-* [ovhcloud cloud instance snapshot](ovhcloud_cloud_instance_snapshot.md)	 - Manage snapshots of the given instance
+* [ovhcloud cloud instance backup](ovhcloud_cloud_instance_backup.md)	 - Manage backups of the given instance
 

--- a/doc/ovhcloud_cloud_instance_backup_delete.md
+++ b/doc/ovhcloud_cloud_instance_backup_delete.md
@@ -1,9 +1,9 @@
-## ovhcloud cloud instance snapshot delete
+## ovhcloud cloud instance backup delete
 
-Delete a specific instance snapshot in the current cloud project
+Delete a specific instance backup in the current cloud project
 
 ```
-ovhcloud cloud instance snapshot delete <snapshot_id> [flags]
+ovhcloud cloud instance backup delete <backup_id> [flags]
 ```
 
 ### Options
@@ -34,5 +34,5 @@ ovhcloud cloud instance snapshot delete <snapshot_id> [flags]
 
 ### SEE ALSO
 
-* [ovhcloud cloud instance snapshot](ovhcloud_cloud_instance_snapshot.md)	 - Manage snapshots of the given instance
+* [ovhcloud cloud instance backup](ovhcloud_cloud_instance_backup.md)	 - Manage backups of the given instance
 

--- a/doc/ovhcloud_cloud_instance_backup_get.md
+++ b/doc/ovhcloud_cloud_instance_backup_get.md
@@ -1,17 +1,15 @@
-## ovhcloud cloud instance snapshot create
+## ovhcloud cloud instance backup get
 
-Create a snapshot of the given instance
+Get a specific instance backup in the current cloud project
 
 ```
-ovhcloud cloud instance snapshot create <instance_id> <snapshot_name> [flags]
+ovhcloud cloud instance backup get <backup_id> [flags]
 ```
 
 ### Options
 
 ```
-      --distant-region-name string     Name of the distant region (for cross region snapshot)
-      --distant-snapshot-name string   Name of the snapshot in the distant region (for cross region snapshot)
-  -h, --help                           help for create
+  -h, --help   help for get
 ```
 
 ### Options inherited from parent commands
@@ -36,5 +34,5 @@ ovhcloud cloud instance snapshot create <instance_id> <snapshot_name> [flags]
 
 ### SEE ALSO
 
-* [ovhcloud cloud instance snapshot](ovhcloud_cloud_instance_snapshot.md)	 - Manage snapshots of the given instance
+* [ovhcloud cloud instance backup](ovhcloud_cloud_instance_backup.md)	 - Manage backups of the given instance
 

--- a/doc/ovhcloud_cloud_instance_backup_list.md
+++ b/doc/ovhcloud_cloud_instance_backup_list.md
@@ -1,15 +1,22 @@
-## ovhcloud cloud instance snapshot abort
+## ovhcloud cloud instance backup list
 
-Abort the snapshot creation of the given instance
+List all instance backups in the current cloud project
 
 ```
-ovhcloud cloud instance snapshot abort <instance_id> [flags]
+ovhcloud cloud instance backup list [flags]
 ```
 
 ### Options
 
 ```
-  -h, --help   help for abort
+      --filter stringArray   Filter results by any property using https://github.com/PaesslerAG/gval syntax
+                             Examples:
+                               --filter 'state=="running"'
+                               --filter 'name=~"^my.*"'
+                               --filter 'nested.property.subproperty>10'
+                               --filter 'startDate>="2023-12-01"'
+                               --filter 'name=~"something" && nbField>10'
+  -h, --help                 help for list
 ```
 
 ### Options inherited from parent commands
@@ -34,5 +41,5 @@ ovhcloud cloud instance snapshot abort <instance_id> [flags]
 
 ### SEE ALSO
 
-* [ovhcloud cloud instance snapshot](ovhcloud_cloud_instance_snapshot.md)	 - Manage snapshots of the given instance
+* [ovhcloud cloud instance backup](ovhcloud_cloud_instance_backup.md)	 - Manage backups of the given instance
 

--- a/doc/ovhcloud_cloud_instance_create.md
+++ b/doc/ovhcloud_cloud_instance_create.md
@@ -61,7 +61,7 @@ ovhcloud cloud instance create <region (e.g. GRA9, BHS5, SBG3)> [flags]
       --backup-cron string                                      Autobackup Unix Cron pattern (eg: '0 0 * * *')
       --backup-rotation int                                     Number of backups to keep
       --billing-period string                                   Billing period (hourly, monthly), default is hourly (default "hourly")
-      --boot-from.image string                                  Image ID to boot from (you can use 'ovhcloud cloud reference list-images' to get the image ID or 'ovhcloud cloud instance snapshot ls' to get the snapshots)
+      --boot-from.image string                                  Image ID to boot from (you can use 'ovhcloud cloud reference list-images' to get the image ID or 'ovhcloud cloud instance backup ls' to get the backups)
       --boot-from.volume string                                 Volume ID to boot from
       --bulk int                                                Number of instances to create
       --editor                                                  Use a text editor to define parameters

--- a/internal/cmd/cloud_instance.go
+++ b/internal/cmd/cloud_instance.go
@@ -75,7 +75,7 @@ There are three ways to define the creation parameters:
 	instanceCreateCmd.Flags().StringVar(&cloud.InstanceCreationParameters.Name, "name", "", "Instance name")
 
 	// Boot options
-	instanceCreateCmd.Flags().StringVar(&cloud.InstanceCreationParameters.BootFrom.ImageID, "boot-from.image", "", "Image ID to boot from (you can use 'ovhcloud cloud reference list-images' to get the image ID or 'ovhcloud cloud instance snapshot ls' to get the snapshots)")
+	instanceCreateCmd.Flags().StringVar(&cloud.InstanceCreationParameters.BootFrom.ImageID, "boot-from.image", "", "Image ID to boot from (you can use 'ovhcloud cloud reference list-images' to get the image ID or 'ovhcloud cloud instance backup ls' to get the backups)")
 	instanceCreateCmd.Flags().StringVar(&cloud.InstanceCreationParameters.BootFrom.VolumeID, "boot-from.volume", "", "Volume ID to boot from")
 	markFlagsMutuallyExclusive(instanceCreateCmd, "boot-from.image", "boot-from.volume")
 
@@ -359,49 +359,49 @@ There are three ways to define the installation parameters:
 	setFlavorCmd.Flags().BoolVar(&cloud.InstanceFlavorViaInteractiveSelector, "flavor-selector", false, "Use the interactive flavor selector")
 	instanceCmd.AddCommand(setFlavorCmd)
 
-	snapshotCmd := &cobra.Command{
-		Use:   "snapshot",
-		Short: "Manage snapshots of the given instance",
+	backupCmd := &cobra.Command{
+		Use:   "backup",
+		Short: "Manage backups of the given instance",
 	}
-	instanceCmd.AddCommand(snapshotCmd)
+	instanceCmd.AddCommand(backupCmd)
 
-	snapshotCreateCmd := &cobra.Command{
-		Use:   "create <instance_id> <snapshot_name>",
-		Short: "Create a snapshot of the given instance",
-		Run:   cloud.CreateInstanceSnapshot,
+	backupCreateCmd := &cobra.Command{
+		Use:   "create <instance_id> <backup_name>",
+		Short: "Create a backup of the given instance",
+		Run:   cloud.CreateInstanceBackup,
 		Args:  cobra.ExactArgs(2),
 	}
-	snapshotCreateCmd.Flags().StringVar(&cloud.InstanceSnapshotSpec.DistantSnapshotName, "distant-snapshot-name", "", "Name of the snapshot in the distant region (for cross region snapshot)")
-	snapshotCreateCmd.Flags().StringVar(&cloud.InstanceSnapshotSpec.DistantRegionName, "distant-region-name", "", "Name of the distant region (for cross region snapshot)")
-	snapshotCreateCmd.MarkFlagsRequiredTogether("distant-snapshot-name", "distant-region-name")
-	snapshotCmd.AddCommand(snapshotCreateCmd)
+	backupCreateCmd.Flags().StringVar(&cloud.InstanceBackupSpec.DistantSnapshotName, "distant-backup-name", "", "Name of the backup in the distant region (for cross region backup)")
+	backupCreateCmd.Flags().StringVar(&cloud.InstanceBackupSpec.DistantRegionName, "distant-region-name", "", "Name of the distant region (for cross region backup)")
+	backupCreateCmd.MarkFlagsRequiredTogether("distant-backup-name", "distant-region-name")
+	backupCmd.AddCommand(backupCreateCmd)
 
-	snapshotCmd.AddCommand(&cobra.Command{
+	backupCmd.AddCommand(&cobra.Command{
 		Use:   "abort <instance_id>",
-		Short: "Abort the snapshot creation of the given instance",
-		Run:   cloud.AbortInstanceSnapshot,
+		Short: "Abort the backup creation of the given instance",
+		Run:   cloud.AbortInstanceBackup,
 		Args:  cobra.ExactArgs(1),
 	})
 
-	snapshotCmd.AddCommand(withFilterFlag(&cobra.Command{
+	backupCmd.AddCommand(withFilterFlag(&cobra.Command{
 		Use:     "list",
 		Aliases: []string{"ls"},
-		Short:   "List all instance snapshots in the current cloud project",
-		Run:     cloud.ListInstanceSnapshots,
+		Short:   "List all instance backups in the current cloud project",
+		Run:     cloud.ListInstanceBackups,
 		Args:    cobra.NoArgs,
 	}))
 
-	snapshotCmd.AddCommand(&cobra.Command{
-		Use:   "get <snapshot_id>",
-		Short: "Get a specific instance snapshot in the current cloud project",
-		Run:   cloud.GetInstanceSnapshot,
+	backupCmd.AddCommand(&cobra.Command{
+		Use:   "get <backup_id>",
+		Short: "Get a specific instance backup in the current cloud project",
+		Run:   cloud.GetInstanceBackup,
 		Args:  cobra.ExactArgs(1),
 	})
 
-	snapshotCmd.AddCommand(&cobra.Command{
-		Use:   "delete <snapshot_id>",
-		Short: "Delete a specific instance snapshot in the current cloud project",
-		Run:   cloud.DeleteInstanceSnapshot,
+	backupCmd.AddCommand(&cobra.Command{
+		Use:   "delete <backup_id>",
+		Short: "Delete a specific instance backup in the current cloud project",
+		Run:   cloud.DeleteInstanceBackup,
 		Args:  cobra.ExactArgs(1),
 	})
 

--- a/internal/services/cloud/cloud_instance.go
+++ b/internal/services/cloud/cloud_instance.go
@@ -140,7 +140,7 @@ var (
 		UserData string `json:"userData,omitempty"`
 	}{}
 
-	InstanceSnapshotSpec struct {
+	InstanceBackupSpec struct {
 		SnapshotName        string `json:"snapshotName,omitempty"`
 		DistantSnapshotName string `json:"distantSnapshotName,omitempty"`
 		DistantRegionName   string `json:"distantRegionName,omitempty"`
@@ -834,7 +834,7 @@ func SetInstanceFlavor(_ *cobra.Command, args []string) {
 	display.OutputInfo(&flags.OutputFormatConfig, nil, "✅ Instance correctly migrated to the desired flavor")
 }
 
-func CreateInstanceSnapshot(_ *cobra.Command, args []string) {
+func CreateInstanceBackup(_ *cobra.Command, args []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "%s", err)
@@ -850,19 +850,19 @@ func CreateInstanceSnapshot(_ *cobra.Command, args []string) {
 	}
 	region := instance["region"].(string)
 
-	InstanceSnapshotSpec.SnapshotName = args[1]
+	InstanceBackupSpec.SnapshotName = args[1]
 
 	endpoint = fmt.Sprintf("/v1/cloud/project/%s/region/%s/instance/%s/snapshot", projectID, url.PathEscape(region), url.PathEscape(args[0]))
 	var response map[string]any
-	if err := httpLib.Client.Post(endpoint, InstanceSnapshotSpec, &response); err != nil {
-		display.OutputError(&flags.OutputFormatConfig, "error creating snapshot for instance %q: %s", args[0], err)
+	if err := httpLib.Client.Post(endpoint, InstanceBackupSpec, &response); err != nil {
+		display.OutputError(&flags.OutputFormatConfig, "error creating backup for instance %q: %s", args[0], err)
 		return
 	}
 
-	display.OutputInfo(&flags.OutputFormatConfig, response, "✅ Snapshot created successfully with ID: %s", response["imageId"])
+	display.OutputInfo(&flags.OutputFormatConfig, response, "✅ Backup created successfully with ID: %s", response["imageId"])
 }
 
-func AbortInstanceSnapshot(_ *cobra.Command, args []string) {
+func AbortInstanceBackup(_ *cobra.Command, args []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "%s", err)
@@ -878,17 +878,17 @@ func AbortInstanceSnapshot(_ *cobra.Command, args []string) {
 	}
 	region := instance["region"].(string)
 
-	// Abort the snapshot
+	// Abort the backup
 	endpoint = fmt.Sprintf("/v1/cloud/project/%s/region/%s/instance/%s/abortSnapshot", projectID, url.PathEscape(region), url.PathEscape(args[0]))
 	if err := httpLib.Client.Post(endpoint, nil, nil); err != nil {
-		display.OutputError(&flags.OutputFormatConfig, "error aborting snapshot for instance %q: %s", args[0], err)
+		display.OutputError(&flags.OutputFormatConfig, "error aborting backup for instance %q: %s", args[0], err)
 		return
 	}
 
-	display.OutputInfo(&flags.OutputFormatConfig, nil, "✅ Snapshot aborted successfully")
+	display.OutputInfo(&flags.OutputFormatConfig, nil, "✅ Backup aborted successfully")
 }
 
-func ListInstanceSnapshots(_ *cobra.Command, _ []string) {
+func ListInstanceBackups(_ *cobra.Command, _ []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "%s", err)
@@ -898,7 +898,7 @@ func ListInstanceSnapshots(_ *cobra.Command, _ []string) {
 	common.ManageListRequestNoExpand(fmt.Sprintf("/v1/cloud/project/%s/snapshot", projectID), []string{"id", "name", "type", "status", "region"}, flags.GenericFilters)
 }
 
-func GetInstanceSnapshot(_ *cobra.Command, args []string) {
+func GetInstanceBackup(_ *cobra.Command, args []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "%s", err)
@@ -908,7 +908,7 @@ func GetInstanceSnapshot(_ *cobra.Command, args []string) {
 	common.ManageObjectRequest(fmt.Sprintf("/v1/cloud/project/%s/snapshot", projectID), args[0], "")
 }
 
-func DeleteInstanceSnapshot(_ *cobra.Command, args []string) {
+func DeleteInstanceBackup(_ *cobra.Command, args []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "%s", err)
@@ -918,11 +918,11 @@ func DeleteInstanceSnapshot(_ *cobra.Command, args []string) {
 	endpoint := fmt.Sprintf("/v1/cloud/project/%s/snapshot/%s", projectID, url.PathEscape(args[0]))
 
 	if err := httpLib.Client.Delete(endpoint, nil); err != nil {
-		display.OutputError(&flags.OutputFormatConfig, "error deleting snapshot %q: %s", args[0], err)
+		display.OutputError(&flags.OutputFormatConfig, "error deleting backup %q: %s", args[0], err)
 		return
 	}
 
-	display.OutputInfo(&flags.OutputFormatConfig, nil, "✅ Snapshot successfully deleted")
+	display.OutputInfo(&flags.OutputFormatConfig, nil, "✅ Backup successfully deleted")
 }
 
 // Application Access


### PR DESCRIPTION
# Description

Renames the `ovhcloud cloud instance snapshot` subcommand tree to `ovhcloud cloud instance backup` for clearer, more user-friendly naming.

This is a hard rename — no backward-compatible alias is kept.

## Type of change

- [x] Breaking change (fix or feature that can break a current behavior)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have commented my code
- [x] I ran `go mod tidy`
- [x] I have added tests that prove my fix is effective or that my feature works