### PR TITLE
feat(support-tickets): add create command to open new tickets

### DIFF
--- a/doc/ovhcloud_support-tickets.md
+++ b/doc/ovhcloud_support-tickets.md
@@ -30,6 +30,7 @@ Retrieve information and manage your support tickets
 ### SEE ALSO
 
 * [ovhcloud](ovhcloud.md)	 - CLI to manage your OVHcloud services
+* [ovhcloud support-tickets create](ovhcloud_support-tickets_create.md)	 - Create a new support ticket
 * [ovhcloud support-tickets get](ovhcloud_support-tickets_get.md)	 - Retrieve information of a specific support ticket
 * [ovhcloud support-tickets list](ovhcloud_support-tickets_list.md)	 - List your support tickets
 * [ovhcloud support-tickets messages](ovhcloud_support-tickets_messages.md)	 - List messages for a support ticket

--- a/doc/ovhcloud_support-tickets_create.md
+++ b/doc/ovhcloud_support-tickets_create.md
@@ -1,0 +1,90 @@
+## ovhcloud support-tickets create
+
+Create a new support ticket
+
+### Synopsis
+
+Use this command to create a new support ticket.
+There are three ways to define the creation parameters:
+
+1. Using only CLI flags:
+
+	ovhcloud support-tickets create --subject 'My issue' --body 'Detailed description of the issue' --product publiccloud --category assistance
+
+2. Using a configuration file:
+
+  First you can generate an example of parameters file using the following command:
+
+	ovhcloud support-tickets create --init-file ./params.json
+
+  You will be able to choose from several examples of parameters. Once an example has been selected, the content is written in the given file.
+  After editing the file to set the correct creation parameters, run:
+
+	ovhcloud support-tickets create --from-file ./params.json
+
+  Note that you can also pipe the content of the parameters file, like the following:
+
+	cat ./params.json | ovhcloud support-tickets create
+
+  In both cases, you can override the parameters in the given file using command line flags, for example:
+
+	ovhcloud support-tickets create --from-file ./params.json --subject 'Overridden subject'
+
+3. Using your default text editor:
+
+	ovhcloud support-tickets create --editor
+
+  You will be able to choose from several examples of parameters. Once an example has been selected, the CLI will open your
+  default text editor to update the parameters. When saving the file, the creation will start.
+
+  Note that it is also possible to override values in the presented examples using command line flags like the following:
+
+	ovhcloud support-tickets create --editor --subject 'Overridden subject'
+
+
+```
+ovhcloud support-tickets create [flags]
+```
+
+### Options
+
+```
+      --body string           Ticket message body
+      --category string       Ticket category (assistance, billing, incident)
+      --editor                Use a text editor to define parameters
+      --from-file string      File containing parameters
+  -h, --help                  help for create
+      --impact string         Ticket impact - Business/Enterprise support only (low, medium, high)
+      --init-file string      Create a file with example parameters
+      --product string        Ticket product (adsl, cdn, dedicated, dedicated-billing, dedicated-other, dedicatedcloud, domain, exchange, fax, hosting, housing, iaas, mail, network, publiccloud, sms, ssl, storage, telecom-billing, telecom-other, vac, voip, vps, web-billing, web-other)
+      --replace               Replace parameters file if it already exists
+      --service-name string   Service name (resource identifier) the ticket is about
+      --subcategory string    Ticket subcategory (alerts, autorenew, bill, down, inProgress, new, other, perfs, start, usage)
+      --subject string        Ticket subject (short summary)
+      --urgency string        Ticket urgency - Business/Enterprise support only (low, medium, high)
+      --watchers strings      Comma-separated list of e-mail addresses to notify on ticket updates (max. 10)
+```
+
+### Options inherited from parent commands
+
+```
+  -d, --debug            Activate debug mode (will log all HTTP requests details)
+  -e, --ignore-errors    Ignore errors in API calls when it is not fatal to the execution
+  -o, --output string    Output format: json, yaml, interactive, or a custom format expression (using https://github.com/PaesslerAG/gval syntax)
+                         Examples:
+                           --output json
+                           --output yaml
+                           --output interactive
+                           --output 'id' (to extract a single field)
+                           --output 'nested.field.subfield' (to extract a nested field)
+                           --output '[id, "name"]' (to extract multiple fields as an array)
+                           --output '{"newKey": oldKey, "otherKey": nested.field}' (to extract and rename fields in an object)
+                           --output 'name+","+type' (to extract and concatenate fields in a string)
+                           --output '(nbFieldA + nbFieldB) * 10' (to compute values from numeric fields)
+      --profile string   Use a specific profile from the configuration file
+```
+
+### SEE ALSO
+
+* [ovhcloud support-tickets](ovhcloud_support-tickets.md)	 - Retrieve information and manage your support tickets
+

--- a/internal/assets/api-schemas/support.json
+++ b/internal/assets/api-schemas/support.json
@@ -1,0 +1,947 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "OVHcloud API specification",
+    "description": "Specification for OVHcloud API",
+    "version": "1.0",
+    "contact": {
+      "name": "OVH",
+      "email": "api@ml.ovh.net"
+    }
+  },
+  "servers": [
+    {
+      "url": "https://eu.api.ovh.com/v1"
+    }
+  ],
+  "components": {
+    "schemas": {
+      "any": {
+        "description": "Can be anything (text, int, bool, json, html, etc.)",
+        "example": "This is a content of any type !"
+      },
+      "duration": {
+        "type": "string",
+        "description": "Duration (e.g., P1Y2M3DT4H6M9S)",
+        "example": "P1Y2M3DT4H6M9S"
+      },
+      "email": {
+        "type": "string",
+        "description": "Email address (e.g., api@ml.ovh.net)",
+        "format": "email",
+        "example": "api@ml.ovh.net"
+      },
+      "internationalPhoneNumber": {
+        "type": "string",
+        "description": "International phone number",
+        "format": "phone-number"
+      },
+      "ip": {
+        "type": "string",
+        "description": "IP address (e.g., 192.0.2.0)",
+        "format": "ipv4",
+        "example": "192.0.2.0"
+      },
+      "ipBlock": {
+        "type": "string",
+        "description": "IP (v4 or v6) CIDR notation (e.g., 192.0.2.0/24)",
+        "format": "ip-block",
+        "example": "192.0.2.0/24"
+      },
+      "ipInterface": {
+        "type": "string",
+        "description": "IP address (e.g., 192.0.2.0)",
+        "format": "ipv4",
+        "example": "192.0.2.0"
+      },
+      "ipv4": {
+        "type": "string",
+        "description": "IPv4 address (e.g., 192.0.2.0)",
+        "format": "ipv4",
+        "example": "192.0.2.0"
+      },
+      "ipv4Block": {
+        "type": "string",
+        "description": "IPv4 CIDR notation (e.g., 192.0.2.0/24)",
+        "format": "ipv4-block",
+        "example": "192.0.2.0/24"
+      },
+      "ipv6": {
+        "type": "string",
+        "description": "IPv6 address (e.g., 2001:41d0:1:1994::1)",
+        "format": "ipv6",
+        "example": "2001:41d0:1:1994::1"
+      },
+      "ipv6Block": {
+        "type": "string",
+        "description": "IPv6 CIDR notation (e.g., 2001:41d0::/128)",
+        "format": "ipv6-block",
+        "example": "2001:41d0::/128"
+      },
+      "macAddress": {
+        "type": "string",
+        "description": "MAC address (e.g., 2001:4860:4860::8844)",
+        "format": "mac-address",
+        "example": "2001:4860:4860::8888. 2001:4860:4860::8844"
+      },
+      "phoneNumber": {
+        "type": "string",
+        "description": "Phone number",
+        "format": "phone-number"
+      },
+      "support.Message": {
+        "type": "object",
+        "description": "Support ticket message",
+        "properties": {
+          "body": {
+            "type": "string",
+            "description": "Message body"
+          },
+          "creationDate": {
+            "type": "string",
+            "description": "Message creation date",
+            "format": "date-time"
+          },
+          "from": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/support.MessageSenderEnum"
+              }
+            ],
+            "description": "Message sender type"
+          },
+          "messageId": {
+            "type": "integer",
+            "description": "Message identifier"
+          },
+          "ticketId": {
+            "type": "integer",
+            "description": "Ticket identifier"
+          },
+          "updateDate": {
+            "type": "string",
+            "description": "Message last update date",
+            "format": "date-time"
+          }
+        }
+      },
+      "support.MessageSenderEnum": {
+        "type": "string",
+        "description": "Message sender type",
+        "enum": [
+          "customer",
+          "support"
+        ]
+      },
+      "support.NewMessageInfo": {
+        "type": "object",
+        "description": "Newly created support identifiers",
+        "properties": {
+          "additionalNotice": {
+            "type": "string",
+            "description": "Notice or warning",
+            "nullable": true
+          },
+          "messageId": {
+            "type": "integer",
+            "description": "Message identifier"
+          },
+          "ticketId": {
+            "type": "integer",
+            "description": "Ticket identifier"
+          },
+          "ticketNumber": {
+            "type": "integer",
+            "description": "Ticket external number"
+          }
+        }
+      },
+      "support.Ticket": {
+        "type": "object",
+        "description": "Support Ticket",
+        "properties": {
+          "accountId": {
+            "type": "string",
+            "description": "Customer account identifier"
+          },
+          "canBeClosed": {
+            "type": "boolean",
+            "description": "Can this ticket be closed or not"
+          },
+          "category": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/support.TicketCategoryEnum"
+              }
+            ],
+            "description": "Ticket request category",
+            "nullable": true
+          },
+          "creationDate": {
+            "type": "string",
+            "description": "Ticket creation date",
+            "format": "date-time"
+          },
+          "lastMessageFrom": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/support.MessageSenderEnum"
+              }
+            ],
+            "description": "Sender type of last message"
+          },
+          "product": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/support.TicketProductEnum"
+              }
+            ],
+            "description": "Product service concerned by ticket",
+            "nullable": true
+          },
+          "score": {
+            "type": "string",
+            "description": "Ticket score"
+          },
+          "serviceName": {
+            "type": "string",
+            "description": "Name of service concerned by ticket",
+            "nullable": true
+          },
+          "state": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/support.TicketStatusEnum"
+              }
+            ],
+            "description": "State of ticket"
+          },
+          "subject": {
+            "type": "string",
+            "description": "Ticket subject"
+          },
+          "ticketId": {
+            "type": "integer",
+            "description": "Ticket identifier"
+          },
+          "ticketNumber": {
+            "type": "integer",
+            "description": "Ticket external number"
+          },
+          "type": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/support.TicketTypeEnum"
+              }
+            ],
+            "description": "Ticket type"
+          },
+          "updateDate": {
+            "type": "string",
+            "description": "Ticket last update date",
+            "format": "date-time"
+          }
+        }
+      },
+      "support.TicketCategoryEnum": {
+        "type": "string",
+        "description": "Ticket request category",
+        "enum": [
+          "assistance",
+          "billing",
+          "incident"
+        ]
+      },
+      "support.TicketImpactUrgencyEnum": {
+        "type": "string",
+        "description": "Ticket level of impact or urgency (reserved for Business or Enterprise support level accounts)",
+        "enum": [
+          "high",
+          "low",
+          "medium"
+        ]
+      },
+      "support.TicketProductEnum": {
+        "type": "string",
+        "description": "Ticket product",
+        "enum": [
+          "adsl",
+          "cdn",
+          "dedicated",
+          "dedicated-billing",
+          "dedicated-other",
+          "dedicatedcloud",
+          "domain",
+          "exchange",
+          "fax",
+          "hosting",
+          "housing",
+          "iaas",
+          "mail",
+          "network",
+          "publiccloud",
+          "sms",
+          "ssl",
+          "storage",
+          "telecom-billing",
+          "telecom-other",
+          "vac",
+          "voip",
+          "vps",
+          "web-billing",
+          "web-other"
+        ]
+      },
+      "support.TicketStatusEnum": {
+        "type": "string",
+        "description": "Support ticket statuses",
+        "enum": [
+          "closed",
+          "open",
+          "unknown"
+        ]
+      },
+      "support.TicketSubCategoryEnum": {
+        "type": "string",
+        "description": "Ticket request subcategory",
+        "enum": [
+          "alerts",
+          "autorenew",
+          "bill",
+          "down",
+          "inProgress",
+          "new",
+          "other",
+          "perfs",
+          "start",
+          "usage"
+        ]
+      },
+      "support.TicketTypeEnum": {
+        "type": "string",
+        "description": "DEPRECATED - Ticket type (criticalIntervention requires VIP support level)",
+        "enum": [
+          "criticalIntervention",
+          "genericRequest"
+        ]
+      },
+      "time": {
+        "type": "string",
+        "description": "Time (e.g., 15:04:05)",
+        "format": "time",
+        "example": "15:04:05"
+      }
+    },
+    "securitySchemes": {
+      "oAuth2AuthCode": {
+        "type": "oauth2",
+        "description": "Oauth2",
+        "x-client-id": "1bb9c7df371741c0",
+        "x-client-secret": "a5b4de870aca620d10fbf63cd18d205b",
+        "flows": {
+          "authorizationCode": {
+            "authorizationUrl": "https://auth.eu.ovhcloud.com/oauth2/authorize",
+            "tokenUrl": "https://auth.eu.ovhcloud.com/oauth2/token",
+            "scopes": {
+              "account/all": "Manage your account",
+              "all": "Manage your whole account and all your services",
+              "services/all": "Manage your services lifecycle and billing"
+            }
+          }
+        }
+      }
+    }
+  },
+  "paths": {
+    "/support/tickets": {
+      "get": {
+        "summary": "List support tickets identifiers for this service",
+        "security": [
+          {
+            "oAuth2AuthCode": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "archived",
+            "description": "Search archived tickets",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "in": "query",
+            "name": "category",
+            "description": "Search by ticket category",
+            "schema": {
+              "$ref": "#/components/schemas/support.TicketCategoryEnum"
+            }
+          },
+          {
+            "in": "query",
+            "name": "customerReplyNeeded",
+            "description": "Tickets pending a customer reply",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "in": "query",
+            "name": "excludeAutogenerated",
+            "description": "Exclude auto-generated tickets",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "in": "query",
+            "name": "maxCreationDate",
+            "description": "Maximum creation date",
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
+          },
+          {
+            "in": "query",
+            "name": "minCreationDate",
+            "description": "Minimum creation date",
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "description": "Page of tickets to fetch (only if pageSize is defined)",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "description": "Number of ticket to fetch",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "product",
+            "description": "Search by ticket product",
+            "schema": {
+              "$ref": "#/components/schemas/support.TicketProductEnum"
+            }
+          },
+          {
+            "in": "query",
+            "name": "serviceName",
+            "description": "Ticket message service name",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "status",
+            "description": "Status of ticket",
+            "schema": {
+              "$ref": "#/components/schemas/support.TicketStatusEnum"
+            }
+          },
+          {
+            "in": "query",
+            "name": "subject",
+            "description": "Search by ticket subject",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "ticketNumber",
+            "description": "Search by ticket number",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "integer"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-badges": [
+          {
+            "color": "green",
+            "label": "Stable production version"
+          }
+        ],
+        "x-iam-actions": [
+          {
+            "name": "account:apiovh:support/tickets/get",
+            "required": true
+          }
+        ],
+        "x-expanded-response": "SupportTicket"
+      }
+    },
+    "/support/tickets/create": {
+      "post": {
+        "summary": "Create a new ticket",
+        "security": [
+          {
+            "oAuth2AuthCode": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "body": {
+                    "type": "string",
+                    "description": "Ticket message body"
+                  },
+                  "category": {
+                    "description": "Ticket message category",
+                    "$ref": "#/components/schemas/support.TicketCategoryEnum"
+                  },
+                  "impact": {
+                    "description": "Ticket impact (reserved for Business or Enterprise support level accounts)",
+                    "$ref": "#/components/schemas/support.TicketImpactUrgencyEnum"
+                  },
+                  "product": {
+                    "description": "Ticket message product",
+                    "$ref": "#/components/schemas/support.TicketProductEnum"
+                  },
+                  "serviceName": {
+                    "type": "string",
+                    "description": "Ticket message service name"
+                  },
+                  "subcategory": {
+                    "description": "Ticket message subcategory",
+                    "$ref": "#/components/schemas/support.TicketSubCategoryEnum"
+                  },
+                  "subject": {
+                    "type": "string",
+                    "description": "Ticket message subject"
+                  },
+                  "type": {
+                    "description": "DEPRECATED - Ticket type (criticalIntervention requires VIP support level)",
+                    "$ref": "#/components/schemas/support.TicketTypeEnum"
+                  },
+                  "urgency": {
+                    "description": "Ticket urgency (reserved for Business or Enterprise support level accounts)",
+                    "$ref": "#/components/schemas/support.TicketImpactUrgencyEnum"
+                  },
+                  "watchers": {
+                    "type": "array",
+                    "description": "List of e-mail addresses to notify on ticket updates (max. 10)",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "required": [
+                  "body",
+                  "subject"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/support.NewMessageInfo"
+                }
+              }
+            }
+          }
+        },
+        "x-badges": [
+          {
+            "color": "green",
+            "label": "Stable production version"
+          }
+        ],
+        "x-iam-actions": [
+          {
+            "name": "account:apiovh:support/tickets/create",
+            "required": true
+          }
+        ]
+      }
+    },
+    "/support/tickets/{ticketId}": {
+      "get": {
+        "summary": "Get ticket",
+        "security": [
+          {
+            "oAuth2AuthCode": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "ticketId",
+            "description": "internal identifier ticket",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/support.Ticket"
+                }
+              }
+            }
+          }
+        },
+        "x-badges": [
+          {
+            "color": "green",
+            "label": "Stable production version"
+          }
+        ],
+        "x-iam-actions": [
+          {
+            "name": "account:apiovh:support/tickets/get",
+            "required": true
+          }
+        ]
+      }
+    },
+    "/support/tickets/{ticketId}/canBeScored": {
+      "get": {
+        "summary": "Checks whether ticket can be scored",
+        "security": [
+          {
+            "oAuth2AuthCode": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "ticketId",
+            "description": "internal ticket identifier",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        },
+        "x-badges": [
+          {
+            "color": "green",
+            "label": "Stable production version"
+          }
+        ],
+        "x-iam-actions": [
+          {
+            "name": "account:apiovh:support/tickets/canBeScored/get",
+            "required": true
+          }
+        ]
+      }
+    },
+    "/support/tickets/{ticketId}/close": {
+      "post": {
+        "summary": "Close ticket",
+        "security": [
+          {
+            "oAuth2AuthCode": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "ticketId",
+            "description": "internal ticket identifier",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation"
+          }
+        },
+        "x-badges": [
+          {
+            "color": "green",
+            "label": "Stable production version"
+          }
+        ],
+        "x-iam-actions": [
+          {
+            "name": "account:apiovh:support/tickets/close",
+            "required": true
+          }
+        ]
+      }
+    },
+    "/support/tickets/{ticketId}/messages": {
+      "get": {
+        "summary": "Get ticket messages",
+        "security": [
+          {
+            "oAuth2AuthCode": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "ticketId",
+            "description": "internal ticket identifier",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/support.Message"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-badges": [
+          {
+            "color": "green",
+            "label": "Stable production version"
+          }
+        ],
+        "x-iam-actions": [
+          {
+            "name": "account:apiovh:support/tickets/messages/get",
+            "required": true
+          }
+        ]
+      }
+    },
+    "/support/tickets/{ticketId}/reopen": {
+      "post": {
+        "summary": "Reopen a ticket",
+        "security": [
+          {
+            "oAuth2AuthCode": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "ticketId",
+            "description": "internal ticket identifier",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "body": {
+                    "type": "string",
+                    "description": "ticket reopen reason"
+                  }
+                },
+                "required": [
+                  "body"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "successful operation"
+          }
+        },
+        "x-badges": [
+          {
+            "color": "green",
+            "label": "Stable production version"
+          }
+        ],
+        "x-iam-actions": [
+          {
+            "name": "account:apiovh:support/tickets/reopen",
+            "required": true
+          }
+        ]
+      }
+    },
+    "/support/tickets/{ticketId}/reply": {
+      "post": {
+        "summary": "Reply to ticket",
+        "security": [
+          {
+            "oAuth2AuthCode": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "ticketId",
+            "description": "internal ticket identifier",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "body": {
+                    "type": "string",
+                    "description": "text body of ticket response"
+                  }
+                },
+                "required": [
+                  "body"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "successful operation"
+          }
+        },
+        "x-badges": [
+          {
+            "color": "green",
+            "label": "Stable production version"
+          }
+        ],
+        "x-iam-actions": [
+          {
+            "name": "account:apiovh:support/tickets/reply",
+            "required": true
+          }
+        ]
+      }
+    },
+    "/support/tickets/{ticketId}/score": {
+      "post": {
+        "summary": "Set ticket score",
+        "security": [
+          {
+            "oAuth2AuthCode": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "ticketId",
+            "description": "internal ticket identifier",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "score": {
+                    "type": "string",
+                    "description": "ticket score"
+                  },
+                  "scoreComment": {
+                    "type": "string",
+                    "description": "ticket comment about the score"
+                  }
+                },
+                "required": [
+                  "score"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "successful operation"
+          }
+        },
+        "x-badges": [
+          {
+            "color": "green",
+            "label": "Stable production version"
+          }
+        ],
+        "x-iam-actions": [
+          {
+            "name": "account:apiovh:support/tickets/score",
+            "required": true
+          }
+        ]
+      }
+    }
+  }
+}

--- a/internal/assets/assets.go
+++ b/internal/assets/assets.go
@@ -74,6 +74,9 @@ var (
 	//go:embed api-schemas/storagenetapp.json
 	StoragenetappOpenapiSchema []byte
 
+	//go:embed api-schemas/support.json
+	SupportOpenapiSchema []byte
+
 	//go:embed api-schemas/telephony.json
 	TelephonyOpenapiSchema []byte
 

--- a/internal/assets/assets_wasm.go
+++ b/internal/assets/assets_wasm.go
@@ -28,6 +28,7 @@ var (
 	SmsOpenapiSchema                             []byte
 	SslgatewayOpenapiSchema                      []byte
 	StoragenetappOpenapiSchema                   []byte
+	SupportOpenapiSchema                         []byte
 	TelephonyOpenapiSchema                       []byte
 	VmwareclouddirectorbackupOpenapiSchema       []byte
 	VmwareclouddirectororganizationOpenapiSchema []byte

--- a/internal/cmd/supporttickets.go
+++ b/internal/cmd/supporttickets.go
@@ -5,6 +5,7 @@
 package cmd
 
 import (
+	"github.com/ovh/ovhcloud-cli/internal/assets"
 	"github.com/ovh/ovhcloud-cli/internal/services/supporttickets"
 	"github.com/spf13/cobra"
 )
@@ -53,5 +54,72 @@ func init() {
 	_ = supportticketsReplyCmd.MarkFlagRequired("body")
 	supportticketsCmd.AddCommand(supportticketsReplyCmd)
 
+	supportticketsCmd.AddCommand(getSupportTicketCreateCmd())
+
 	rootCmd.AddCommand(supportticketsCmd)
+}
+
+func getSupportTicketCreateCmd() *cobra.Command {
+	createCmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a new support ticket",
+		Long: `Use this command to create a new support ticket.
+There are three ways to define the creation parameters:
+
+1. Using only CLI flags:
+
+	ovhcloud support-tickets create --subject 'My issue' --body 'Detailed description of the issue' --product publiccloud --category assistance
+
+2. Using a configuration file:
+
+  First you can generate an example of parameters file using the following command:
+
+	ovhcloud support-tickets create --init-file ./params.json
+
+  You will be able to choose from several examples of parameters. Once an example has been selected, the content is written in the given file.
+  After editing the file to set the correct creation parameters, run:
+
+	ovhcloud support-tickets create --from-file ./params.json
+
+  Note that you can also pipe the content of the parameters file, like the following:
+
+	cat ./params.json | ovhcloud support-tickets create
+
+  In both cases, you can override the parameters in the given file using command line flags, for example:
+
+	ovhcloud support-tickets create --from-file ./params.json --subject 'Overridden subject'
+
+3. Using your default text editor:
+
+	ovhcloud support-tickets create --editor
+
+  You will be able to choose from several examples of parameters. Once an example has been selected, the CLI will open your
+  default text editor to update the parameters. When saving the file, the creation will start.
+
+  Note that it is also possible to override values in the presented examples using command line flags like the following:
+
+	ovhcloud support-tickets create --editor --subject 'Overridden subject'
+`,
+		Run:  supporttickets.CreateSupportTicket,
+		Args: cobra.NoArgs,
+	}
+
+	createCmd.Flags().StringVar(&supporttickets.CreateSpec.Subject, "subject", "", "Ticket subject (short summary)")
+	createCmd.Flags().StringVar(&supporttickets.CreateSpec.Body, "body", "", "Ticket message body")
+	createCmd.Flags().StringVar(&supporttickets.CreateSpec.Category, "category", "", "Ticket category (assistance, billing, incident)")
+	createCmd.Flags().StringVar(&supporttickets.CreateSpec.Product, "product", "", "Ticket product (adsl, cdn, dedicated, dedicated-billing, dedicated-other, dedicatedcloud, domain, exchange, fax, hosting, housing, iaas, mail, network, publiccloud, sms, ssl, storage, telecom-billing, telecom-other, vac, voip, vps, web-billing, web-other)")
+	createCmd.Flags().StringVar(&supporttickets.CreateSpec.ServiceName, "service-name", "", "Service name (resource identifier) the ticket is about")
+	createCmd.Flags().StringVar(&supporttickets.CreateSpec.Subcategory, "subcategory", "", "Ticket subcategory (alerts, autorenew, bill, down, inProgress, new, other, perfs, start, usage)")
+	createCmd.Flags().StringVar(&supporttickets.CreateSpec.Impact, "impact", "", "Ticket impact - Business/Enterprise support only (low, medium, high)")
+	createCmd.Flags().StringVar(&supporttickets.CreateSpec.Urgency, "urgency", "", "Ticket urgency - Business/Enterprise support only (low, medium, high)")
+	createCmd.Flags().StringVar(&supporttickets.CreateSpec.Type, "type", "", "Ticket type - DEPRECATED (criticalIntervention, genericRequest)")
+	_ = createCmd.Flags().MarkHidden("type")
+	createCmd.Flags().StringSliceVar(&supporttickets.CreateSpec.Watchers, "watchers", nil, "Comma-separated list of e-mail addresses to notify on ticket updates (max. 10)")
+
+	// Common flags for other means to define parameters
+	addParameterFileFlags(createCmd, false, assets.SupportOpenapiSchema, "/support/tickets/create", "post", supporttickets.TicketCreateExample, nil)
+	addInteractiveEditorFlag(createCmd)
+	markFlagsMutuallyExclusive(createCmd, "from-file", "editor")
+
+	return createCmd
 }

--- a/internal/cmd/supporttickets_test.go
+++ b/internal/cmd/supporttickets_test.go
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: 2025 OVH SAS <opensource@ovh.net>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd_test
+
+import (
+	"net/http"
+
+	"github.com/jarcoal/httpmock"
+	"github.com/maxatome/go-testdeep/td"
+	"github.com/maxatome/tdhttpmock"
+	"github.com/ovh/ovhcloud-cli/internal/cmd"
+)
+
+func (ms *MockSuite) TestSupportTicketsCreateCmd(assert, require *td.T) {
+	httpmock.RegisterMatcherResponder(http.MethodPost,
+		"https://eu.api.ovh.com/v1/support/tickets/create",
+		tdhttpmock.JSONBody(td.JSON(`
+			{
+				"body":        "Detailed description",
+				"category":    "assistance",
+				"product":     "publiccloud",
+				"serviceName": "service-id",
+				"subject":     "Short summary"
+			}`,
+		)),
+		httpmock.NewStringResponder(200, `
+		{
+			"ticketId": 15647305,
+			"ticketNumber": 9876543,
+			"messageId": 42
+		}`),
+	)
+
+	out, err := cmd.Execute("support-tickets", "create",
+		"--subject", "Short summary",
+		"--body", "Detailed description",
+		"--category", "assistance",
+		"--product", "publiccloud",
+		"--service-name", "service-id",
+	)
+	require.CmpNoError(err)
+	assert.String(out, `✅ Ticket 15647305 (number 9876543) created successfully`)
+}
+
+func (ms *MockSuite) TestSupportTicketsCreateCmdMissingMandatoryField(assert, require *td.T) {
+	// No httpmock responder registered: the mandatory-field check in
+	// common.CreateResource must fire before any HTTP call is attempted.
+	out, _ := cmd.Execute("support-tickets", "create", "--body", "Detailed description")
+	assert.Cmp(out, td.Contains(`🛑`))
+	assert.Cmp(out, td.Contains(`mandatory field "subject"`))
+}
+
+func (ms *MockSuite) TestSupportTicketsCreateCmdMutuallyExclusiveFlags(assert, require *td.T) {
+	// --from-file and --editor are mutually exclusive; cobra rejects the
+	// combination before any HTTP call is attempted.
+	_, err := cmd.Execute("support-tickets", "create",
+		"--from-file", "/dev/null",
+		"--editor",
+	)
+	require.CmpError(err)
+	assert.Cmp(err.Error(), td.Contains(`[from-file editor]`))
+}

--- a/internal/services/supporttickets/parameter-samples/ticket-create.json
+++ b/internal/services/supporttickets/parameter-samples/ticket-create.json
@@ -1,0 +1,7 @@
+{
+  "body": "Please describe your issue here.",
+  "category": "assistance",
+  "product": "publiccloud",
+  "subcategory": "other",
+  "subject": "Short summary of the issue"
+}

--- a/internal/services/supporttickets/supporttickets.go
+++ b/internal/services/supporttickets/supporttickets.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net/url"
 
+	"github.com/ovh/ovhcloud-cli/internal/assets"
 	"github.com/ovh/ovhcloud-cli/internal/display"
 	"github.com/ovh/ovhcloud-cli/internal/flags"
 	httpLib "github.com/ovh/ovhcloud-cli/internal/http"
@@ -23,9 +24,26 @@ var (
 	//go:embed templates/supporttickets.tmpl
 	supportticketsTemplate string
 
+	//go:embed parameter-samples/ticket-create.json
+	TicketCreateExample string
+
 	// ReplySpec holds the parameters for the reply command.
 	ReplySpec struct {
 		Body string `json:"body,omitempty"`
+	}
+
+	// CreateSpec holds the parameters for the create command.
+	CreateSpec struct {
+		Body        string   `json:"body,omitempty"`
+		Category    string   `json:"category,omitempty"`
+		Impact      string   `json:"impact,omitempty"`
+		Product     string   `json:"product,omitempty"`
+		ServiceName string   `json:"serviceName,omitempty"`
+		Subcategory string   `json:"subcategory,omitempty"`
+		Subject     string   `json:"subject,omitempty"`
+		Type        string   `json:"type,omitempty"`
+		Urgency     string   `json:"urgency,omitempty"`
+		Watchers    []string `json:"watchers,omitempty"`
 	}
 )
 
@@ -51,4 +69,32 @@ func ReplySupportTicket(_ *cobra.Command, args []string) {
 	}
 
 	display.OutputInfo(&flags.OutputFormatConfig, nil, "✅ Reply sent successfully")
+}
+
+func CreateSupportTicket(cmd *cobra.Command, _ []string) {
+	createdResource, err := common.CreateResource(
+		cmd,
+		"/support/tickets/create",
+		"/v1/support/tickets/create",
+		TicketCreateExample,
+		CreateSpec,
+		assets.SupportOpenapiSchema,
+		[]string{"body", "subject"})
+	if err != nil {
+		display.OutputError(&flags.OutputFormatConfig, "failed to create ticket: %s", err)
+		return
+	}
+
+	ticketID, hasID := createdResource["ticketId"]
+	hasID = hasID && ticketID != nil
+	ticketNumber, hasNumber := createdResource["ticketNumber"]
+	hasNumber = hasNumber && ticketNumber != nil
+	switch {
+	case hasID && hasNumber:
+		display.OutputInfo(&flags.OutputFormatConfig, nil, "✅ Ticket %v (number %v) created successfully", ticketID, ticketNumber)
+	case hasID:
+		display.OutputInfo(&flags.OutputFormatConfig, nil, "✅ Ticket %v created successfully", ticketID)
+	default:
+		display.OutputInfo(&flags.OutputFormatConfig, nil, "✅ Ticket created successfully")
+	}
 }


### PR DESCRIPTION
# Description

Adds `ovhcloud support-tickets create`, which calls `POST /support/tickets/create`. The `support-tickets` subtree already exposes `list` / `get` / `messages` / `reply` — this completes the CRUD surface for the support API.

Fixes #187.

Example:

```
ovhcloud support-tickets create \
    --subject 'My issue' \
    --body 'Detailed description' \
    --product publiccloud \
    --category assistance \
    --service-name <id>
```

## Implementation notes

Follows the existing IAM-user-create pattern:

- **`internal/services/supporttickets/supporttickets.go`** — `CreateSpec` struct (one field per request-body property) + `TicketCreateExample` embed + `CreateSupportTicket(cmd, _)` that delegates to `common.CreateResource` with mandatory fields `["body", "subject"]`. Output prefers `ticketId` + `ticketNumber` from the response, with a nil-value guard so a JSON-null id falls through to a generic success message.
- **`internal/cmd/supporttickets.go`** — cobra subcommand exposing typed flags for every field of the request body (`--subject`, `--body`, `--category`, `--product`, `--service-name`, `--subcategory`, `--impact`, `--urgency`, `--type`, `--watchers`) plus the standard `--from-file` / `--init-file` / `--editor` UX helpers. `--from-file` and `--editor` marked mutually exclusive via `markFlagsMutuallyExclusive`. `--type` is wired but `MarkHidden`: the OpenAPI spec marks its values DEPRECATED, but keeping the flag functional means `--from-file` JSON payloads carrying a `type` field still parse without an "unknown field" error.
- **`internal/assets/{assets,assets_wasm}.go`** — embed `support.json`, fetched via `make schemas UNIVERSE=support`.
- **`internal/services/supporttickets/parameter-samples/ticket-create.json`** — minimal example body for `--init-file` / `--editor` (no `serviceName` placeholder, so a user who runs `--from-file` without editing it doesn't POST a literal `<your-service-id>` string).
- **`internal/cmd/supporttickets_test.go`** — happy-path test mirroring the `httpmock` + `tdhttpmock.JSONBody` pattern used by `TestIAMPolicyCreateCmd`, plus two error-path tests: mandatory-field check (`mandatory field "subject" is missing`) and the `--from-file` / `--editor` mutual-exclusion guard.
- **`doc/ovhcloud_support-tickets*.md`** — regenerated via `make doc`.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have commented my code
- [x] I ran `go mod tidy`
- [x] I have added tests that prove my fix is effective or that my feature works

## Test plan

- [x] `go build ./...`
- [x] `GOOS=js GOARCH=wasm go build ./...`
- [x] `go test ./...` (includes new `TestSupportTicketsCreateCmd` + error-path tests)
- [x] `make doc` — no spurious changes outside the new command
- [x] `--help` output renders flags grouped correctly (input flags in their own section)
- [x] Manual smoke against `eu.api.ovh.com` — ticket created end-to-end

## DCO

`Signed-off-by: Jean Humann <jean.humann@cleyrop.com>` on the single commit.
