### PR TITLE
feat(cloud): add ai authorization commands to manage AI Endpoints access

### DIFF
--- a/doc/ovhcloud_cloud.md
+++ b/doc/ovhcloud_cloud.md
@@ -30,6 +30,7 @@ Manage your projects and services in the Public Cloud universe (MKS, MPR, MRS, O
 ### SEE ALSO
 
 * [ovhcloud](ovhcloud.md)	 - CLI to manage your OVHcloud services
+* [ovhcloud cloud ai](ovhcloud_cloud_ai.md)	 - Manage AI Endpoints settings for your cloud project
 * [ovhcloud cloud alerting](ovhcloud_cloud_alerting.md)	 - Manage billing alert configurations in the given cloud project
 * [ovhcloud cloud instance](ovhcloud_cloud_instance.md)	 - Manage instances in the given cloud project
 * [ovhcloud cloud ip](ovhcloud_cloud_ip.md)	 - Manage public IPs (floating and failover) in the given cloud project

--- a/doc/ovhcloud_cloud_ai.md
+++ b/doc/ovhcloud_cloud_ai.md
@@ -1,0 +1,35 @@
+## ovhcloud cloud ai
+
+Manage AI Endpoints settings for your cloud project
+
+### Options
+
+```
+      --cloud-project string   Cloud project ID
+  -h, --help                   help for ai
+```
+
+### Options inherited from parent commands
+
+```
+  -d, --debug            Activate debug mode (will log all HTTP requests details)
+  -e, --ignore-errors    Ignore errors in API calls when it is not fatal to the execution
+  -o, --output string    Output format: json, yaml, interactive, or a custom format expression (using https://github.com/PaesslerAG/gval syntax)
+                         Examples:
+                           --output json
+                           --output yaml
+                           --output interactive
+                           --output 'id' (to extract a single field)
+                           --output 'nested.field.subfield' (to extract a nested field)
+                           --output '[id, "name"]' (to extract multiple fields as an array)
+                           --output '{"newKey": oldKey, "otherKey": nested.field}' (to extract and rename fields in an object)
+                           --output 'name+","+type' (to extract and concatenate fields in a string)
+                           --output '(nbFieldA + nbFieldB) * 10' (to compute values from numeric fields)
+      --profile string   Use a specific profile from the configuration file
+```
+
+### SEE ALSO
+
+* [ovhcloud cloud](ovhcloud_cloud.md)	 - Manage your projects and services in the Public Cloud universe (MKS, MPR, MRS, Object Storage...)
+* [ovhcloud cloud ai authorization](ovhcloud_cloud_ai_authorization.md)	 - Manage AI Endpoints authorization for the project
+

--- a/doc/ovhcloud_cloud_ai_authorization.md
+++ b/doc/ovhcloud_cloud_ai_authorization.md
@@ -1,0 +1,36 @@
+## ovhcloud cloud ai authorization
+
+Manage AI Endpoints authorization for the project
+
+### Options
+
+```
+  -h, --help   help for authorization
+```
+
+### Options inherited from parent commands
+
+```
+      --cloud-project string   Cloud project ID
+  -d, --debug                  Activate debug mode (will log all HTTP requests details)
+  -e, --ignore-errors          Ignore errors in API calls when it is not fatal to the execution
+  -o, --output string          Output format: json, yaml, interactive, or a custom format expression (using https://github.com/PaesslerAG/gval syntax)
+                               Examples:
+                                 --output json
+                                 --output yaml
+                                 --output interactive
+                                 --output 'id' (to extract a single field)
+                                 --output 'nested.field.subfield' (to extract a nested field)
+                                 --output '[id, "name"]' (to extract multiple fields as an array)
+                                 --output '{"newKey": oldKey, "otherKey": nested.field}' (to extract and rename fields in an object)
+                                 --output 'name+","+type' (to extract and concatenate fields in a string)
+                                 --output '(nbFieldA + nbFieldB) * 10' (to compute values from numeric fields)
+      --profile string         Use a specific profile from the configuration file
+```
+
+### SEE ALSO
+
+* [ovhcloud cloud ai](ovhcloud_cloud_ai.md)	 - Manage AI Endpoints settings for your cloud project
+* [ovhcloud cloud ai authorization create](ovhcloud_cloud_ai_authorization_create.md)	 - Authorize AI Endpoints usage on the project
+* [ovhcloud cloud ai authorization get](ovhcloud_cloud_ai_authorization_get.md)	 - Get the AI Endpoints authorization status of the project
+

--- a/doc/ovhcloud_cloud_ai_authorization_create.md
+++ b/doc/ovhcloud_cloud_ai_authorization_create.md
@@ -1,0 +1,38 @@
+## ovhcloud cloud ai authorization create
+
+Authorize AI Endpoints usage on the project
+
+```
+ovhcloud cloud ai authorization create [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for create
+```
+
+### Options inherited from parent commands
+
+```
+      --cloud-project string   Cloud project ID
+  -d, --debug                  Activate debug mode (will log all HTTP requests details)
+  -e, --ignore-errors          Ignore errors in API calls when it is not fatal to the execution
+  -o, --output string          Output format: json, yaml, interactive, or a custom format expression (using https://github.com/PaesslerAG/gval syntax)
+                               Examples:
+                                 --output json
+                                 --output yaml
+                                 --output interactive
+                                 --output 'id' (to extract a single field)
+                                 --output 'nested.field.subfield' (to extract a nested field)
+                                 --output '[id, "name"]' (to extract multiple fields as an array)
+                                 --output '{"newKey": oldKey, "otherKey": nested.field}' (to extract and rename fields in an object)
+                                 --output 'name+","+type' (to extract and concatenate fields in a string)
+                                 --output '(nbFieldA + nbFieldB) * 10' (to compute values from numeric fields)
+      --profile string         Use a specific profile from the configuration file
+```
+
+### SEE ALSO
+
+* [ovhcloud cloud ai authorization](ovhcloud_cloud_ai_authorization.md)	 - Manage AI Endpoints authorization for the project
+

--- a/doc/ovhcloud_cloud_ai_authorization_get.md
+++ b/doc/ovhcloud_cloud_ai_authorization_get.md
@@ -1,0 +1,38 @@
+## ovhcloud cloud ai authorization get
+
+Get the AI Endpoints authorization status of the project
+
+```
+ovhcloud cloud ai authorization get [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for get
+```
+
+### Options inherited from parent commands
+
+```
+      --cloud-project string   Cloud project ID
+  -d, --debug                  Activate debug mode (will log all HTTP requests details)
+  -e, --ignore-errors          Ignore errors in API calls when it is not fatal to the execution
+  -o, --output string          Output format: json, yaml, interactive, or a custom format expression (using https://github.com/PaesslerAG/gval syntax)
+                               Examples:
+                                 --output json
+                                 --output yaml
+                                 --output interactive
+                                 --output 'id' (to extract a single field)
+                                 --output 'nested.field.subfield' (to extract a nested field)
+                                 --output '[id, "name"]' (to extract multiple fields as an array)
+                                 --output '{"newKey": oldKey, "otherKey": nested.field}' (to extract and rename fields in an object)
+                                 --output 'name+","+type' (to extract and concatenate fields in a string)
+                                 --output '(nbFieldA + nbFieldB) * 10' (to compute values from numeric fields)
+      --profile string         Use a specific profile from the configuration file
+```
+
+### SEE ALSO
+
+* [ovhcloud cloud ai authorization](ovhcloud_cloud_ai_authorization.md)	 - Manage AI Endpoints authorization for the project
+

--- a/internal/cmd/cloud_ai.go
+++ b/internal/cmd/cloud_ai.go
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: 2025 OVH SAS <opensource@ovh.net>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"github.com/ovh/ovhcloud-cli/internal/services/cloud"
+	"github.com/spf13/cobra"
+)
+
+func initCloudAICommand(cloudCmd *cobra.Command) {
+	aiCmd := &cobra.Command{
+		Use:   "ai",
+		Short: "Manage AI Endpoints settings for your cloud project",
+	}
+	aiCmd.PersistentFlags().StringVar(&cloud.CloudProject, "cloud-project", "", "Cloud project ID")
+
+	// AI Endpoints authorization commands
+	aiAuthorizationCmd := &cobra.Command{
+		Use:   "authorization",
+		Short: "Manage AI Endpoints authorization for the project",
+	}
+
+	aiAuthorizationCmd.AddCommand(&cobra.Command{
+		Use:   "get",
+		Short: "Get the AI Endpoints authorization status of the project",
+		Run:   cloud.GetAIAuthorization,
+	})
+
+	aiAuthorizationCmd.AddCommand(&cobra.Command{
+		Use:   "create",
+		Short: "Authorize AI Endpoints usage on the project",
+		Run:   cloud.CreateAIAuthorization,
+	})
+
+	aiCmd.AddCommand(aiAuthorizationCmd)
+
+	cloudCmd.AddCommand(aiCmd)
+}

--- a/internal/cmd/cloud_ai_test.go
+++ b/internal/cmd/cloud_ai_test.go
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: 2025 OVH SAS <opensource@ovh.net>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd_test
+
+import (
+	"github.com/jarcoal/httpmock"
+	"github.com/maxatome/go-testdeep/td"
+	"github.com/ovh/ovhcloud-cli/internal/cmd"
+)
+
+// TestCloudAIAuthorizationGetCmd tests the "cloud ai authorization get" command
+func (ms *MockSuite) TestCloudAIAuthorizationGetCmd(assert, require *td.T) {
+	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/v1/cloud/project/test-project/ai/authorization",
+		httpmock.NewStringResponder(200, `{"authorized": true}`).Once())
+
+	out, err := cmd.Execute("cloud", "ai", "authorization", "get",
+		"--cloud-project", "test-project", "-o", "json")
+
+	require.CmpNoError(err)
+	assert.Cmp(out, td.Contains("authorized"))
+	assert.Cmp(out, td.Contains("true"))
+}
+
+// TestCloudAIAuthorizationCreateCmd tests the "cloud ai authorization create" command
+func (ms *MockSuite) TestCloudAIAuthorizationCreateCmd(assert, require *td.T) {
+	httpmock.RegisterResponder("POST", "https://eu.api.ovh.com/v1/cloud/project/test-project/ai/authorization",
+		httpmock.NewStringResponder(200, `{}`).Once())
+
+	out, err := cmd.Execute("cloud", "ai", "authorization", "create",
+		"--cloud-project", "test-project")
+
+	require.CmpNoError(err)
+	assert.Cmp(out, td.Contains("✅"))
+	assert.Cmp(out, td.Contains("AI Endpoints authorized successfully"))
+}

--- a/internal/cmd/cloud_project.go
+++ b/internal/cmd/cloud_project.go
@@ -101,6 +101,7 @@ func init() {
 		Run:   cloud.UnleashProject,
 	})
 
+	initCloudAICommand(cloudCmd)
 	initKubeCommand(cloudCmd)
 	initContainerRegistryCommand(cloudCmd)
 	initManagedDatabaseCommand(cloudCmd)

--- a/internal/services/cloud/cloud_ai.go
+++ b/internal/services/cloud/cloud_ai.go
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: 2025 OVH SAS <opensource@ovh.net>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cloud
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/ovh/ovhcloud-cli/internal/display"
+	"github.com/ovh/ovhcloud-cli/internal/flags"
+	httpLib "github.com/ovh/ovhcloud-cli/internal/http"
+)
+
+// GetAIAuthorization returns the AI Endpoints authorization status of the project
+func GetAIAuthorization(_ *cobra.Command, _ []string) {
+	projectID, err := getConfiguredCloudProject()
+	if err != nil {
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
+		return
+	}
+
+	var authorization map[string]any
+	endpoint := fmt.Sprintf("/v1/cloud/project/%s/ai/authorization", projectID)
+	if err := httpLib.Client.Get(endpoint, &authorization); err != nil {
+		display.OutputError(&flags.OutputFormatConfig, "error fetching AI Endpoints authorization: %s", err)
+		return
+	}
+
+	display.OutputObject(authorization, projectID, "", &flags.OutputFormatConfig)
+}
+
+// CreateAIAuthorization authorizes AI Endpoints usage on the project
+func CreateAIAuthorization(_ *cobra.Command, _ []string) {
+	projectID, err := getConfiguredCloudProject()
+	if err != nil {
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
+		return
+	}
+
+	endpoint := fmt.Sprintf("/v1/cloud/project/%s/ai/authorization", projectID)
+	if err := httpLib.Client.Post(endpoint, nil, nil); err != nil {
+		display.OutputError(&flags.OutputFormatConfig, "failed to authorize AI Endpoints: %s", err)
+		return
+	}
+
+	display.OutputInfo(&flags.OutputFormatConfig, nil, "✅ AI Endpoints authorized successfully")
+}


### PR DESCRIPTION
# Description

Adds `ovhcloud cloud project ai authorization get` and `ovhcloud cloud project ai authorization create`, which call `GET` / `POST /cloud/project/{serviceName}/ai/authorization`.

A Public Cloud project must be authorized before its AI Endpoints calls leave the anonymous rate-limit tier. The `cloud project` subtree already exposes `list` / `get` / `edit` / `service-info` / `unleash` / `termination`, but nothing for this gate, so users currently fall back to the OVH Manager or a raw API call to flip it from a script or provisioning runbook.

Example:

```
ovhcloud cloud project ai authorization get    --cloud-project <id>
ovhcloud cloud project ai authorization create --cloud-project <id>
```

## Implementation notes

Follows the existing `unleash` / `service-info` pattern:

- **`internal/services/cloud/cloud_project.go`** — `GetAIAuthorization(cmd, _)` does a `GET` and renders the `{authorized: bool}` object via `display.OutputObject` (empty template → JSON fallback, as used by other cloud getters). `CreateAIAuthorization(cmd, _)` does a bodyless `POST` and reports success. Both resolve the project through `getConfiguredCloudProject`, so they honor `--cloud-project` / `OVH_CLOUD_PROJECT_SERVICE` / config.
- **`internal/cmd/cloud_project.go`** — nests an `ai` → `authorization` cobra group under `cloud project` with `get` and `create` subcommands, inheriting the existing `--cloud-project` persistent flag. No request body, so no schema embed / parameter-samples are needed.
- **`internal/cmd/cloud_project_test.go`** — happy-path tests for both commands using the existing `httpmock` + go-testdeep `MockSuite` pattern.
- **`doc/ovhcloud_cloud_project*.md`** — regenerated via `make doc`.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have commented my code
- [x] I ran `go mod tidy`
- [x] I have added tests that prove my feature works

## Test plan

- [x] `go build ./...`
- [x] `GOOS=js GOARCH=wasm go build ./...`
- [x] `go test ./...` (includes new `TestCloudProjectAIAuthorizationGetCmd` + `TestCloudProjectAIAuthorizationCreateCmd`)
- [x] `make doc` — no spurious changes outside the new commands
- [x] `--help` renders the new `ai authorization get` / `create` commands with inherited `--cloud-project`

## DCO

`Signed-off-by: Jean Humann <jean.humann@cleyrop.com>` on the single commit.
