### PR TITLE
Add support for --output flags in config show

### DIFF
--- a/internal/display/display.go
+++ b/internal/display/display.go
@@ -181,22 +181,6 @@ func RenderTable(values []map[string]any, columnsToDisplay []string, outputForma
 }
 
 func RenderConfigTable(cfg *ini.File, outputformat *OutputFormat) {
-	var (
-		rows    [][]string
-		columns = []string{"section", "key", "value"}
-	)
-
-	for _, section := range cfg.Sections() {
-		if section.Name() == "DEFAULT" {
-			continue
-		}
-
-		rows = append(rows, []string{section.Name()})
-		for _, key := range section.Keys() {
-			value := ansi.Truncate(key.Value(), maxCellWidth, "…")
-			rows = append(rows, []string{"", key.Name(), value})
-		}
-	}
 	// if a custom output format is passed, it is used instead of rendering the Config Table
 	if outputformat.IsJson() || outputformat.IsYaml() || outputformat.IsInteractive() || outputformat.CustomFormat() != "" {
 		result := map[string]any{}
@@ -212,6 +196,23 @@ func RenderConfigTable(cfg *ini.File, outputformat *OutputFormat) {
 		}
 		OutputObject(result, "", "", outputformat)
 		return
+	}
+	// otherwise, render the config as a table
+	var (
+		rows    [][]string
+		columns = []string{"section", "key", "value"}
+	)
+
+	for _, section := range cfg.Sections() {
+		if section.Name() == "DEFAULT" {
+			continue
+		}
+
+		rows = append(rows, []string{section.Name()})
+		for _, key := range section.Keys() {
+			value := ansi.Truncate(key.Value(), maxCellWidth, "…")
+			rows = append(rows, []string{"", key.Name(), value})
+		}
 	}
 
 	var (

--- a/internal/display/display.go
+++ b/internal/display/display.go
@@ -180,7 +180,7 @@ func RenderTable(values []map[string]any, columnsToDisplay []string, outputForma
 	outputf("%s%s", t, "\n💡 Use option -o json or -o yaml to get the raw output with all information")
 }
 
-func RenderConfigTable(cfg *ini.File) {
+func RenderConfigTable(cfg *ini.File, outputformat *OutputFormat) {
 	var (
 		rows    [][]string
 		columns = []string{"section", "key", "value"}
@@ -196,6 +196,22 @@ func RenderConfigTable(cfg *ini.File) {
 			value := ansi.Truncate(key.Value(), maxCellWidth, "…")
 			rows = append(rows, []string{"", key.Name(), value})
 		}
+	}
+	// if a custom output format is passed, it is used instead of rendering the Config Table
+	if outputformat.IsJson() || outputformat.IsYaml() || outputformat.IsInteractive() || outputformat.CustomFormat() != "" {
+		result := map[string]any{}
+		for _, section := range cfg.Sections() {
+			if section.Name() == "DEFAULT" {
+				continue
+			}
+			sectionMap := map[string]any{}
+			for _, key := range section.Keys() {
+				sectionMap[key.Name()] = key.Value()
+			}
+			result[section.Name()] = sectionMap
+		}
+		OutputObject(result, "", "", outputformat)
+		return
 	}
 
 	var (

--- a/internal/display/display_wasm.go
+++ b/internal/display/display_wasm.go
@@ -112,7 +112,24 @@ func RenderTable(values []map[string]any, columnsToDisplay []string, outputForma
 	}
 }
 
-func RenderConfigTable(cfg *ini.File) {
+func RenderConfigTable(cfg *ini.File, outputformat *OutputFormat) {
+	// if a custom output format is passed, it is used instead of rendering the Config Table
+	if outputformat.IsJson() || outputformat.IsYaml() || outputformat.IsInteractive() || outputformat.CustomFormat() != "" {
+		result := map[string]any{}
+		for _, section := range cfg.Sections() {
+			if section.Name() == "DEFAULT" {
+				continue
+			}
+			sectionMap := map[string]any{}
+			for _, key := range section.Keys() {
+				sectionMap[key.Name()] = key.Value()
+			}
+			result[section.Name()] = sectionMap
+		}
+		OutputObject(result, "", "", outputformat)
+		return
+	}
+	// otherwise, render the table
 	// TODO: untested
 	output := map[string]any{}
 	if err := cfg.MapTo(&output); err != nil {

--- a/internal/services/config/config.go
+++ b/internal/services/config/config.go
@@ -26,7 +26,23 @@ func ShowConfig(_ *cobra.Command, _ []string) {
 	if profileName := config.GetActiveProfileName(flags.CliConfig, flags.Profile); profileName != "" && !config.IsDefaultProfile(profileName) {
 		display.OutputInfo(&flags.OutputFormatConfig, nil, "Active profile: %s\n", profileName)
 	}
-	display.RenderConfigTable(flags.CliConfig)
+	result := map[string]any{}
+	for _, section := range flags.CliConfig.Sections() {
+		if section.Name() == "DEFAULT" {
+			continue
+		}
+		sectionMap := map[string]any{}
+		for _, key := range section.Keys() {
+			sectionMap[key.Name()] = key.Value()
+		}
+		result[section.Name()] = sectionMap
+	}
+	if flags.OutputFormatConfig.IsJson() || flags.OutputFormatConfig.IsYaml() ||
+		flags.OutputFormatConfig.IsInteractive() || flags.OutputFormatConfig.CustomFormat() != "" {
+		display.OutputObject(result, "", "", &flags.OutputFormatConfig)
+	} else {
+		display.RenderConfigTable(flags.CliConfig)
+	}
 }
 
 func SetConfig(_ *cobra.Command, args []string) {

--- a/internal/services/config/config.go
+++ b/internal/services/config/config.go
@@ -26,7 +26,6 @@ func ShowConfig(_ *cobra.Command, _ []string) {
 	if profileName := config.GetActiveProfileName(flags.CliConfig, flags.Profile); profileName != "" && !config.IsDefaultProfile(profileName) {
 		display.OutputInfo(&flags.OutputFormatConfig, nil, "Active profile: %s\n", profileName)
 	}
-
 	display.RenderConfigTable(flags.CliConfig, &flags.OutputFormatConfig)
 }
 

--- a/internal/services/config/config.go
+++ b/internal/services/config/config.go
@@ -26,23 +26,8 @@ func ShowConfig(_ *cobra.Command, _ []string) {
 	if profileName := config.GetActiveProfileName(flags.CliConfig, flags.Profile); profileName != "" && !config.IsDefaultProfile(profileName) {
 		display.OutputInfo(&flags.OutputFormatConfig, nil, "Active profile: %s\n", profileName)
 	}
-	result := map[string]any{}
-	for _, section := range flags.CliConfig.Sections() {
-		if section.Name() == "DEFAULT" {
-			continue
-		}
-		sectionMap := map[string]any{}
-		for _, key := range section.Keys() {
-			sectionMap[key.Name()] = key.Value()
-		}
-		result[section.Name()] = sectionMap
-	}
-	if flags.OutputFormatConfig.IsJson() || flags.OutputFormatConfig.IsYaml() ||
-		flags.OutputFormatConfig.IsInteractive() || flags.OutputFormatConfig.CustomFormat() != "" {
-		display.OutputObject(result, "", "", &flags.OutputFormatConfig)
-	} else {
-		display.RenderConfigTable(flags.CliConfig)
-	}
+
+	display.RenderConfigTable(flags.CliConfig, &flags.OutputFormatConfig)
 }
 
 func SetConfig(_ *cobra.Command, args []string) {


### PR DESCRIPTION
# Description

Add support for output as json to config show 

Fixes #196 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

As I was not sure if using a specific display option is by design for the config, this change may not be necessary to the project.

# Checklist:

- [X] My code follows the style guidelines of this project
- [ ] I have commented my code
- [ ] I ran `go mod tidy`
- [ ] I have added tests that prove my fix is effective or that my feature works

# Changes

Current version
```bash
./ovhcloud config show -o json
┌─────────┬────────────────────┬─────────────────────┐
│ section │        key         │        value        │
├─────────┼────────────────────┼─────────────────────┤
│ default │                    │                     │
│         │ endpoint           │ ovh-eu              │
│ ovh-eu  │                    │                     │
│         │ application_key    │ aaaaaaaaaaaaa       │
│         │ application_secret │ xxxxxxxxxxxxxxx     │
│         │ consumer_key       │ yyyyyyyyyyyyyyyyyyy │
└─────────┴────────────────────┴─────────────────────┘
```

Updated
```bash 
./ovhcloud config show -o json
{
  "default": {
    "endpoint": "ovh-eu"
  },
  "ovh-eu": {
    "application_key": "aaaaaaaaaaaaa",
    "application_secret": "xxxxxxxxxxxxxxx",
    "consumer_key": "yyyyyyyyyyyyyyyyyyy"
  }
}
```