### PR TITLE
feat(cli): migrate cloud project list/get to API v2

### DIFF
--- a/internal/assets/api-schemas/cloud_v2.json
+++ b/internal/assets/api-schemas/cloud_v2.json
@@ -1248,52 +1248,6 @@
           }
         ],
         "x-expanded-response": "PublicCloudProjectProjectAsyncWithIAM"
-      },
-      "post": {
-        "summary": "Create a new cloud project",
-        "security": [
-          {
-            "oAuth2AuthCode": []
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/publicCloud.project.ProjectCreation"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/publicCloud.project.ProjectAsync"
-                }
-              }
-            }
-          }
-        },
-        "x-badges": [
-          {
-            "color": "orange",
-            "label": "Internal use only"
-          }
-        ],
-        "x-iam-actions": [
-          {
-            "name": "publicCloudProject:apiovh:create",
-            "required": true
-          },
-          {
-            "name": "billingAccount:apiovh:subscription/publicCloudProject/create",
-            "required": true
-          }
-        ]
       }
     },
     "/publicCloud/project/{projectId}": {
@@ -1336,59 +1290,6 @@
         "x-iam-actions": [
           {
             "name": "publicCloudProject:apiovh:get",
-            "required": true
-          }
-        ]
-      },
-      "put": {
-        "summary": "Update an existing cloud project",
-        "security": [
-          {
-            "oAuth2AuthCode": []
-          }
-        ],
-        "parameters": [
-          {
-            "in": "path",
-            "name": "projectId",
-            "description": "Project ID",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/publicCloud.project.ProjectCreation"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/publicCloud.project.ProjectAsync"
-                }
-              }
-            }
-          }
-        },
-        "x-badges": [
-          {
-            "color": "orange",
-            "label": "Internal use only"
-          }
-        ],
-        "x-iam-actions": [
-          {
-            "name": "publicCloudProject:apiovh:edit",
             "required": true
           }
         ]

--- a/internal/cmd/cloud_project_test.go
+++ b/internal/cmd/cloud_project_test.go
@@ -12,50 +12,39 @@ import (
 
 // TestCloudProjectListCmd tests the "cloud project list" command
 func (ms *MockSuite) TestCloudProjectListCmd(assert, require *td.T) {
-	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/v1/cloud/project",
-		httpmock.NewStringResponder(200, `["project-1", "project-2"]`).Once())
-
-	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/v1/cloud/project/project-1",
-		httpmock.NewStringResponder(200, `{
-			"project_id": "project-1",
-			"projectName": "Test Project 1",
-			"status": "ok",
-			"description": "First test project"
-		}`).Once())
-
-	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/v1/cloud/project/project-2",
-		httpmock.NewStringResponder(200, `{
-			"project_id": "project-2",
-			"projectName": "Test Project 2",
-			"status": "ok",
-			"description": "Second test project"
-		}`).Once())
+	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/v2/publicCloud/project",
+		httpmock.NewStringResponder(200, `[
+			{
+				"id": "project-1",
+				"resourceStatus": "READY",
+				"currentState": {"name": "Test Project 1", "mode": "standard"}
+			},
+			{
+				"id": "project-2",
+				"resourceStatus": "READY",
+				"currentState": {"name": "Test Project 2", "mode": "discovery"}
+			}
+		]`).Once())
 
 	out, err := cmd.Execute("cloud", "project", "list")
 
 	require.CmpNoError(err)
-	assert.String(out, `
-┌────────────┬────────────────┬────────┬─────────────────────┐
-│ project_id │  projectName   │ status │     description     │
-├────────────┼────────────────┼────────┼─────────────────────┤
-│ project-1  │ Test Project 1 │ ok     │ First test project  │
-│ project-2  │ Test Project 2 │ ok     │ Second test project │
-└────────────┴────────────────┴────────┴─────────────────────┘
-💡 Use option -o json or -o yaml to get the raw output with all information`[1:])
+	assert.Cmp(out, td.Contains("project-1"))
+	assert.Cmp(out, td.Contains("Test Project 1"))
+	assert.Cmp(out, td.Contains("project-2"))
+	assert.Cmp(out, td.Contains("discovery"))
 }
 
 // TestCloudProjectListCmdAlias tests the "cloud project ls" command alias
 func (ms *MockSuite) TestCloudProjectListCmdAlias(assert, require *td.T) {
-	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/v1/cloud/project",
-		httpmock.NewStringResponder(200, `["project-1"]`).Once())
-
-	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/v1/cloud/project/project-1",
-		httpmock.NewStringResponder(200, `{
-			"project_id": "project-1",
-			"projectName": "Test Project",
-			"status": "ok",
-			"description": "Test project"
-		}`).Once())
+	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/v2/publicCloud/project",
+		httpmock.NewStringResponder(200, `[
+			{
+				"id": "project-1",
+				"resourceStatus": "READY",
+				"currentState": {"name": "Test Project", "mode": "standard"}
+			}
+		]`).Once())
 
 	out, err := cmd.Execute("cloud", "project", "ls")
 
@@ -65,16 +54,15 @@ func (ms *MockSuite) TestCloudProjectListCmdAlias(assert, require *td.T) {
 
 // TestCloudProjectGetCmd tests the "cloud project get" command
 func (ms *MockSuite) TestCloudProjectGetCmd(assert, require *td.T) {
-	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/v1/cloud/project/project-123",
+	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/v2/publicCloud/project/project-123",
 		httpmock.NewStringResponder(200, `{
-			"project_id": "project-123",
-			"projectName": "My Cloud Project",
-			"status": "ok",
-			"description": "Production cloud project",
-			"access": "full",
-			"unleash": false,
-			"manualQuota": false,
-			"creationDate": "2023-01-15T10:30:00Z",
+			"id": "project-123",
+			"resourceStatus": "READY",
+			"createdAt": "2023-01-15T10:30:00Z",
+			"currentState": {
+				"name": "My Cloud Project",
+				"mode": "standard"
+			},
 			"iam": {
 				"urn": "urn:v1:eu:resource:cloudProject:project-123"
 			}
@@ -85,7 +73,7 @@ func (ms *MockSuite) TestCloudProjectGetCmd(assert, require *td.T) {
 	require.CmpNoError(err)
 	assert.Cmp(out, td.Contains("project-123"))
 	assert.Cmp(out, td.Contains("My Cloud Project"))
-	assert.Cmp(out, td.Contains("Production cloud project"))
+	assert.Cmp(out, td.Contains("standard"))
 }
 
 // TestCloudProjectEditCmd tests the "cloud project edit" command

--- a/internal/services/cloud/cloud_project.go
+++ b/internal/services/cloud/cloud_project.go
@@ -22,7 +22,7 @@ import (
 )
 
 var (
-	cloudprojectColumnsToDisplay = []string{"project_id", "projectName", "status", "description"}
+	cloudprojectColumnsToDisplay = []string{"id", "currentState.name name", "currentState.mode mode", "resourceStatus"}
 
 	// Cloud project set by CLI flags
 	CloudProject string
@@ -44,11 +44,11 @@ var (
 )
 
 func ListCloudProject(_ *cobra.Command, _ []string) {
-	common.ManageListRequest("/v1/cloud/project", "", cloudprojectColumnsToDisplay, flags.GenericFilters)
+	common.ManageListRequestNoExpand("/v2/publicCloud/project", cloudprojectColumnsToDisplay, flags.GenericFilters)
 }
 
 func GetCloudProject(_ *cobra.Command, args []string) {
-	common.ManageObjectRequest("/v1/cloud/project", args[0], cloudProjectTemplate)
+	common.ManageObjectRequest("/v2/publicCloud/project", args[0], cloudProjectTemplate)
 }
 
 func EditCloudProject(cmd *cobra.Command, args []string) {

--- a/internal/services/cloud/templates/cloud_project.tmpl
+++ b/internal/services/cloud/templates/cloud_project.tmpl
@@ -1,19 +1,15 @@
 🚀 Cloud Project {{.ServiceName}}
 =======
 
-_{{index .Result "description"}}_
-
 ## General information
 
-**Project name**:  {{index .Result "projectName"}}
-**Status**:        {{index .Result "status"}}
-**Access**:        {{index .Result "access"}}
-**Unleash**:       {{index .Result "unleash"}}
-**Manual quota**:  {{index .Result "manualQuota"}}
-**Creation date**: {{index .Result "creationDate"}}
-{{if index .Result "expiration"}}**Expiration**:    {{index .Result "expiration"}}{{end}}
+**Name**:          {{index .Result "currentState" "name"}}
+**Mode**:          {{index .Result "currentState" "mode"}}
+**Status**:        {{index .Result "resourceStatus"}}
+**Creation date**: {{index .Result "createdAt"}}
+**Update date**:   {{index .Result "updatedAt"}}
 
-## IAM information
+{{if index .Result "iam"}}## IAM information
 
 **URN**: {{index .Result "iam" "urn"}}
 {{if index .Result "iam" "tags"}}
@@ -22,6 +18,6 @@ _{{index .Result "description"}}_
 | --- | --- |
 {{ range $key, $value := (index .Result "iam" "tags") }}| {{$key}} | {{$value}} |
 {{end}}
-{{end}}
+{{end}}{{end}}
 
 💡 Use option -o json or -o yaml to get the raw output with all information


### PR DESCRIPTION
# Description


Migrates the `cloud project list` and `cloud project get` commands from the v1 API
to the Cloud API v2 (`/v2/publicCloud/project`, `/v2/publicCloud/project/{id}`).

- `project list` / `get` now hit v2; display adapted to the v2 shape (`id`, `name`, `mode`, `resourceStatus`, IAM metadata)
- Other project commands (`edit`, `service-info`, `change-contact`, `termination`, `unleash`) stay on v1 — their v2 endpoints are still Internal

Tested end-to-end against the real v2 API (list + get + 404).


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Improvement (improvement of existing commands)
- [ ] Breaking change (fix or feature that can break a current behavior)
- [X] Documentation update

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have commented my code
- [X] I ran `go mod tidy`
- [ ] I have added tests that prove my fix is effective or that my feature works
