### PR TITLE
feat(cli): add cloud network security-group + migrate gateway to API v2

### DIFF
--- a/doc/ovhcloud_cloud_network.md
+++ b/doc/ovhcloud_cloud_network.md
@@ -34,4 +34,5 @@ Manage networks in the given cloud project
 * [ovhcloud cloud network gateway](ovhcloud_cloud_network_gateway.md)	 - Manage gateways in the given cloud project
 * [ovhcloud cloud network private](ovhcloud_cloud_network_private.md)	 - Manage private networks in the given cloud project
 * [ovhcloud cloud network public](ovhcloud_cloud_network_public.md)	 - Manage public networks in the given cloud project
+* [ovhcloud cloud network security-group](ovhcloud_cloud_network_security-group.md)	 - Manage security groups in the given cloud project
 

--- a/doc/ovhcloud_cloud_network_gateway_create.md
+++ b/doc/ovhcloud_cloud_network_gateway_create.md
@@ -4,82 +4,59 @@ Create a gateway in the given cloud project
 
 ### Synopsis
 
-Use this command to create a new gateway.
+Use this command to create a new gateway in the given public cloud project.
 
-Two options are available to create a gateway:
-	- Create a gateway in an existing private network
-	- Create a gateway in a new private network
-
-When creating a gateway in an existing private network, you must specify the network ID and subnet ID 
-using the flags --network-id and --subnet-id.
-In this case, only two parameters are supported and required: the gateway model and its name (respectively
---model and --name flags).
-
-There are three ways to define the parameters:
+Subnets are nested objects: to attach them, use the repeatable --subnet flag, a
+configuration file or your text editor. There are three ways to define the
+creation parameters:
 
 1. Using only CLI flags:
 
-	ovhcloud cloud network gateway create <region> --name MyGateway --model xl
+	ovhcloud cloud network gateway create --name MyGateway --region GRA11 --external-gateway-enabled --external-gateway-model S
 
 2. Using a configuration file:
 
   First you can generate an example of parameters file using the following command:
 
-	ovhcloud cloud network gateway create <region> --init-file ./params.json
+	ovhcloud cloud network gateway create --init-file ./params.json
 
-  You will be able to choose from several examples of parameters. Once an example has been selected, the content is written in the given file.
   After editing the file to set the correct creation parameters, run:
 
-	ovhcloud cloud network gateway create <region> --from-file ./params.json
+	ovhcloud cloud network gateway create --from-file ./params.json
 
   Note that you can also pipe the content of the parameters file, like the following:
 
-	cat ./params.json | ovhcloud cloud network gateway create <region>
+	cat ./params.json | ovhcloud cloud network gateway create
 
   In both cases, you can override the parameters in the given file using command line flags, for example:
 
-	ovhcloud cloud network gateway create <region> --from-file ./params.json --name MyGateway
+	ovhcloud cloud network gateway create --from-file ./params.json --name MyGateway
 
 3. Using your default text editor:
 
-	ovhcloud cloud network gateway create <region> --editor
-
-  You will be able to choose from several examples of parameters. Once an example has been selected, the CLI will open your
-  default text editor to update the parameters. When saving the file, the creation will start.
-
-  Note that it is also possible to override values in the presented examples using command line flags like the following:
-
-	ovhcloud cloud network gateway create <region> --editor --name MyGateway
+	ovhcloud cloud network gateway create --editor
 
 
 ```
-ovhcloud cloud network gateway create <region> [flags]
+ovhcloud cloud network gateway create [flags]
 ```
 
 ### Options
 
 ```
-      --editor                                   Use a text editor to define parameters
-      --from-file string                         File containing parameters
-  -h, --help                                     help for create
-      --init-file string                         Create a file with example parameters
-      --model string                             Gateway model (s, m, l, xl, 2xl, 3xl)
-      --name string                              Name of the gateway
-      --network-id string                        ID of the existing private network to create the gateway in
-      --network-name string                      Name of the private network
-      --network-vlan-id int                      VLAN ID for the private network
-      --replace                                  Replace parameters file if it already exists
-      --subnet-allocation-pools strings          Allocation pools for the subnet in format start:end
-      --subnet-cidr string                       CIDR of the subnet
-      --subnet-dns-name-servers strings          DNS name servers for the subnet
-      --subnet-enable-dhcp                       Enable DHCP for the subnet
-      --subnet-gateway-ip string                 Gateway IP address for the subnet
-      --subnet-host-routes strings               Host routes for the subnet in format destination:nextHop
-      --subnet-id string                         ID of the existing subnet to create the gateway in
-      --subnet-ip-version int                    IP version (4 or 6)
-      --subnet-name string                       Name of the subnet
-      --subnet-use-default-public-dns-resolver   Use default DNS resolver for the subnet
-      --wait                                     Wait for gateway creation to be done before exiting
+      --availability-zone string        Availability zone within the region
+      --description string              Description of the gateway
+      --editor                          Use a text editor to define parameters
+      --external-gateway-enabled        Whether the external gateway is enabled
+      --external-gateway-model string   External gateway sizing model (S, M, L, XL, 2XL, 3XL)
+      --from-file string                File containing parameters
+  -h, --help                            help for create
+      --init-file string                Create a file with example parameters
+      --name string                     Name of the gateway
+      --region string                   Region where the gateway will be created
+      --replace                         Replace parameters file if it already exists
+      --subnet strings                  ID of a subnet to attach to the gateway (repeatable)
+      --wait                            Wait for gateway creation to be done before exiting
 ```
 
 ### Options inherited from parent commands

--- a/doc/ovhcloud_cloud_network_security-group.md
+++ b/doc/ovhcloud_cloud_network_security-group.md
@@ -1,21 +1,11 @@
-## ovhcloud cloud network gateway edit
+## ovhcloud cloud network security-group
 
-Edit the given gateway
-
-```
-ovhcloud cloud network gateway edit <gateway_id> [flags]
-```
+Manage security groups in the given cloud project
 
 ### Options
 
 ```
-      --description string              Description of the gateway
-      --editor                          Use a text editor to define parameters
-      --external-gateway-enabled        Whether the external gateway is enabled
-      --external-gateway-model string   External gateway sizing model (S, M, L, XL, 2XL, 3XL)
-  -h, --help                            help for edit
-      --name string                     Name of the gateway
-      --subnet strings                  ID of a subnet to attach to the gateway (repeatable)
+  -h, --help   help for security-group
 ```
 
 ### Options inherited from parent commands
@@ -40,5 +30,10 @@ ovhcloud cloud network gateway edit <gateway_id> [flags]
 
 ### SEE ALSO
 
-* [ovhcloud cloud network gateway](ovhcloud_cloud_network_gateway.md)	 - Manage gateways in the given cloud project
+* [ovhcloud cloud network](ovhcloud_cloud_network.md)	 - Manage networks in the given cloud project
+* [ovhcloud cloud network security-group create](ovhcloud_cloud_network_security-group_create.md)	 - Create a new security group
+* [ovhcloud cloud network security-group delete](ovhcloud_cloud_network_security-group_delete.md)	 - Delete a specific security group
+* [ovhcloud cloud network security-group edit](ovhcloud_cloud_network_security-group_edit.md)	 - Edit the given security group
+* [ovhcloud cloud network security-group get](ovhcloud_cloud_network_security-group_get.md)	 - Get a specific security group
+* [ovhcloud cloud network security-group list](ovhcloud_cloud_network_security-group_list.md)	 - List security groups
 

--- a/doc/ovhcloud_cloud_network_security-group_create.md
+++ b/doc/ovhcloud_cloud_network_security-group_create.md
@@ -1,0 +1,81 @@
+## ovhcloud cloud network security-group create
+
+Create a new security group
+
+### Synopsis
+
+Use this command to create a security group in the given public cloud project.
+
+Rules are nested objects: to define them, use a configuration file or your text
+editor. There are three ways to define the creation parameters:
+
+1. Using only CLI flags:
+
+	ovhcloud cloud network security-group create --name my-sg --region GRA11
+
+2. Using a configuration file:
+
+  First you can generate an example of parameters file using the following command:
+
+	ovhcloud cloud network security-group create --init-file ./params.json
+
+  After editing the file to set the correct creation parameters, run:
+
+	ovhcloud cloud network security-group create --from-file ./params.json
+
+  You can also pipe the content of the parameters file:
+
+	cat ./params.json | ovhcloud cloud network security-group create
+
+  In both cases, you can override values using command line flags, for example:
+
+	ovhcloud cloud network security-group create --from-file ./params.json --name my-sg
+
+3. Using your default text editor:
+
+	ovhcloud cloud network security-group create --editor
+
+
+```
+ovhcloud cloud network security-group create [flags]
+```
+
+### Options
+
+```
+      --availability-zone string   Availability zone within the region
+      --description string         Description of the security group
+      --editor                     Use a text editor to define parameters
+      --from-file string           File containing parameters
+  -h, --help                       help for create
+      --init-file string           Create a file with example parameters
+      --name string                Name of the security group
+      --region string              Region where the security group will be created
+      --replace                    Replace parameters file if it already exists
+      --wait                       Wait for security group creation to be done before exiting
+```
+
+### Options inherited from parent commands
+
+```
+      --cloud-project string   Cloud project ID
+  -d, --debug                  Activate debug mode (will log all HTTP requests details)
+  -e, --ignore-errors          Ignore errors in API calls when it is not fatal to the execution
+  -o, --output string          Output format: json, yaml, interactive, or a custom format expression (using https://github.com/PaesslerAG/gval syntax)
+                               Examples:
+                                 --output json
+                                 --output yaml
+                                 --output interactive
+                                 --output 'id' (to extract a single field)
+                                 --output 'nested.field.subfield' (to extract a nested field)
+                                 --output '[id, "name"]' (to extract multiple fields as an array)
+                                 --output '{"newKey": oldKey, "otherKey": nested.field}' (to extract and rename fields in an object)
+                                 --output 'name+","+type' (to extract and concatenate fields in a string)
+                                 --output '(nbFieldA + nbFieldB) * 10' (to compute values from numeric fields)
+      --profile string         Use a specific profile from the configuration file
+```
+
+### SEE ALSO
+
+* [ovhcloud cloud network security-group](ovhcloud_cloud_network_security-group.md)	 - Manage security groups in the given cloud project
+

--- a/doc/ovhcloud_cloud_network_security-group_delete.md
+++ b/doc/ovhcloud_cloud_network_security-group_delete.md
@@ -1,21 +1,15 @@
-## ovhcloud cloud network gateway edit
+## ovhcloud cloud network security-group delete
 
-Edit the given gateway
+Delete a specific security group
 
 ```
-ovhcloud cloud network gateway edit <gateway_id> [flags]
+ovhcloud cloud network security-group delete <security_group_id> [flags]
 ```
 
 ### Options
 
 ```
-      --description string              Description of the gateway
-      --editor                          Use a text editor to define parameters
-      --external-gateway-enabled        Whether the external gateway is enabled
-      --external-gateway-model string   External gateway sizing model (S, M, L, XL, 2XL, 3XL)
-  -h, --help                            help for edit
-      --name string                     Name of the gateway
-      --subnet strings                  ID of a subnet to attach to the gateway (repeatable)
+  -h, --help   help for delete
 ```
 
 ### Options inherited from parent commands
@@ -40,5 +34,5 @@ ovhcloud cloud network gateway edit <gateway_id> [flags]
 
 ### SEE ALSO
 
-* [ovhcloud cloud network gateway](ovhcloud_cloud_network_gateway.md)	 - Manage gateways in the given cloud project
+* [ovhcloud cloud network security-group](ovhcloud_cloud_network_security-group.md)	 - Manage security groups in the given cloud project
 

--- a/doc/ovhcloud_cloud_network_security-group_edit.md
+++ b/doc/ovhcloud_cloud_network_security-group_edit.md
@@ -1,21 +1,18 @@
-## ovhcloud cloud network gateway edit
+## ovhcloud cloud network security-group edit
 
-Edit the given gateway
+Edit the given security group
 
 ```
-ovhcloud cloud network gateway edit <gateway_id> [flags]
+ovhcloud cloud network security-group edit <security_group_id> [flags]
 ```
 
 ### Options
 
 ```
-      --description string              Description of the gateway
-      --editor                          Use a text editor to define parameters
-      --external-gateway-enabled        Whether the external gateway is enabled
-      --external-gateway-model string   External gateway sizing model (S, M, L, XL, 2XL, 3XL)
-  -h, --help                            help for edit
-      --name string                     Name of the gateway
-      --subnet strings                  ID of a subnet to attach to the gateway (repeatable)
+      --description string   Description of the security group
+      --editor               Use a text editor to define parameters
+  -h, --help                 help for edit
+      --name string          Name of the security group
 ```
 
 ### Options inherited from parent commands
@@ -40,5 +37,5 @@ ovhcloud cloud network gateway edit <gateway_id> [flags]
 
 ### SEE ALSO
 
-* [ovhcloud cloud network gateway](ovhcloud_cloud_network_gateway.md)	 - Manage gateways in the given cloud project
+* [ovhcloud cloud network security-group](ovhcloud_cloud_network_security-group.md)	 - Manage security groups in the given cloud project
 

--- a/doc/ovhcloud_cloud_network_security-group_get.md
+++ b/doc/ovhcloud_cloud_network_security-group_get.md
@@ -1,21 +1,15 @@
-## ovhcloud cloud network gateway edit
+## ovhcloud cloud network security-group get
 
-Edit the given gateway
+Get a specific security group
 
 ```
-ovhcloud cloud network gateway edit <gateway_id> [flags]
+ovhcloud cloud network security-group get <security_group_id> [flags]
 ```
 
 ### Options
 
 ```
-      --description string              Description of the gateway
-      --editor                          Use a text editor to define parameters
-      --external-gateway-enabled        Whether the external gateway is enabled
-      --external-gateway-model string   External gateway sizing model (S, M, L, XL, 2XL, 3XL)
-  -h, --help                            help for edit
-      --name string                     Name of the gateway
-      --subnet strings                  ID of a subnet to attach to the gateway (repeatable)
+  -h, --help   help for get
 ```
 
 ### Options inherited from parent commands
@@ -40,5 +34,5 @@ ovhcloud cloud network gateway edit <gateway_id> [flags]
 
 ### SEE ALSO
 
-* [ovhcloud cloud network gateway](ovhcloud_cloud_network_gateway.md)	 - Manage gateways in the given cloud project
+* [ovhcloud cloud network security-group](ovhcloud_cloud_network_security-group.md)	 - Manage security groups in the given cloud project
 

--- a/doc/ovhcloud_cloud_network_security-group_list.md
+++ b/doc/ovhcloud_cloud_network_security-group_list.md
@@ -1,21 +1,22 @@
-## ovhcloud cloud network gateway edit
+## ovhcloud cloud network security-group list
 
-Edit the given gateway
+List security groups
 
 ```
-ovhcloud cloud network gateway edit <gateway_id> [flags]
+ovhcloud cloud network security-group list [flags]
 ```
 
 ### Options
 
 ```
-      --description string              Description of the gateway
-      --editor                          Use a text editor to define parameters
-      --external-gateway-enabled        Whether the external gateway is enabled
-      --external-gateway-model string   External gateway sizing model (S, M, L, XL, 2XL, 3XL)
-  -h, --help                            help for edit
-      --name string                     Name of the gateway
-      --subnet strings                  ID of a subnet to attach to the gateway (repeatable)
+      --filter stringArray   Filter results by any property using https://github.com/PaesslerAG/gval syntax
+                             Examples:
+                               --filter 'state=="running"'
+                               --filter 'name=~"^my.*"'
+                               --filter 'nested.property.subproperty>10'
+                               --filter 'startDate>="2023-12-01"'
+                               --filter 'name=~"something" && nbField>10'
+  -h, --help                 help for list
 ```
 
 ### Options inherited from parent commands
@@ -40,5 +41,5 @@ ovhcloud cloud network gateway edit <gateway_id> [flags]
 
 ### SEE ALSO
 
-* [ovhcloud cloud network gateway](ovhcloud_cloud_network_gateway.md)	 - Manage gateways in the given cloud project
+* [ovhcloud cloud network security-group](ovhcloud_cloud_network_security-group.md)	 - Manage security groups in the given cloud project
 

--- a/internal/assets/api-schemas/cloud_v2.json
+++ b/internal/assets/api-schemas/cloud_v2.json
@@ -1157,6 +1157,755 @@
         "description": "Time (e.g., 15:04:05)",
         "format": "time",
         "example": "15:04:05"
+      },
+      "publicCloud.securityGroup.SecurityGroup": {
+        "type": "object",
+        "description": "A Public Cloud security group",
+        "properties": {
+          "checksum": {
+            "type": "string",
+            "description": "Computed hash representing the current target specification value",
+            "readOnly": true
+          },
+          "createdAt": {
+            "type": "string",
+            "description": "Creation date of the security group",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "currentState": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/publicCloud.securityGroup.SecurityGroupCurrentState"
+              }
+            ],
+            "description": "Current state of the security group",
+            "nullable": true,
+            "readOnly": true
+          },
+          "currentTasks": {
+            "type": "array",
+            "description": "Ongoing asynchronous tasks related to the security group",
+            "nullable": true,
+            "items": {
+              "$ref": "#/components/schemas/common.CurrentTask"
+            },
+            "readOnly": true
+          },
+          "id": {
+            "type": "string",
+            "description": "Unique identifier of the security group",
+            "format": "uuid",
+            "readOnly": true
+          },
+          "resourceStatus": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/common.ResourceStatusEnum"
+              }
+            ],
+            "description": "Security group readiness in the system",
+            "readOnly": true
+          },
+          "targetSpec": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/publicCloud.securityGroup.SecurityGroupTargetSpec"
+              }
+            ],
+            "description": "Last target specification of the security group",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "description": "Last update date of the security group",
+            "format": "date-time",
+            "readOnly": true
+          }
+        }
+      },
+      "publicCloud.gateway.GatewayStatusEnum": {
+        "type": "string",
+        "description": "OpenStack router status",
+        "enum": [
+          "ACTIVE",
+          "BUILD",
+          "DOWN",
+          "ERROR"
+        ]
+      },
+      "publicCloud.securityGroup.SecurityGroupUpdateTargetSpec": {
+        "type": "object",
+        "description": "Desired specification for updating a security group (mutable fields only)",
+        "properties": {
+          "description": {
+            "type": "string",
+            "description": "Security group description",
+            "nullable": true
+          },
+          "name": {
+            "type": "string",
+            "description": "Security group name"
+          },
+          "rules": {
+            "type": "array",
+            "description": "Desired firewall rules",
+            "nullable": true,
+            "items": {
+              "$ref": "#/components/schemas/publicCloud.securityGroup.SecurityGroupTargetRule"
+            }
+          }
+        },
+        "required": [
+          "name"
+        ]
+      },
+      "publicCloud.securityGroup.SecurityGroupTargetSpec": {
+        "type": "object",
+        "description": "Desired specification for creating a security group",
+        "properties": {
+          "description": {
+            "type": "string",
+            "description": "Security group description",
+            "nullable": true
+          },
+          "location": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/publicCloud.common.Location"
+              }
+            ],
+            "description": "Geographic location"
+          },
+          "name": {
+            "type": "string",
+            "description": "Security group name"
+          },
+          "rules": {
+            "type": "array",
+            "description": "Desired firewall rules",
+            "nullable": true,
+            "items": {
+              "$ref": "#/components/schemas/publicCloud.securityGroup.SecurityGroupTargetRule"
+            }
+          }
+        },
+        "required": [
+          "location",
+          "name"
+        ]
+      },
+      "publicCloud.securityGroup.SecurityGroupStateRule": {
+        "type": "object",
+        "description": "Actual firewall rule from OpenStack for a security group",
+        "properties": {
+          "description": {
+            "type": "string",
+            "description": "Rule description",
+            "nullable": true,
+            "readOnly": true
+          },
+          "direction": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/publicCloud.securityGroup.TrafficFlowEnum"
+              }
+            ],
+            "description": "Traffic flow",
+            "readOnly": true
+          },
+          "ethernetType": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/publicCloud.securityGroup.EthernetTypeEnum"
+              }
+            ],
+            "description": "Ethernet type",
+            "readOnly": true
+          },
+          "id": {
+            "type": "string",
+            "description": "Rule identifier from OpenStack",
+            "format": "uuid",
+            "readOnly": true
+          },
+          "portRangeMax": {
+            "type": "integer",
+            "description": "Maximum port number",
+            "nullable": true,
+            "readOnly": true
+          },
+          "portRangeMin": {
+            "type": "integer",
+            "description": "Minimum port number",
+            "nullable": true,
+            "readOnly": true
+          },
+          "protocol": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/publicCloud.securityGroup.ProtocolEnum"
+              }
+            ],
+            "description": "Network protocol",
+            "nullable": true,
+            "readOnly": true
+          },
+          "remoteGroup": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/publicCloud.securityGroup.SecurityGroupRef"
+              }
+            ],
+            "description": "Reference to remote security group",
+            "nullable": true,
+            "readOnly": true
+          },
+          "remoteIpPrefix": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ipBlock"
+              }
+            ],
+            "description": "Remote CIDR prefix",
+            "nullable": true,
+            "readOnly": true
+          }
+        }
+      },
+      "publicCloud.securityGroup.SecurityGroupUpdate": {
+        "type": "object",
+        "description": "Payload to update a Public Cloud security group",
+        "properties": {
+          "checksum": {
+            "type": "string",
+            "description": "Computed hash controlling concurrent modifications"
+          },
+          "targetSpec": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/publicCloud.securityGroup.SecurityGroupUpdateTargetSpec"
+              }
+            ],
+            "description": "Desired target specification for the security group"
+          }
+        },
+        "required": [
+          "checksum",
+          "targetSpec"
+        ]
+      },
+      "publicCloud.gateway.Gateway": {
+        "type": "object",
+        "description": "A Public Cloud gateway (OpenStack router)",
+        "properties": {
+          "checksum": {
+            "type": "string",
+            "description": "Computed hash representing the current target specification value",
+            "readOnly": true
+          },
+          "createdAt": {
+            "type": "string",
+            "description": "Creation date of the gateway",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "currentState": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/publicCloud.gateway.GatewayCurrentState"
+              }
+            ],
+            "description": "Current state of the gateway",
+            "nullable": true,
+            "readOnly": true
+          },
+          "currentTasks": {
+            "type": "array",
+            "description": "Ongoing asynchronous tasks related to the gateway",
+            "nullable": true,
+            "items": {
+              "$ref": "#/components/schemas/common.CurrentTask"
+            },
+            "readOnly": true
+          },
+          "id": {
+            "type": "string",
+            "description": "Unique identifier of the gateway",
+            "format": "uuid",
+            "readOnly": true
+          },
+          "resourceStatus": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/common.ResourceStatusEnum"
+              }
+            ],
+            "description": "Gateway readiness in the system",
+            "readOnly": true
+          },
+          "targetSpec": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/publicCloud.gateway.GatewayTargetSpec"
+              }
+            ],
+            "description": "Last target specification of the gateway",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "description": "Last update date of the gateway",
+            "format": "date-time",
+            "readOnly": true
+          }
+        }
+      },
+      "publicCloud.securityGroup.ProtocolEnum": {
+        "type": "string",
+        "description": "Network protocol for a security group rule",
+        "enum": [
+          "AH",
+          "DCCP",
+          "EGP",
+          "ESP",
+          "GRE",
+          "ICMP",
+          "ICMPV6",
+          "IGMP",
+          "OSPF",
+          "PGM",
+          "RSVP",
+          "SCTP",
+          "TCP",
+          "UDP",
+          "UDPLITE",
+          "VRRP"
+        ]
+      },
+      "publicCloud.gateway.GatewayCurrentState": {
+        "type": "object",
+        "description": "Current state of a gateway from OpenStack",
+        "properties": {
+          "description": {
+            "type": "string",
+            "description": "Gateway description",
+            "nullable": true,
+            "readOnly": true
+          },
+          "externalGateway": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/publicCloud.gateway.ExternalGateway"
+              }
+            ],
+            "description": "External gateway configuration",
+            "readOnly": true
+          },
+          "externalIp": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ip"
+              }
+            ],
+            "description": "External IP address assigned to the gateway",
+            "nullable": true,
+            "readOnly": true
+          },
+          "location": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/publicCloud.gateway.GatewayLocation"
+              }
+            ],
+            "description": "Current location",
+            "readOnly": true
+          },
+          "name": {
+            "type": "string",
+            "description": "Gateway name",
+            "readOnly": true
+          },
+          "status": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/publicCloud.gateway.GatewayStatusEnum"
+              }
+            ],
+            "description": "OpenStack router status",
+            "readOnly": true
+          },
+          "subnets": {
+            "type": "array",
+            "description": "Currently attached subnets",
+            "nullable": true,
+            "items": {
+              "$ref": "#/components/schemas/publicCloud.gateway.GatewaySubnet"
+            },
+            "readOnly": true
+          }
+        }
+      },
+      "publicCloud.securityGroup.SecurityGroupCreation": {
+        "type": "object",
+        "description": "Payload to create a Public Cloud security group",
+        "properties": {
+          "targetSpec": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/publicCloud.securityGroup.SecurityGroupTargetSpec"
+              }
+            ],
+            "description": "Desired target specification for the security group to create"
+          }
+        },
+        "required": [
+          "targetSpec"
+        ]
+      },
+      "publicCloud.securityGroup.SecurityGroupTargetRule": {
+        "type": "object",
+        "description": "Desired firewall rule for a security group",
+        "properties": {
+          "description": {
+            "type": "string",
+            "description": "Rule description",
+            "nullable": true
+          },
+          "direction": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/publicCloud.securityGroup.TrafficFlowEnum"
+              }
+            ],
+            "description": "Traffic flow"
+          },
+          "ethernetType": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/publicCloud.securityGroup.EthernetTypeEnum"
+              }
+            ],
+            "description": "Ethernet type"
+          },
+          "portRangeMax": {
+            "type": "integer",
+            "description": "Maximum port number",
+            "nullable": true
+          },
+          "portRangeMin": {
+            "type": "integer",
+            "description": "Minimum port number",
+            "nullable": true
+          },
+          "protocol": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/publicCloud.securityGroup.ProtocolEnum"
+              }
+            ],
+            "description": "Network protocol",
+            "nullable": true
+          },
+          "remoteGroup": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/publicCloud.securityGroup.SecurityGroupRef"
+              }
+            ],
+            "description": "Reference to remote security group (mutually exclusive with remoteIpPrefix)",
+            "nullable": true
+          },
+          "remoteIpPrefix": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ipBlock"
+              }
+            ],
+            "description": "Remote CIDR prefix (mutually exclusive with remoteGroup)",
+            "nullable": true
+          }
+        },
+        "required": [
+          "direction",
+          "ethernetType"
+        ]
+      },
+      "publicCloud.gateway.GatewaySubnet": {
+        "type": "object",
+        "description": "A subnet reference for a gateway",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Subnet ID",
+            "format": "uuid"
+          }
+        },
+        "required": [
+          "id"
+        ]
+      },
+      "publicCloud.securityGroup.SecurityGroupCurrentState": {
+        "type": "object",
+        "description": "Current state of a security group from OpenStack",
+        "properties": {
+          "defaultRules": {
+            "type": "array",
+            "description": "Default egress rules auto-created by OpenStack",
+            "nullable": true,
+            "items": {
+              "$ref": "#/components/schemas/publicCloud.securityGroup.SecurityGroupStateRule"
+            },
+            "readOnly": true
+          },
+          "description": {
+            "type": "string",
+            "description": "Security group description",
+            "nullable": true,
+            "readOnly": true
+          },
+          "location": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/publicCloud.common.Location"
+              }
+            ],
+            "description": "Geographic location",
+            "readOnly": true
+          },
+          "name": {
+            "type": "string",
+            "description": "Security group name",
+            "readOnly": true
+          },
+          "rules": {
+            "type": "array",
+            "description": "User-specified firewall rules",
+            "nullable": true,
+            "items": {
+              "$ref": "#/components/schemas/publicCloud.securityGroup.SecurityGroupStateRule"
+            },
+            "readOnly": true
+          }
+        }
+      },
+      "publicCloud.gateway.GatewayLocation": {
+        "type": "object",
+        "description": "Gateway location",
+        "properties": {
+          "availabilityZone": {
+            "type": "string",
+            "description": "Availability zone within the region",
+            "nullable": true
+          },
+          "region": {
+            "type": "string",
+            "description": "Region code"
+          }
+        },
+        "required": [
+          "region"
+        ]
+      },
+      "publicCloud.gateway.GatewayCreation": {
+        "type": "object",
+        "description": "Payload to create a Public Cloud gateway",
+        "properties": {
+          "targetSpec": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/publicCloud.gateway.GatewayTargetSpec"
+              }
+            ],
+            "description": "Desired target specification for the gateway to create"
+          }
+        },
+        "required": [
+          "targetSpec"
+        ]
+      },
+      "publicCloud.common.Location": {
+        "type": "object",
+        "description": "Resource location",
+        "properties": {
+          "availabilityZone": {
+            "type": "string",
+            "description": "Availability zone within the region",
+            "nullable": true
+          },
+          "region": {
+            "type": "string",
+            "description": "Region code"
+          }
+        },
+        "required": [
+          "region"
+        ]
+      },
+      "publicCloud.gateway.ExternalGateway": {
+        "type": "object",
+        "description": "External gateway configuration",
+        "properties": {
+          "enabled": {
+            "type": "boolean",
+            "description": "Whether the external gateway is enabled"
+          },
+          "model": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/publicCloud.gateway.ExternalGatewayModelEnum"
+              }
+            ],
+            "description": "External gateway sizing model. Present only when enabled is true.",
+            "nullable": true
+          }
+        },
+        "required": [
+          "enabled"
+        ]
+      },
+      "publicCloud.gateway.ExternalGatewayModelEnum": {
+        "type": "string",
+        "description": "External gateway sizing model",
+        "enum": [
+          "2XL",
+          "3XL",
+          "L",
+          "M",
+          "S",
+          "XL"
+        ]
+      },
+      "publicCloud.securityGroup.SecurityGroupRef": {
+        "type": "object",
+        "description": "Reference to a security group",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Security group identifier",
+            "format": "uuid"
+          }
+        },
+        "required": [
+          "id"
+        ]
+      },
+      "publicCloud.gateway.GatewayUpdateTargetSpec": {
+        "type": "object",
+        "description": "Desired specification for updating a gateway (mutable fields only)",
+        "properties": {
+          "description": {
+            "type": "string",
+            "description": "Gateway description",
+            "nullable": true
+          },
+          "externalGateway": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/publicCloud.gateway.ExternalGateway"
+              }
+            ],
+            "description": "External gateway configuration"
+          },
+          "name": {
+            "type": "string",
+            "description": "Gateway name"
+          },
+          "subnets": {
+            "type": "array",
+            "description": "Subnets to attach as router interfaces",
+            "nullable": true,
+            "items": {
+              "$ref": "#/components/schemas/publicCloud.gateway.GatewaySubnet"
+            }
+          }
+        },
+        "required": [
+          "externalGateway",
+          "name"
+        ]
+      },
+      "publicCloud.gateway.GatewayUpdate": {
+        "type": "object",
+        "description": "Payload to update a Public Cloud gateway",
+        "properties": {
+          "checksum": {
+            "type": "string",
+            "description": "Computed hash controlling concurrent modifications"
+          },
+          "targetSpec": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/publicCloud.gateway.GatewayUpdateTargetSpec"
+              }
+            ],
+            "description": "Desired target specification for the gateway"
+          }
+        },
+        "required": [
+          "checksum",
+          "targetSpec"
+        ]
+      },
+      "publicCloud.gateway.GatewayTargetSpec": {
+        "type": "object",
+        "description": "Desired specification for a gateway",
+        "properties": {
+          "description": {
+            "type": "string",
+            "description": "Gateway description",
+            "nullable": true
+          },
+          "externalGateway": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/publicCloud.gateway.ExternalGateway"
+              }
+            ],
+            "description": "External gateway configuration"
+          },
+          "location": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/publicCloud.gateway.GatewayLocation"
+              }
+            ],
+            "description": "Target location"
+          },
+          "name": {
+            "type": "string",
+            "description": "Gateway name"
+          },
+          "subnets": {
+            "type": "array",
+            "description": "Subnets to attach as router interfaces",
+            "nullable": true,
+            "items": {
+              "$ref": "#/components/schemas/publicCloud.gateway.GatewaySubnet"
+            }
+          }
+        },
+        "required": [
+          "externalGateway",
+          "location",
+          "name"
+        ]
+      },
+      "publicCloud.securityGroup.EthernetTypeEnum": {
+        "type": "string",
+        "description": "Ethernet type for a security group rule",
+        "enum": [
+          "IPV4",
+          "IPV6"
+        ]
+      },
+      "publicCloud.securityGroup.TrafficFlowEnum": {
+        "type": "string",
+        "description": "Flow rule of traffic for a security group rule",
+        "enum": [
+          "EGRESS",
+          "INGRESS"
+        ]
       }
     },
     "securitySchemes": {
@@ -3189,6 +3938,1048 @@
           {
             "color": "red",
             "label": "Deprecated, will be removed"
+          }
+        ]
+      }
+    },
+    "/publicCloud/project/{projectId}/gateway": {
+      "get": {
+        "summary": "List gateways",
+        "security": [
+          {
+            "oAuth2AuthCode": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "header",
+            "name": "X-Pagination-Cursor",
+            "description": "Pagination cursor",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Pagination-Size",
+            "description": "Pagination size",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "in": "path",
+            "name": "projectId",
+            "description": "Project ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/publicCloud.gateway.Gateway"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Network"
+        ],
+        "x-badges": [
+          {
+            "color": "blue",
+            "label": "Alpha version"
+          }
+        ],
+        "x-iam-actions": [
+          {
+            "name": "publicCloudProject:apiovh:gateway/get",
+            "required": true
+          }
+        ],
+        "x-response-identifier": "id",
+        "x-expanded-response": "PublicCloudGatewayGateway"
+      },
+      "post": {
+        "summary": "Create a gateway",
+        "security": [
+          {
+            "oAuth2AuthCode": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "projectId",
+            "description": "Project ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/publicCloud.gateway.GatewayCreation"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/publicCloud.gateway.Gateway"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Error 400 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Common error model",
+                  "properties": {
+                    "class": {
+                      "type": "string",
+                      "description": "Class of the error"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "Error message"
+                    }
+                  }
+                },
+                "examples": {
+                  "Client::BadRequest::InvalidParameter": {
+                    "value": {
+                      "class": "Client::BadRequest::InvalidParameter",
+                      "message": "Invalid parameter in the request"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Error 409 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Common error model",
+                  "properties": {
+                    "class": {
+                      "type": "string",
+                      "description": "Class of the error"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "Error message"
+                    }
+                  }
+                },
+                "examples": {
+                  "Client::Conflict::RegionInMaintenance": {
+                    "value": {
+                      "class": "Client::Conflict::RegionInMaintenance",
+                      "message": "This region is currently in maintenance"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Network"
+        ],
+        "x-badges": [
+          {
+            "color": "blue",
+            "label": "Alpha version"
+          }
+        ],
+        "x-iam-actions": [
+          {
+            "name": "publicCloudProject:apiovh:gateway/create",
+            "required": true
+          }
+        ]
+      }
+    },
+    "/publicCloud/project/{projectId}/gateway/{gatewayId}": {
+      "delete": {
+        "summary": "Delete a gateway",
+        "security": [
+          {
+            "oAuth2AuthCode": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "gatewayId",
+            "description": "Gateway ID",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "in": "path",
+            "name": "projectId",
+            "description": "Project ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/publicCloud.gateway.Gateway"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Error 404 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Common error model",
+                  "properties": {
+                    "class": {
+                      "type": "string",
+                      "description": "Class of the error"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "Error message"
+                    }
+                  }
+                },
+                "examples": {
+                  "Client::NotFound::GatewayDoesNotExist": {
+                    "value": {
+                      "class": "Client::NotFound::GatewayDoesNotExist",
+                      "message": "Gateway not found"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Error 409 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Common error model",
+                  "properties": {
+                    "class": {
+                      "type": "string",
+                      "description": "Class of the error"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "Error message"
+                    }
+                  }
+                },
+                "examples": {
+                  "Client::Conflict::ResourceAlreadyBeingDeleted": {
+                    "value": {
+                      "class": "Client::Conflict::ResourceAlreadyBeingDeleted",
+                      "message": "Resource is already being deleted"
+                    }
+                  },
+                  "Client::Conflict::ResourceInInvalidState": {
+                    "value": {
+                      "class": "Client::Conflict::ResourceInInvalidState",
+                      "message": "Resource cannot be modified in its current state"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Network"
+        ],
+        "x-badges": [
+          {
+            "color": "blue",
+            "label": "Alpha version"
+          }
+        ],
+        "x-iam-actions": [
+          {
+            "name": "publicCloudProject:apiovh:gateway/delete",
+            "required": true
+          }
+        ]
+      },
+      "get": {
+        "summary": "Get a gateway",
+        "security": [
+          {
+            "oAuth2AuthCode": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "gatewayId",
+            "description": "Gateway ID",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "in": "path",
+            "name": "projectId",
+            "description": "Project ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/publicCloud.gateway.Gateway"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Error 404 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Common error model",
+                  "properties": {
+                    "class": {
+                      "type": "string",
+                      "description": "Class of the error"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "Error message"
+                    }
+                  }
+                },
+                "examples": {
+                  "Client::NotFound::GatewayDoesNotExist": {
+                    "value": {
+                      "class": "Client::NotFound::GatewayDoesNotExist",
+                      "message": "Gateway not found"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Network"
+        ],
+        "x-badges": [
+          {
+            "color": "blue",
+            "label": "Alpha version"
+          }
+        ],
+        "x-iam-actions": [
+          {
+            "name": "publicCloudProject:apiovh:gateway/get",
+            "required": true
+          }
+        ],
+        "x-response-identifier": "id"
+      },
+      "put": {
+        "summary": "Update a gateway",
+        "security": [
+          {
+            "oAuth2AuthCode": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "gatewayId",
+            "description": "Gateway ID",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "in": "path",
+            "name": "projectId",
+            "description": "Project ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/publicCloud.gateway.GatewayUpdate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/publicCloud.gateway.Gateway"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Error 400 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Common error model",
+                  "properties": {
+                    "class": {
+                      "type": "string",
+                      "description": "Class of the error"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "Error message"
+                    }
+                  }
+                },
+                "examples": {
+                  "Client::BadRequest::InvalidParameter": {
+                    "value": {
+                      "class": "Client::BadRequest::InvalidParameter",
+                      "message": "Invalid parameter in the request"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Error 404 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Common error model",
+                  "properties": {
+                    "class": {
+                      "type": "string",
+                      "description": "Class of the error"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "Error message"
+                    }
+                  }
+                },
+                "examples": {
+                  "Client::NotFound::GatewayDoesNotExist": {
+                    "value": {
+                      "class": "Client::NotFound::GatewayDoesNotExist",
+                      "message": "Gateway not found"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Error 409 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Common error model",
+                  "properties": {
+                    "class": {
+                      "type": "string",
+                      "description": "Class of the error"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "Error message"
+                    }
+                  }
+                },
+                "examples": {
+                  "Client::Conflict::ChecksumMismatch": {
+                    "value": {
+                      "class": "Client::Conflict::ChecksumMismatch",
+                      "message": "Checksum mismatch — a concurrent update was detected. Refresh the resource and retry"
+                    }
+                  },
+                  "Client::Conflict::ResourceInInvalidState": {
+                    "value": {
+                      "class": "Client::Conflict::ResourceInInvalidState",
+                      "message": "Resource cannot be modified in its current state"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Network"
+        ],
+        "x-badges": [
+          {
+            "color": "blue",
+            "label": "Alpha version"
+          }
+        ],
+        "x-iam-actions": [
+          {
+            "name": "publicCloudProject:apiovh:gateway/edit",
+            "required": true
+          }
+        ]
+      }
+    },
+    "/publicCloud/project/{projectId}/securityGroup": {
+      "get": {
+        "summary": "List security groups",
+        "security": [
+          {
+            "oAuth2AuthCode": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "header",
+            "name": "X-Pagination-Cursor",
+            "description": "Pagination cursor",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Pagination-Size",
+            "description": "Pagination size",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "in": "path",
+            "name": "projectId",
+            "description": "Project ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/publicCloud.securityGroup.SecurityGroup"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Network"
+        ],
+        "x-badges": [
+          {
+            "color": "blue",
+            "label": "Alpha version"
+          }
+        ],
+        "x-iam-actions": [
+          {
+            "name": "publicCloudProject:apiovh:securityGroup/get",
+            "required": true
+          }
+        ],
+        "x-response-identifier": "id",
+        "x-expanded-response": "PublicCloudSecurityGroupSecurityGroup"
+      },
+      "post": {
+        "summary": "Create a security group",
+        "security": [
+          {
+            "oAuth2AuthCode": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "projectId",
+            "description": "Project ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/publicCloud.securityGroup.SecurityGroupCreation"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/publicCloud.securityGroup.SecurityGroup"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Error 409 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Common error model",
+                  "properties": {
+                    "class": {
+                      "type": "string",
+                      "description": "Class of the error"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "Error message"
+                    }
+                  }
+                },
+                "examples": {
+                  "Client::Conflict::RegionInMaintenance": {
+                    "value": {
+                      "class": "Client::Conflict::RegionInMaintenance",
+                      "message": "This region is currently in maintenance"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Network"
+        ],
+        "x-badges": [
+          {
+            "color": "blue",
+            "label": "Alpha version"
+          }
+        ],
+        "x-iam-actions": [
+          {
+            "name": "publicCloudProject:apiovh:securityGroup/create",
+            "required": true
+          }
+        ]
+      }
+    },
+    "/publicCloud/project/{projectId}/securityGroup/{securityGroupId}": {
+      "delete": {
+        "summary": "Delete a security group",
+        "security": [
+          {
+            "oAuth2AuthCode": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "projectId",
+            "description": "Project ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "securityGroupId",
+            "description": "Security group ID",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/publicCloud.securityGroup.SecurityGroup"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Error 404 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Common error model",
+                  "properties": {
+                    "class": {
+                      "type": "string",
+                      "description": "Class of the error"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "Error message"
+                    }
+                  }
+                },
+                "examples": {
+                  "Client::NotFound::SecurityGroupDoesNotExist": {
+                    "value": {
+                      "class": "Client::NotFound::SecurityGroupDoesNotExist",
+                      "message": "Security group not found"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Error 409 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Common error model",
+                  "properties": {
+                    "class": {
+                      "type": "string",
+                      "description": "Class of the error"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "Error message"
+                    }
+                  }
+                },
+                "examples": {
+                  "Client::Conflict::ResourceAlreadyBeingDeleted": {
+                    "value": {
+                      "class": "Client::Conflict::ResourceAlreadyBeingDeleted",
+                      "message": "Resource is already being deleted"
+                    }
+                  },
+                  "Client::Conflict::ResourceInInvalidState": {
+                    "value": {
+                      "class": "Client::Conflict::ResourceInInvalidState",
+                      "message": "Resource cannot be modified in its current state"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Network"
+        ],
+        "x-badges": [
+          {
+            "color": "blue",
+            "label": "Alpha version"
+          }
+        ],
+        "x-iam-actions": [
+          {
+            "name": "publicCloudProject:apiovh:securityGroup/delete",
+            "required": true
+          }
+        ]
+      },
+      "get": {
+        "summary": "Get a security group",
+        "security": [
+          {
+            "oAuth2AuthCode": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "projectId",
+            "description": "Project ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "securityGroupId",
+            "description": "Security group ID",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/publicCloud.securityGroup.SecurityGroup"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Error 404 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Common error model",
+                  "properties": {
+                    "class": {
+                      "type": "string",
+                      "description": "Class of the error"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "Error message"
+                    }
+                  }
+                },
+                "examples": {
+                  "Client::NotFound::SecurityGroupDoesNotExist": {
+                    "value": {
+                      "class": "Client::NotFound::SecurityGroupDoesNotExist",
+                      "message": "Security group not found"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Network"
+        ],
+        "x-badges": [
+          {
+            "color": "blue",
+            "label": "Alpha version"
+          }
+        ],
+        "x-iam-actions": [
+          {
+            "name": "publicCloudProject:apiovh:securityGroup/get",
+            "required": true
+          }
+        ],
+        "x-response-identifier": "id"
+      },
+      "put": {
+        "summary": "Update a security group",
+        "security": [
+          {
+            "oAuth2AuthCode": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "projectId",
+            "description": "Project ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "securityGroupId",
+            "description": "Security group ID",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/publicCloud.securityGroup.SecurityGroupUpdate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/publicCloud.securityGroup.SecurityGroup"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Error 404 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Common error model",
+                  "properties": {
+                    "class": {
+                      "type": "string",
+                      "description": "Class of the error"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "Error message"
+                    }
+                  }
+                },
+                "examples": {
+                  "Client::NotFound::SecurityGroupDoesNotExist": {
+                    "value": {
+                      "class": "Client::NotFound::SecurityGroupDoesNotExist",
+                      "message": "Security group not found"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Error 409 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Common error model",
+                  "properties": {
+                    "class": {
+                      "type": "string",
+                      "description": "Class of the error"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "Error message"
+                    }
+                  }
+                },
+                "examples": {
+                  "Client::Conflict::ChecksumMismatch": {
+                    "value": {
+                      "class": "Client::Conflict::ChecksumMismatch",
+                      "message": "Checksum mismatch — a concurrent update was detected. Refresh the resource and retry"
+                    }
+                  },
+                  "Client::Conflict::ResourceInInvalidState": {
+                    "value": {
+                      "class": "Client::Conflict::ResourceInInvalidState",
+                      "message": "Resource cannot be modified in its current state"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Network"
+        ],
+        "x-badges": [
+          {
+            "color": "blue",
+            "label": "Alpha version"
+          }
+        ],
+        "x-iam-actions": [
+          {
+            "name": "publicCloudProject:apiovh:securityGroup/edit",
+            "required": true
           }
         ]
       }

--- a/internal/cmd/cloud_network.go
+++ b/internal/cmd/cloud_network.go
@@ -19,6 +19,9 @@ func initCloudNetworkCommand(cloudCmd *cobra.Command) {
 	networkCmd.PersistentFlags().StringVar(&cloud.CloudProject, "cloud-project", "", "Cloud project ID")
 	cloudCmd.AddCommand(networkCmd)
 
+	// Security group commands (Cloud API v2)
+	initCloudSecurityGroupCommand(networkCmd)
+
 	// Private network commands
 	privateNetworkCmd := &cobra.Command{
 		Use:   "private",
@@ -146,8 +149,11 @@ func initCloudNetworkCommand(cloudCmd *cobra.Command) {
 		Run:   cloud.EditGateway,
 		Args:  cobra.ExactArgs(1),
 	}
-	gatewayEditCmd.Flags().StringVar(&cloud.CloudGatewaySpec.Name, "name", "", "Name of the gateway")
-	gatewayEditCmd.Flags().StringVar(&cloud.CloudGatewaySpec.Model, "model", "", "Model of the gateway (s, m, l, xl, 2xl, 3xl)")
+	gatewayEditCmd.Flags().StringVar(&cloud.CloudGatewaySpec.TargetSpec.Name, "name", "", "Name of the gateway")
+	gatewayEditCmd.Flags().StringVar(&cloud.CloudGatewaySpec.TargetSpec.Description, "description", "", "Description of the gateway")
+	gatewayEditCmd.Flags().BoolVar(&cloud.CloudGatewaySpec.TargetSpec.ExternalGateway.Enabled, "external-gateway-enabled", false, "Whether the external gateway is enabled")
+	gatewayEditCmd.Flags().StringVar(&cloud.CloudGatewaySpec.TargetSpec.ExternalGateway.Model, "external-gateway-model", "", "External gateway sizing model (S, M, L, XL, 2XL, 3XL)")
+	gatewayEditCmd.Flags().StringSliceVar(&cloud.CloudGatewaySpec.TargetSpec.CliSubnets, "subnet", nil, "ID of a subnet to attach to the gateway (repeatable)")
 	addInteractiveEditorFlag(gatewayEditCmd)
 	gatewayCmd.AddCommand(gatewayEditCmd)
 
@@ -328,87 +334,56 @@ There are three ways to define the parameters:
 
 func getGatewayCreationCmd() *cobra.Command {
 	gatewayCreateCmd := &cobra.Command{
-		Use:   "create <region>",
+		Use:   "create",
 		Short: "Create a gateway in the given cloud project",
-		Long: `Use this command to create a new gateway.
+		Long: `Use this command to create a new gateway in the given public cloud project.
 
-Two options are available to create a gateway:
-	- Create a gateway in an existing private network
-	- Create a gateway in a new private network
-
-When creating a gateway in an existing private network, you must specify the network ID and subnet ID 
-using the flags --network-id and --subnet-id.
-In this case, only two parameters are supported and required: the gateway model and its name (respectively
---model and --name flags).
-
-There are three ways to define the parameters:
+Subnets are nested objects: to attach them, use the repeatable --subnet flag, a
+configuration file or your text editor. There are three ways to define the
+creation parameters:
 
 1. Using only CLI flags:
 
-	ovhcloud cloud network gateway create <region> --name MyGateway --model xl
+	ovhcloud cloud network gateway create --name MyGateway --region GRA11 --external-gateway-enabled --external-gateway-model S
 
 2. Using a configuration file:
 
   First you can generate an example of parameters file using the following command:
 
-	ovhcloud cloud network gateway create <region> --init-file ./params.json
+	ovhcloud cloud network gateway create --init-file ./params.json
 
-  You will be able to choose from several examples of parameters. Once an example has been selected, the content is written in the given file.
   After editing the file to set the correct creation parameters, run:
 
-	ovhcloud cloud network gateway create <region> --from-file ./params.json
+	ovhcloud cloud network gateway create --from-file ./params.json
 
   Note that you can also pipe the content of the parameters file, like the following:
 
-	cat ./params.json | ovhcloud cloud network gateway create <region>
+	cat ./params.json | ovhcloud cloud network gateway create
 
   In both cases, you can override the parameters in the given file using command line flags, for example:
 
-	ovhcloud cloud network gateway create <region> --from-file ./params.json --name MyGateway
+	ovhcloud cloud network gateway create --from-file ./params.json --name MyGateway
 
 3. Using your default text editor:
 
-	ovhcloud cloud network gateway create <region> --editor
-
-  You will be able to choose from several examples of parameters. Once an example has been selected, the CLI will open your
-  default text editor to update the parameters. When saving the file, the creation will start.
-
-  Note that it is also possible to override values in the presented examples using command line flags like the following:
-
-	ovhcloud cloud network gateway create <region> --editor --name MyGateway
+	ovhcloud cloud network gateway create --editor
 `,
-		Run:  cloud.CreateGateway,
-		Args: cobra.ExactArgs(1),
+		Run: cloud.CreateGateway,
 	}
 
-	gatewayCreateCmd.Flags().StringVar(&cloud.CloudGatewaySpec.Model, "model", "", "Gateway model (s, m, l, xl, 2xl, 3xl)")
-	gatewayCreateCmd.Flags().StringVar(&cloud.CloudGatewaySpec.Name, "name", "", "Name of the gateway")
-
-	gatewayCreateCmd.Flags().StringVar(&cloud.CloudGatewaySpec.Network.Name, "network-name", "", "Name of the private network")
-	gatewayCreateCmd.Flags().IntVar(&cloud.CloudGatewaySpec.Network.VlanId, "network-vlan-id", 0, "VLAN ID for the private network")
-
-	gatewayCreateCmd.Flags().StringVar(&cloud.CloudGatewaySpec.Network.Subnet.Name, "subnet-name", "", "Name of the subnet")
-	gatewayCreateCmd.Flags().StringVar(&cloud.CloudGatewaySpec.Network.Subnet.Cidr, "subnet-cidr", "", "CIDR of the subnet")
-	gatewayCreateCmd.Flags().IntVar(&cloud.CloudGatewaySpec.Network.Subnet.IPVersion, "subnet-ip-version", 0, "IP version (4 or 6)")
-	gatewayCreateCmd.Flags().BoolVar(&cloud.CloudGatewaySpec.Network.Subnet.EnableDhcp, "subnet-enable-dhcp", false, "Enable DHCP for the subnet")
-	gatewayCreateCmd.Flags().StringVar(&cloud.CloudGatewaySpec.Network.Subnet.GatewayIp, "subnet-gateway-ip", "", "Gateway IP address for the subnet")
-	gatewayCreateCmd.Flags().BoolVar(&cloud.CloudGatewaySpec.Network.Subnet.UseDefaultPublicDNSResolver, "subnet-use-default-public-dns-resolver", false, "Use default DNS resolver for the subnet")
-
-	gatewayCreateCmd.Flags().StringSliceVar(&cloud.CloudGatewaySpec.Network.Subnet.DnsNameServers, "subnet-dns-name-servers", nil, "DNS name servers for the subnet")
-	gatewayCreateCmd.Flags().StringSliceVar(&cloud.CloudGatewaySpec.Network.Subnet.CliAllocationPools, "subnet-allocation-pools", nil, "Allocation pools for the subnet in format start:end")
-	gatewayCreateCmd.Flags().StringSliceVar(&cloud.CloudGatewaySpec.Network.Subnet.CliHostRoutes, "subnet-host-routes", nil, "Host routes for the subnet in format destination:nextHop")
+	gatewayCreateCmd.Flags().StringVar(&cloud.CloudGatewaySpec.TargetSpec.Name, "name", "", "Name of the gateway")
+	gatewayCreateCmd.Flags().StringVar(&cloud.CloudGatewaySpec.TargetSpec.Description, "description", "", "Description of the gateway")
+	gatewayCreateCmd.Flags().StringVar(&cloud.CloudGatewaySpec.TargetSpec.Location.Region, "region", "", "Region where the gateway will be created")
+	gatewayCreateCmd.Flags().StringVar(&cloud.CloudGatewaySpec.TargetSpec.Location.AvailabilityZone, "availability-zone", "", "Availability zone within the region")
+	gatewayCreateCmd.Flags().BoolVar(&cloud.CloudGatewaySpec.TargetSpec.ExternalGateway.Enabled, "external-gateway-enabled", false, "Whether the external gateway is enabled")
+	gatewayCreateCmd.Flags().StringVar(&cloud.CloudGatewaySpec.TargetSpec.ExternalGateway.Model, "external-gateway-model", "", "External gateway sizing model (S, M, L, XL, 2XL, 3XL)")
+	gatewayCreateCmd.Flags().StringSliceVar(&cloud.CloudGatewaySpec.TargetSpec.CliSubnets, "subnet", nil, "ID of a subnet to attach to the gateway (repeatable)")
 
 	// Common flags for other means to define parameters
-	addParameterFileFlags(gatewayCreateCmd, false, assets.CloudOpenapiSchema, "/cloud/project/{serviceName}/region/{regionName}/gateway", "post", cloud.GatewayCreationExample, nil)
+	addParameterFileFlags(gatewayCreateCmd, false, assets.CloudV2OpenapiSchema, "/publicCloud/project/{projectId}/gateway", "post", cloud.GatewayCreationExample, nil)
 	addInteractiveEditorFlag(gatewayCreateCmd)
 	gatewayCreateCmd.Flags().BoolVar(&flags.WaitForTask, "wait", false, "Wait for gateway creation to be done before exiting")
 	markFlagsMutuallyExclusive(gatewayCreateCmd, "from-file", "editor")
-
-	// Add a flag to specify the network ID if creating in an existing private network
-	gatewayCreateCmd.Flags().StringVar(&cloud.CloudGatewaySpec.ExistingNetworkID, "network-id", "", "ID of the existing private network to create the gateway in")
-	gatewayCreateCmd.Flags().StringVar(&cloud.CloudGatewaySpec.ExistingSubnetID, "subnet-id", "", "ID of the existing subnet to create the gateway in")
-	markFlagsMutuallyExclusive(gatewayCreateCmd, "network-name", "network-id")
-	markFlagsMutuallyExclusive(gatewayCreateCmd, "subnet-name", "subnet-id")
 
 	return gatewayCreateCmd
 }

--- a/internal/cmd/cloud_network_gateway_test.go
+++ b/internal/cmd/cloud_network_gateway_test.go
@@ -1,0 +1,147 @@
+// SPDX-FileCopyrightText: 2025 OVH SAS <opensource@ovh.net>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd_test
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/jarcoal/httpmock"
+	"github.com/maxatome/go-testdeep/td"
+	"github.com/maxatome/tdhttpmock"
+	"github.com/ovh/ovhcloud-cli/internal/cmd"
+)
+
+func (ms *MockSuite) TestCloudGatewayV2ListCmd(assert, require *td.T) {
+	httpmock.RegisterResponder(http.MethodGet,
+		"https://eu.api.ovh.com/v2/publicCloud/project/fakeProjectID/gateway",
+		httpmock.NewStringResponder(200, `[
+			{
+				"id": "gw-12345",
+				"resourceStatus": "READY",
+				"currentState": {
+					"name": "my-gateway",
+					"location": {"region": "GRA11"},
+					"status": "ACTIVE"
+				}
+			}
+		]`))
+
+	out, err := cmd.Execute("cloud", "network", "gateway", "list", "--cloud-project", "fakeProjectID", "-o", "json")
+	require.CmpNoError(err)
+	assert.Cmp(json.RawMessage(out), td.JSON(`[
+		{
+			"id": "gw-12345",
+			"resourceStatus": "READY",
+			"currentState": {
+				"name": "my-gateway",
+				"location": {"region": "GRA11"},
+				"status": "ACTIVE"
+			}
+		}
+	]`))
+}
+
+func (ms *MockSuite) TestCloudGatewayV2GetCmd(assert, require *td.T) {
+	httpmock.RegisterResponder(http.MethodGet,
+		"https://eu.api.ovh.com/v2/publicCloud/project/fakeProjectID/gateway/gw-12345",
+		httpmock.NewStringResponder(200, `{
+			"id": "gw-12345",
+			"resourceStatus": "READY",
+			"currentState": {
+				"name": "my-gateway",
+				"location": {"region": "GRA11"},
+				"status": "ACTIVE"
+			}
+		}`))
+
+	out, err := cmd.Execute("cloud", "network", "gateway", "get", "--cloud-project", "fakeProjectID", "gw-12345", "-o", "json")
+	require.CmpNoError(err)
+	assert.Cmp(json.RawMessage(out), td.JSON(`{
+		"id": "gw-12345",
+		"resourceStatus": "READY",
+		"currentState": {
+			"name": "my-gateway",
+			"location": {"region": "GRA11"},
+			"status": "ACTIVE"
+		}
+	}`))
+}
+
+func (ms *MockSuite) TestCloudGatewayV2CreateCmd(assert, require *td.T) {
+	httpmock.RegisterMatcherResponder(http.MethodPost,
+		"https://eu.api.ovh.com/v2/publicCloud/project/fakeProjectID/gateway",
+		tdhttpmock.JSONBody(td.JSON(`
+			{
+				"targetSpec": {
+					"name": "my-gateway",
+					"location": {
+						"region": "GRA11"
+					},
+					"externalGateway": {
+						"enabled": true,
+						"model": "S"
+					}
+				}
+			}`),
+		),
+		httpmock.NewStringResponder(200, `{"id": "gw-12345"}`),
+	)
+
+	out, err := cmd.Execute("cloud", "network", "gateway", "create", "--cloud-project", "fakeProjectID",
+		"--name", "my-gateway", "--region", "GRA11", "--external-gateway-enabled", "--external-gateway-model", "S")
+	require.CmpNoError(err)
+	assert.String(out, `⚡️ Gateway creation started successfully (id: gw-12345)`)
+}
+
+func (ms *MockSuite) TestCloudGatewayV2EditCmd(assert, require *td.T) {
+	httpmock.RegisterResponder(http.MethodGet,
+		"https://eu.api.ovh.com/v2/publicCloud/project/fakeProjectID/gateway/gw-12345",
+		httpmock.NewStringResponder(200, `{
+			"id": "gw-12345",
+			"checksum": "abc123",
+			"resourceStatus": "READY",
+			"targetSpec": {
+				"name": "my-gateway",
+				"description": "old description",
+				"externalGateway": {
+					"enabled": true,
+					"model": "S"
+				}
+			}
+		}`))
+
+	httpmock.RegisterMatcherResponder(http.MethodPut,
+		"https://eu.api.ovh.com/v2/publicCloud/project/fakeProjectID/gateway/gw-12345",
+		tdhttpmock.JSONBody(td.JSON(`
+			{
+				"checksum": "abc123",
+				"targetSpec": {
+					"name": "renamed-gateway",
+					"description": "old description",
+					"externalGateway": {
+						"enabled": true,
+						"model": "S"
+					}
+				}
+			}`),
+		),
+		httpmock.NewStringResponder(200, ``),
+	)
+
+	out, err := cmd.Execute("cloud", "network", "gateway", "edit", "--cloud-project", "fakeProjectID", "gw-12345", "--name", "renamed-gateway")
+	require.CmpNoError(err)
+	assert.String(out, `✅ Resource updated successfully`)
+}
+
+func (ms *MockSuite) TestCloudGatewayV2DeleteCmd(assert, require *td.T) {
+	httpmock.RegisterResponder(http.MethodDelete,
+		"https://eu.api.ovh.com/v2/publicCloud/project/fakeProjectID/gateway/gw-12345",
+		httpmock.NewStringResponder(200, ``))
+
+	out, err := cmd.Execute("cloud", "network", "gateway", "delete", "--cloud-project", "fakeProjectID", "gw-12345")
+	require.CmpNoError(err)
+	assert.String(out, `✅ Gateway gw-12345 is being deleted…`)
+}

--- a/internal/cmd/cloud_security_group.go
+++ b/internal/cmd/cloud_security_group.go
@@ -1,0 +1,112 @@
+// SPDX-FileCopyrightText: 2025 OVH SAS <opensource@ovh.net>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"github.com/ovh/ovhcloud-cli/internal/assets"
+	"github.com/ovh/ovhcloud-cli/internal/flags"
+	"github.com/ovh/ovhcloud-cli/internal/services/cloud"
+	"github.com/spf13/cobra"
+)
+
+func initCloudSecurityGroupCommand(networkCmd *cobra.Command) {
+	securityGroupCmd := &cobra.Command{
+		Use:     "security-group",
+		Aliases: []string{"sg"},
+		Short:   "Manage security groups in the given cloud project",
+	}
+	networkCmd.AddCommand(securityGroupCmd)
+
+	securityGroupListCmd := &cobra.Command{
+		Use:     "list",
+		Aliases: []string{"ls"},
+		Short:   "List security groups",
+		Run:     cloud.ListSecurityGroups,
+	}
+	securityGroupCmd.AddCommand(withFilterFlag(securityGroupListCmd))
+
+	securityGroupCmd.AddCommand(&cobra.Command{
+		Use:   "get <security_group_id>",
+		Short: "Get a specific security group",
+		Run:   cloud.GetSecurityGroup,
+		Args:  cobra.ExactArgs(1),
+	})
+
+	securityGroupCmd.AddCommand(getSecurityGroupCreateCmd())
+	securityGroupCmd.AddCommand(getSecurityGroupEditCmd())
+
+	securityGroupCmd.AddCommand(&cobra.Command{
+		Use:   "delete <security_group_id>",
+		Short: "Delete a specific security group",
+		Run:   cloud.DeleteSecurityGroup,
+		Args:  cobra.ExactArgs(1),
+	})
+}
+
+func getSecurityGroupCreateCmd() *cobra.Command {
+	securityGroupCreateCmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a new security group",
+		Long: `Use this command to create a security group in the given public cloud project.
+
+Rules are nested objects: to define them, use a configuration file or your text
+editor. There are three ways to define the creation parameters:
+
+1. Using only CLI flags:
+
+	ovhcloud cloud network security-group create --name my-sg --region GRA11
+
+2. Using a configuration file:
+
+  First you can generate an example of parameters file using the following command:
+
+	ovhcloud cloud network security-group create --init-file ./params.json
+
+  After editing the file to set the correct creation parameters, run:
+
+	ovhcloud cloud network security-group create --from-file ./params.json
+
+  You can also pipe the content of the parameters file:
+
+	cat ./params.json | ovhcloud cloud network security-group create
+
+  In both cases, you can override values using command line flags, for example:
+
+	ovhcloud cloud network security-group create --from-file ./params.json --name my-sg
+
+3. Using your default text editor:
+
+	ovhcloud cloud network security-group create --editor
+`,
+		Run: cloud.CreateSecurityGroup,
+	}
+
+	securityGroupCreateCmd.Flags().StringVar(&cloud.SecurityGroupSpec.TargetSpec.Name, "name", "", "Name of the security group")
+	securityGroupCreateCmd.Flags().StringVar(&cloud.SecurityGroupSpec.TargetSpec.Description, "description", "", "Description of the security group")
+	securityGroupCreateCmd.Flags().StringVar(&cloud.SecurityGroupSpec.TargetSpec.Location.Region, "region", "", "Region where the security group will be created")
+	securityGroupCreateCmd.Flags().StringVar(&cloud.SecurityGroupSpec.TargetSpec.Location.AvailabilityZone, "availability-zone", "", "Availability zone within the region")
+
+	addParameterFileFlags(securityGroupCreateCmd, false, assets.CloudV2OpenapiSchema, "/publicCloud/project/{projectId}/securityGroup", "post", cloud.SecurityGroupCreationExample, nil)
+	addInteractiveEditorFlag(securityGroupCreateCmd)
+	securityGroupCreateCmd.Flags().BoolVar(&flags.WaitForTask, "wait", false, "Wait for security group creation to be done before exiting")
+	markFlagsMutuallyExclusive(securityGroupCreateCmd, "from-file", "editor")
+
+	return securityGroupCreateCmd
+}
+
+func getSecurityGroupEditCmd() *cobra.Command {
+	securityGroupEditCmd := &cobra.Command{
+		Use:   "edit <security_group_id>",
+		Short: "Edit the given security group",
+		Run:   cloud.EditSecurityGroup,
+		Args:  cobra.ExactArgs(1),
+	}
+
+	securityGroupEditCmd.Flags().StringVar(&cloud.SecurityGroupSpec.TargetSpec.Name, "name", "", "Name of the security group")
+	securityGroupEditCmd.Flags().StringVar(&cloud.SecurityGroupSpec.TargetSpec.Description, "description", "", "Description of the security group")
+	addInteractiveEditorFlag(securityGroupEditCmd)
+
+	return securityGroupEditCmd
+}

--- a/internal/cmd/cloud_security_group_test.go
+++ b/internal/cmd/cloud_security_group_test.go
@@ -1,0 +1,134 @@
+// SPDX-FileCopyrightText: 2025 OVH SAS <opensource@ovh.net>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd_test
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/jarcoal/httpmock"
+	"github.com/maxatome/go-testdeep/td"
+	"github.com/maxatome/tdhttpmock"
+	"github.com/ovh/ovhcloud-cli/internal/cmd"
+)
+
+func (ms *MockSuite) TestCloudSecurityGroupListCmd(assert, require *td.T) {
+	httpmock.RegisterResponder(http.MethodGet,
+		"https://eu.api.ovh.com/v2/publicCloud/project/fakeProjectID/securityGroup",
+		httpmock.NewStringResponder(200, `[
+			{
+				"id": "sg-12345",
+				"resourceStatus": "READY",
+				"currentState": {
+					"name": "my-sg",
+					"location": {
+						"region": "GRA11"
+					}
+				}
+			}
+		]`))
+
+	out, err := cmd.Execute("cloud", "network", "security-group", "list", "--cloud-project", "fakeProjectID", "-o", "json")
+	require.CmpNoError(err)
+	assert.Cmp(json.RawMessage(out), td.JSON(`[
+		{
+			"id": "sg-12345",
+			"resourceStatus": "READY",
+			"currentState": {
+				"name": "my-sg",
+				"location": {"region": "GRA11"}
+			}
+		}
+	]`))
+}
+
+func (ms *MockSuite) TestCloudSecurityGroupGetCmd(assert, require *td.T) {
+	httpmock.RegisterResponder(http.MethodGet,
+		"https://eu.api.ovh.com/v2/publicCloud/project/fakeProjectID/securityGroup/sg-12345",
+		httpmock.NewStringResponder(200, `{
+			"id": "sg-12345",
+			"resourceStatus": "READY",
+			"currentState": {
+				"name": "my-sg",
+				"location": {"region": "GRA11"}
+			}
+		}`))
+
+	out, err := cmd.Execute("cloud", "network", "security-group", "get", "--cloud-project", "fakeProjectID", "sg-12345", "-o", "json")
+	require.CmpNoError(err)
+	assert.Cmp(json.RawMessage(out), td.JSON(`{
+		"id": "sg-12345",
+		"resourceStatus": "READY",
+		"currentState": {
+			"name": "my-sg",
+			"location": {"region": "GRA11"}
+		}
+	}`))
+}
+
+func (ms *MockSuite) TestCloudSecurityGroupCreateCmd(assert, require *td.T) {
+	httpmock.RegisterMatcherResponder(http.MethodPost,
+		"https://eu.api.ovh.com/v2/publicCloud/project/fakeProjectID/securityGroup",
+		tdhttpmock.JSONBody(td.JSON(`
+			{
+				"targetSpec": {
+					"name": "my-sg",
+					"description": "test group",
+					"location": {
+						"region": "GRA11"
+					}
+				}
+			}`),
+		),
+		httpmock.NewStringResponder(200, `{"id": "sg-12345"}`),
+	)
+
+	out, err := cmd.Execute("cloud", "network", "security-group", "create", "--cloud-project", "fakeProjectID",
+		"--name", "my-sg", "--description", "test group", "--region", "GRA11")
+	require.CmpNoError(err)
+	assert.String(out, `✅ Security group created successfully (id: sg-12345)`)
+}
+
+func (ms *MockSuite) TestCloudSecurityGroupEditCmd(assert, require *td.T) {
+	httpmock.RegisterResponder(http.MethodGet,
+		"https://eu.api.ovh.com/v2/publicCloud/project/fakeProjectID/securityGroup/sg-12345",
+		httpmock.NewStringResponder(200, `{
+			"id": "sg-12345",
+			"checksum": "abc123",
+			"resourceStatus": "READY",
+			"targetSpec": {
+				"name": "my-sg",
+				"description": "old description"
+			}
+		}`))
+
+	httpmock.RegisterMatcherResponder(http.MethodPut,
+		"https://eu.api.ovh.com/v2/publicCloud/project/fakeProjectID/securityGroup/sg-12345",
+		tdhttpmock.JSONBody(td.JSON(`
+			{
+				"checksum": "abc123",
+				"targetSpec": {
+					"name": "renamed-sg",
+					"description": "old description"
+				}
+			}`),
+		),
+		httpmock.NewStringResponder(200, ``),
+	)
+
+	out, err := cmd.Execute("cloud", "network", "security-group", "edit", "--cloud-project", "fakeProjectID", "sg-12345", "--name", "renamed-sg")
+	require.CmpNoError(err)
+	assert.String(out, `✅ Resource updated successfully`)
+}
+
+func (ms *MockSuite) TestCloudSecurityGroupDeleteCmd(assert, require *td.T) {
+	httpmock.RegisterResponder(http.MethodDelete,
+		"https://eu.api.ovh.com/v2/publicCloud/project/fakeProjectID/securityGroup/sg-12345",
+		httpmock.NewStringResponder(200, ``))
+
+	out, err := cmd.Execute("cloud", "network", "security-group", "delete", "--cloud-project", "fakeProjectID", "sg-12345")
+	require.CmpNoError(err)
+	assert.String(out, `✅ Security group sg-12345 is being deleted…`)
+}

--- a/internal/services/cloud/cloud_network.go
+++ b/internal/services/cloud/cloud_network.go
@@ -27,7 +27,7 @@ import (
 var (
 	cloudprojectPrivateNetworkColumnsToDisplay = []string{"id", "name", "region", "visibility", "vlanId"}
 	cloudprojectPublicNetworkColumnsToDisplay  = []string{"id", "name", "region"}
-	cloudprojectGatewayColumnsToDisplay        = []string{"id", "name", "region", "model", "status"}
+	cloudprojectGatewayColumnsToDisplay        = []string{"id", "currentState.name name", "currentState.location.region region", "resourceStatus"}
 
 	//go:embed templates/cloud_network_private.tmpl
 	cloudNetworkPrivateTemplate string
@@ -37,6 +37,9 @@ var (
 
 	//go:embed templates/cloud_network_gateway.tmpl
 	cloudGatewayTemplate string
+
+	//go:embed templates/cloud_network_gateway_v2.tmpl
+	cloudGatewayV2Template string
 
 	//go:embed templates/cloud_network_private_subnet.tmpl
 	cloudNetworkPrivateSubnetTemplate string
@@ -53,30 +56,9 @@ var (
 	//go:embed parameter-samples/gateway-create.json
 	GatewayCreationExample string
 
-	// CloudGatewaySpec contains the parameters for updating a cloud gateway
+	// CloudGatewaySpec contains the parameters for creating or updating a v2 cloud gateway
 	CloudGatewaySpec struct {
-		Model             string `json:"model,omitempty"`
-		Name              string `json:"name,omitempty"`
-		ExistingNetworkID string `json:"-"`
-		ExistingSubnetID  string `json:"-"`
-		Network           struct {
-			Name   string `json:"name,omitempty"`
-			VlanId int    `json:"vlanId,omitempty"`
-			Subnet struct {
-				Name                        string                         `json:"name,omitempty"`
-				Cidr                        string                         `json:"cidr,omitempty"`
-				EnableDhcp                  bool                           `json:"enableDhcp,omitempty"`
-				GatewayIp                   string                         `json:"gatewayIp,omitempty"`
-				DnsNameServers              []string                       `json:"dnsNameServers,omitempty"`
-				UseDefaultPublicDNSResolver bool                           `json:"useDefaultPublicDNSResolver,omitempty"`
-				IPVersion                   int                            `json:"ipVersion,omitempty"`
-				AllocationPools             []PrivateNetworkAllocationPool `json:"allocationPools,omitempty"`
-				HostRoutes                  []PrivateNetworkHostRoute      `json:"hostRoutes,omitempty"`
-
-				CliAllocationPools []string `json:"-"`
-				CliHostRoutes      []string `json:"-"`
-			} `json:"subnet,omitzero"`
-		} `json:"network,omitzero"`
+		TargetSpec CloudGatewayTargetSpec `json:"targetSpec"`
 	}
 
 	CloudNetworkSpec struct {
@@ -114,6 +96,32 @@ type (
 	PrivateNetworkHostRoute struct {
 		Destination string `json:"destination,omitempty"`
 		NextHop     string `json:"nextHop,omitempty"`
+	}
+
+	// CloudGatewayTargetSpec is the desired specification of a v2 gateway.
+	CloudGatewayTargetSpec struct {
+		Name            string                 `json:"name,omitempty"`
+		Description     string                 `json:"description,omitempty"`
+		Location        gatewayLocation        `json:"location,omitzero"`
+		ExternalGateway gatewayExternalGateway `json:"externalGateway,omitzero"`
+		Subnets         []gatewaySubnetRef     `json:"subnets,omitempty"`
+
+		// CliSubnets holds subnet IDs passed on the command line; converted into Subnets.
+		CliSubnets []string `json:"-"`
+	}
+
+	gatewayLocation struct {
+		Region           string `json:"region,omitempty"`
+		AvailabilityZone string `json:"availabilityZone,omitempty"`
+	}
+
+	gatewayExternalGateway struct {
+		Enabled bool   `json:"enabled"`
+		Model   string `json:"model,omitempty"`
+	}
+
+	gatewaySubnetRef struct {
+		Id string `json:"id,omitempty"`
 	}
 )
 
@@ -448,37 +456,15 @@ func ListGateways(_ *cobra.Command, _ []string) {
 		return
 	}
 
-	// Fetch regions with network feature available
-	regions, err := getCloudRegionsWithFeatureAvailable(projectID, "network")
-	if err != nil {
-		display.OutputError(&flags.OutputFormatConfig, "failed to fetch regions with network feature available: %s", err)
-		return
-	}
-
-	// Fetch gateways in all regions
-	url := fmt.Sprintf("/v1/cloud/project/%s/region", projectID)
-	gateways, err := httpLib.FetchObjectsParallel[[]map[string]any](url+"/%s/gateway", regions, true)
-	if err != nil {
-		display.OutputError(&flags.OutputFormatConfig, "failed to fetch gateways: %s", err)
-		return
-	}
-
-	// Flatten gateways in a single array
-	var allGateways []map[string]any
-	for _, regionGateways := range gateways {
-		allGateways = append(allGateways, regionGateways...)
-	}
-
-	// Filter results
-	allGateways, err = filtersLib.FilterLines(allGateways, flags.GenericFilters)
-	if err != nil {
-		display.OutputError(&flags.OutputFormatConfig, "failed to filter results: %s", err)
-		return
-	}
-
-	display.RenderTable(allGateways, cloudprojectGatewayColumnsToDisplay, &flags.OutputFormatConfig)
+	common.ManageListRequestNoExpand(
+		fmt.Sprintf("/v2/publicCloud/project/%s/gateway", projectID),
+		cloudprojectGatewayColumnsToDisplay,
+		flags.GenericFilters,
+	)
 }
 
+// findGateway searches for a v1 gateway across all regions. It is kept to serve
+// the commands that have no Cloud API v2 equivalent yet (expose, interfaces).
 func findGateway(gatewayId string) (string, map[string]any, error) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
@@ -508,127 +494,99 @@ func findGateway(gatewayId string) (string, map[string]any, error) {
 }
 
 func GetGateway(_ *cobra.Command, args []string) {
-	_, foundGateway, err := findGateway(args[0])
-	if err != nil {
-		display.OutputError(&flags.OutputFormatConfig, "%s", err)
-		return
-	}
-
-	display.OutputObject(foundGateway, args[0], cloudGatewayTemplate, &flags.OutputFormatConfig)
-}
-
-func EditGateway(cmd *cobra.Command, args []string) {
-	foundURL, _, err := findGateway(args[0])
-	if err != nil {
-		display.OutputError(&flags.OutputFormatConfig, "%s", err)
-		return
-	}
-
-	if err := common.EditResource(
-		cmd,
-		"/cloud/project/{serviceName}/region/{regionName}/gateway/{id}",
-		foundURL,
-		CloudGatewaySpec,
-		assets.CloudOpenapiSchema,
-	); err != nil {
-		display.OutputError(&flags.OutputFormatConfig, "%s", err)
-		return
-	}
-}
-
-func CreateGateway(cmd *cobra.Command, args []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
-	// Transform CLI flags into the CloudGatewaySpec structure
-	for _, allocationPool := range CloudGatewaySpec.Network.Subnet.CliAllocationPools {
-		parts := strings.Split(allocationPool, ":")
-		if len(parts) != 2 {
-			display.OutputError(&flags.OutputFormatConfig, "invalid allocation pool format, expected start:end, got %s", allocationPool)
-			return
-		}
-		CloudGatewaySpec.Network.Subnet.AllocationPools = append(CloudGatewaySpec.Network.Subnet.AllocationPools, PrivateNetworkAllocationPool{
-			Start: parts[0],
-			End:   parts[1],
-		})
-	}
-	for _, hostRoute := range CloudGatewaySpec.Network.Subnet.CliHostRoutes {
-		parts := strings.Split(hostRoute, ":")
-		if len(parts) != 2 {
-			display.OutputError(&flags.OutputFormatConfig, "invalid host route format, expected destination:nextHop, got %s", hostRoute)
-			return
-		}
-		CloudGatewaySpec.Network.Subnet.HostRoutes = append(CloudGatewaySpec.Network.Subnet.HostRoutes, PrivateNetworkHostRoute{
-			Destination: parts[0],
-			NextHop:     parts[1],
-		})
-	}
-
-	var (
-		endpoint, path string
-		region         = args[0]
+	common.ManageObjectRequest(
+		fmt.Sprintf("/v2/publicCloud/project/%s/gateway", projectID),
+		args[0],
+		cloudGatewayV2Template,
 	)
-	if CloudGatewaySpec.ExistingNetworkID != "" {
-		path = "/cloud/project/{serviceName}/region/{regionName}/network/{networkId}/subnet/{subnetId}/gateway"
-		endpoint = fmt.Sprintf(
-			"/v1/cloud/project/%s/region/%s/network/%s/subnet/%s/gateway",
-			projectID, url.PathEscape(region), url.PathEscape(CloudGatewaySpec.ExistingNetworkID),
-			url.PathEscape(CloudGatewaySpec.ExistingSubnetID))
-	} else {
-		path = "/cloud/project/{serviceName}/region/{regionName}/gateway"
-		endpoint = fmt.Sprintf("/v1/cloud/project/%s/region/%s/gateway", projectID, url.PathEscape(region))
-	}
-
-	if CloudGatewaySpec.Network.Subnet.IPVersion == 0 && CloudGatewaySpec.Network.Subnet.Cidr != "" {
-		CloudGatewaySpec.Network.Subnet.IPVersion = ipVersionFromCIDR(CloudGatewaySpec.Network.Subnet.Cidr)
-	}
-
-	// Create resource
-	task, err := common.CreateResource(
-		cmd,
-		path,
-		endpoint,
-		GatewayCreationExample,
-		CloudGatewaySpec,
-		assets.CloudOpenapiSchema,
-		[]string{"name", "model"})
-	if err != nil {
-		display.OutputError(&flags.OutputFormatConfig, "failed to create gateway: %s", err)
-		return
-	}
-
-	// Wait for task to complete if --wait flag is set
-	if !flags.WaitForTask {
-		display.OutputInfo(&flags.OutputFormatConfig, task, `⚡️ Gateway creation started successfully (operation ID: %s)
-You can check the status of the operation with: 'ovhcloud cloud operation get %s'`, task["id"], task["id"])
-		return
-	}
-
-	gatewayID, err := waitForCloudOperation(projectID, task["id"].(string), "gateway#create", 30*time.Minute)
-	if err != nil {
-		display.OutputError(&flags.OutputFormatConfig, "failed to wait for gateway creation: %s", err)
-		return
-	}
-
-	display.OutputInfo(&flags.OutputFormatConfig, nil, "✅ Gateway %s created successfully", gatewayID)
 }
 
-func DeleteGateway(_ *cobra.Command, args []string) {
-	foundURL, _, err := findGateway(args[0])
+func EditGateway(cmd *cobra.Command, args []string) {
+	projectID, err := getConfiguredCloudProject()
 	if err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
-	if err := httpLib.Client.Delete(foundURL, nil); err != nil {
+	// Convert subnet IDs given on the command line into the expected structure
+	for _, subnetID := range CloudGatewaySpec.TargetSpec.CliSubnets {
+		CloudGatewaySpec.TargetSpec.Subnets = append(CloudGatewaySpec.TargetSpec.Subnets, gatewaySubnetRef{Id: subnetID})
+	}
+
+	if err := common.EditResource(
+		cmd,
+		"/publicCloud/project/{projectId}/gateway/{gatewayId}",
+		fmt.Sprintf("/v2/publicCloud/project/%s/gateway/%s", projectID, url.PathEscape(args[0])),
+		CloudGatewaySpec,
+		assets.CloudV2OpenapiSchema,
+	); err != nil {
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
+		return
+	}
+}
+
+func CreateGateway(cmd *cobra.Command, _ []string) {
+	projectID, err := getConfiguredCloudProject()
+	if err != nil {
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
+		return
+	}
+
+	// Convert subnet IDs given on the command line into the expected structure
+	for _, subnetID := range CloudGatewaySpec.TargetSpec.CliSubnets {
+		CloudGatewaySpec.TargetSpec.Subnets = append(CloudGatewaySpec.TargetSpec.Subnets, gatewaySubnetRef{Id: subnetID})
+	}
+
+	endpoint := fmt.Sprintf("/v2/publicCloud/project/%s/gateway", projectID)
+	gateway, err := common.CreateResource(
+		cmd,
+		"/publicCloud/project/{projectId}/gateway",
+		endpoint,
+		GatewayCreationExample,
+		CloudGatewaySpec,
+		assets.CloudV2OpenapiSchema,
+		[]string{"targetSpec"})
+	if err != nil {
+		display.OutputError(&flags.OutputFormatConfig, "failed to create gateway: %s", err)
+		return
+	}
+
+	gatewayID, _ := gateway["id"].(string)
+
+	// Wait for the resource to be ready if --wait flag is set
+	if !flags.WaitForTask {
+		display.OutputInfo(&flags.OutputFormatConfig, gateway, "⚡️ Gateway creation started successfully (id: %s)", gatewayID)
+		return
+	}
+
+	if err := waitForCloudResourceReady(fmt.Sprintf("%s/%s", endpoint, url.PathEscape(gatewayID)), 30*time.Minute); err != nil {
+		display.OutputError(&flags.OutputFormatConfig, "failed to wait for gateway creation: %s", err)
+		return
+	}
+
+	display.OutputInfo(&flags.OutputFormatConfig, gateway, "✅ Gateway %s created successfully", gatewayID)
+}
+
+func DeleteGateway(_ *cobra.Command, args []string) {
+	projectID, err := getConfiguredCloudProject()
+	if err != nil {
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
+		return
+	}
+
+	endpoint := fmt.Sprintf("/v2/publicCloud/project/%s/gateway/%s", projectID, url.PathEscape(args[0]))
+	if err := httpLib.Client.Delete(endpoint, nil); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "failed to delete gateway: %s", err)
 		return
 	}
 
-	display.OutputInfo(&flags.OutputFormatConfig, nil, "✅ Gateway %s deleted successfully", args[0])
+	display.OutputInfo(&flags.OutputFormatConfig, nil, "✅ Gateway %s is being deleted…", args[0])
 }
 
 func ExposeGateway(_ *cobra.Command, args []string) {

--- a/internal/services/cloud/cloud_security_group.go
+++ b/internal/services/cloud/cloud_security_group.go
@@ -1,0 +1,156 @@
+// SPDX-FileCopyrightText: 2025 OVH SAS <opensource@ovh.net>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cloud
+
+import (
+	_ "embed"
+	"fmt"
+	"net/url"
+	"time"
+
+	"github.com/ovh/ovhcloud-cli/internal/assets"
+	"github.com/ovh/ovhcloud-cli/internal/display"
+	"github.com/ovh/ovhcloud-cli/internal/flags"
+	httpLib "github.com/ovh/ovhcloud-cli/internal/http"
+	"github.com/ovh/ovhcloud-cli/internal/services/common"
+	"github.com/spf13/cobra"
+)
+
+var (
+	cloudSecurityGroupColumnsToDisplay = []string{"id", "currentState.name name", "currentState.location.region region", "resourceStatus"}
+
+	//go:embed templates/cloud_security_group.tmpl
+	cloudSecurityGroupTemplate string
+
+	//go:embed parameter-samples/security-group-create.json
+	SecurityGroupCreationExample string
+
+	// SecurityGroupSpec holds the parameters used to create or edit a security group.
+	SecurityGroupSpec struct {
+		TargetSpec struct {
+			Name        string                    `json:"name,omitempty"`
+			Description string                    `json:"description,omitempty"`
+			Location    securityGroupLocation     `json:"location,omitzero"`
+			Rules       []securityGroupTargetRule `json:"rules,omitempty"`
+		} `json:"targetSpec"`
+	}
+)
+
+type (
+	securityGroupLocation struct {
+		Region           string `json:"region,omitempty"`
+		AvailabilityZone string `json:"availabilityZone,omitempty"`
+	}
+
+	securityGroupTargetRule struct {
+		Description    string `json:"description,omitempty"`
+		Direction      string `json:"direction,omitempty"`
+		EthernetType   string `json:"ethernetType,omitempty"`
+		PortRangeMin   int    `json:"portRangeMin,omitempty"`
+		PortRangeMax   int    `json:"portRangeMax,omitempty"`
+		Protocol       string `json:"protocol,omitempty"`
+		RemoteIpPrefix string `json:"remoteIpPrefix,omitempty"`
+	}
+)
+
+func ListSecurityGroups(_ *cobra.Command, _ []string) {
+	projectID, err := getConfiguredCloudProject()
+	if err != nil {
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
+		return
+	}
+
+	common.ManageListRequestNoExpand(
+		fmt.Sprintf("/v2/publicCloud/project/%s/securityGroup", projectID),
+		cloudSecurityGroupColumnsToDisplay,
+		flags.GenericFilters,
+	)
+}
+
+func GetSecurityGroup(_ *cobra.Command, args []string) {
+	projectID, err := getConfiguredCloudProject()
+	if err != nil {
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
+		return
+	}
+
+	common.ManageObjectRequest(
+		fmt.Sprintf("/v2/publicCloud/project/%s/securityGroup", projectID),
+		args[0],
+		cloudSecurityGroupTemplate,
+	)
+}
+
+func CreateSecurityGroup(cmd *cobra.Command, _ []string) {
+	projectID, err := getConfiguredCloudProject()
+	if err != nil {
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
+		return
+	}
+
+	endpoint := fmt.Sprintf("/v2/publicCloud/project/%s/securityGroup", projectID)
+	securityGroup, err := common.CreateResource(
+		cmd,
+		"/publicCloud/project/{projectId}/securityGroup",
+		endpoint,
+		SecurityGroupCreationExample,
+		SecurityGroupSpec,
+		assets.CloudV2OpenapiSchema,
+		[]string{"targetSpec"},
+	)
+	if err != nil {
+		display.OutputError(&flags.OutputFormatConfig, "failed to create security group: %s", err)
+		return
+	}
+
+	securityGroupID, _ := securityGroup["id"].(string)
+
+	if !flags.WaitForTask {
+		display.OutputInfo(&flags.OutputFormatConfig, securityGroup, "✅ Security group created successfully (id: %s)", securityGroupID)
+		return
+	}
+
+	if err := waitForCloudResourceReady(fmt.Sprintf("%s/%s", endpoint, url.PathEscape(securityGroupID)), 30*time.Minute); err != nil {
+		display.OutputError(&flags.OutputFormatConfig, "failed to wait for security group creation: %s", err)
+		return
+	}
+
+	display.OutputInfo(&flags.OutputFormatConfig, securityGroup, "✅ Security group %s created successfully", securityGroupID)
+}
+
+func EditSecurityGroup(cmd *cobra.Command, args []string) {
+	projectID, err := getConfiguredCloudProject()
+	if err != nil {
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
+		return
+	}
+
+	if err := common.EditResource(
+		cmd,
+		"/publicCloud/project/{projectId}/securityGroup/{securityGroupId}",
+		fmt.Sprintf("/v2/publicCloud/project/%s/securityGroup/%s", projectID, url.PathEscape(args[0])),
+		SecurityGroupSpec,
+		assets.CloudV2OpenapiSchema,
+	); err != nil {
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
+		return
+	}
+}
+
+func DeleteSecurityGroup(_ *cobra.Command, args []string) {
+	projectID, err := getConfiguredCloudProject()
+	if err != nil {
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
+		return
+	}
+
+	endpoint := fmt.Sprintf("/v2/publicCloud/project/%s/securityGroup/%s", projectID, url.PathEscape(args[0]))
+	if err := httpLib.Client.Delete(endpoint, nil); err != nil {
+		display.OutputError(&flags.OutputFormatConfig, "failed to delete security group: %s", err)
+		return
+	}
+
+	display.OutputInfo(&flags.OutputFormatConfig, nil, "✅ Security group %s is being deleted…", args[0])
+}

--- a/internal/services/cloud/parameter-samples/gateway-create.json
+++ b/internal/services/cloud/parameter-samples/gateway-create.json
@@ -1,30 +1,18 @@
 {
-  "model": "s",
-  "name": "mygateway",
-  "network": {
-    "name": "mynetwork",
-    "subnet": {
-      "allocationPools": [
-        {
-          "end": "10.0.2.0",
-          "start": "10.0.2.0"
-        }
-      ],
-      "cidr": "10.0.2.0/24",
-      "dnsNameServers": [
-        "10.0.2.0"
-      ],
-      "enableDhcp": false,
-      "gatewayIp": "10.0.2.0",
-      "hostRoutes": [
-        {
-          "destination": "10.0.2.0/24",
-          "nextHop": "10.0.2.0"
-        }
-      ],
-      "ipVersion": 4,
-      "name": "mysubnet",
-      "useDefaultPublicDNSResolver": false
-    }
+  "targetSpec": {
+    "name": "mygateway",
+    "description": "My gateway",
+    "location": {
+      "region": "GRA11"
+    },
+    "externalGateway": {
+      "enabled": true,
+      "model": "S"
+    },
+    "subnets": [
+      {
+        "id": "00000000-0000-0000-0000-000000000000"
+      }
+    ]
   }
 }

--- a/internal/services/cloud/parameter-samples/security-group-create.json
+++ b/internal/services/cloud/parameter-samples/security-group-create.json
@@ -1,0 +1,20 @@
+{
+  "targetSpec": {
+    "name": "my-security-group",
+    "description": "My security group",
+    "location": {
+      "region": "GRA11"
+    },
+    "rules": [
+      {
+        "description": "Allow inbound SSH",
+        "direction": "INGRESS",
+        "ethernetType": "IPV4",
+        "protocol": "TCP",
+        "portRangeMin": 22,
+        "portRangeMax": 22,
+        "remoteIpPrefix": "0.0.0.0/0"
+      }
+    ]
+  }
+}

--- a/internal/services/cloud/templates/cloud_network_gateway_v2.tmpl
+++ b/internal/services/cloud/templates/cloud_network_gateway_v2.tmpl
@@ -1,0 +1,50 @@
+🚀 Gateway {{.ServiceName}}
+=======
+
+_{{index .Result "currentState" "name"}}_
+
+## General information
+
+**Status**:        {{index .Result "resourceStatus"}}
+**Creation date**: {{index .Result "createdAt"}}
+**Update date**:   {{index .Result "updatedAt"}}
+
+## Current state
+
+{{if index .Result "currentState"}}**Name**:        {{index .Result "currentState" "name"}}
+**Description**: {{index .Result "currentState" "description"}}
+**Region**:      {{index .Result "currentState" "location" "region"}}
+**Status**:      {{index .Result "currentState" "status"}}
+**External IP**: {{index .Result "currentState" "externalIp"}}
+{{if index .Result "currentState" "externalGateway"}}**External gateway enabled**: {{index .Result "currentState" "externalGateway" "enabled"}}
+**External gateway model**:   {{index .Result "currentState" "externalGateway" "model"}}{{end}}
+
+{{if index .Result "currentState" "subnets"}}
+### Subnets
+
+| ID |
+| --- |
+{{range index .Result "currentState" "subnets"}}| {{.id}} |
+{{end}}
+{{end}}
+{{end}}
+
+## Target state
+
+{{if index .Result "targetSpec"}}**Name**:        {{index .Result "targetSpec" "name"}}
+**Description**: {{index .Result "targetSpec" "description"}}
+**Region**:      {{index .Result "targetSpec" "location" "region"}}
+{{if index .Result "targetSpec" "externalGateway"}}**External gateway enabled**: {{index .Result "targetSpec" "externalGateway" "enabled"}}
+**External gateway model**:   {{index .Result "targetSpec" "externalGateway" "model"}}{{end}}
+
+{{if index .Result "targetSpec" "subnets"}}
+### Subnets
+
+| ID |
+| --- |
+{{range index .Result "targetSpec" "subnets"}}| {{.id}} |
+{{end}}
+{{end}}
+{{end}}
+
+💡 Use option -o json or -o yaml to get the raw output with all information

--- a/internal/services/cloud/templates/cloud_security_group.tmpl
+++ b/internal/services/cloud/templates/cloud_security_group.tmpl
@@ -1,0 +1,44 @@
+🛡️ Security Group {{.ServiceName}}
+=======
+
+_{{index .Result "currentState" "name"}}_
+
+## General information
+
+**Status**:        {{index .Result "resourceStatus"}}
+**Creation date**: {{index .Result "createdAt"}}
+**Update date**:   {{index .Result "updatedAt"}}
+
+## Current state
+
+{{if index .Result "currentState"}}**Name**:        {{index .Result "currentState" "name"}}
+**Description**: {{index .Result "currentState" "description"}}
+**Region**:      {{index .Result "currentState" "location" "region"}}
+
+{{if index .Result "currentState" "rules"}}
+### Rules
+
+| Direction | Ethernet | Protocol | Port min | Port max | Remote IP prefix |
+| --- | --- | --- | --- | --- | --- |
+{{range index .Result "currentState" "rules"}}| {{.direction}} | {{.ethernetType}} | {{.protocol}} | {{.portRangeMin}} | {{.portRangeMax}} | {{.remoteIpPrefix}} |
+{{end}}
+{{end}}
+{{end}}
+
+## Target state
+
+{{if index .Result "targetSpec"}}**Name**:        {{index .Result "targetSpec" "name"}}
+**Description**: {{index .Result "targetSpec" "description"}}
+**Region**:      {{index .Result "targetSpec" "location" "region"}}
+
+{{if index .Result "targetSpec" "rules"}}
+### Rules
+
+| Direction | Ethernet | Protocol | Port min | Port max | Remote IP prefix |
+| --- | --- | --- | --- | --- | --- |
+{{range index .Result "targetSpec" "rules"}}| {{.direction}} | {{.ethernetType}} | {{.protocol}} | {{.portRangeMin}} | {{.portRangeMax}} | {{.remoteIpPrefix}} |
+{{end}}
+{{end}}
+{{end}}
+
+💡 Use option -o json or -o yaml to get the raw output with all information

--- a/internal/services/cloud/templates/cloud_security_group.tmpl
+++ b/internal/services/cloud/templates/cloud_security_group.tmpl
@@ -23,6 +23,14 @@ _{{index .Result "currentState" "name"}}_
 {{range index .Result "currentState" "rules"}}| {{.direction}} | {{.ethernetType}} | {{.protocol}} | {{.portRangeMin}} | {{.portRangeMax}} | {{.remoteIpPrefix}} |
 {{end}}
 {{end}}
+{{if index .Result "currentState" "defaultRules"}}
+### Default rules
+
+| Direction | Ethernet | Protocol | Port min | Port max | Remote IP prefix |
+| --- | --- | --- | --- | --- | --- |
+{{range index .Result "currentState" "defaultRules"}}| {{.direction}} | {{.ethernetType}} | {{.protocol}} | {{.portRangeMin}} | {{.portRangeMax}} | {{.remoteIpPrefix}} |
+{{end}}
+{{end}}
 {{end}}
 
 ## Target state

--- a/internal/services/cloud/utils.go
+++ b/internal/services/cloud/utils.go
@@ -158,3 +158,54 @@ func waitForCloudOperation(projectID, operationID, action string, retryDuration 
 		}
 	}
 }
+
+// waitForCloudResourceReady polls a Cloud API v2 managed resource (exposing a
+// "resourceStatus" field following common.ResourceStatusEnum) until it reaches
+// the READY state. Tasks reported in ERROR in "currentTasks" are logged but do
+// not stop the polling: only a resource whose "resourceStatus" is ERROR is
+// considered fatal. It returns an error if the resource ends in error or if the
+// given duration elapses before the resource becomes ready.
+func waitForCloudResourceReady(endpoint string, retryDuration time.Duration) error {
+	ctx, cancel := context.WithTimeout(context.Background(), retryDuration)
+	defer cancel()
+
+	ticker := time.NewTicker(5 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		var resource struct {
+			ResourceStatus string `json:"resourceStatus"`
+			CurrentTasks   []struct {
+				Id     string `json:"id"`
+				Type   string `json:"type"`
+				Status string `json:"status"`
+			} `json:"currentTasks"`
+		}
+		if err := httpLib.Client.Get(endpoint, &resource); err != nil {
+			return fmt.Errorf("error fetching resource: %w", err)
+		}
+
+		switch resource.ResourceStatus {
+		case "READY":
+			return nil
+		case "ERROR":
+			return errors.New("resource ended in error state")
+		}
+
+		// Report tasks currently in error but keep waiting: they may still be
+		// retried on the API side or require user input.
+		for _, task := range resource.CurrentTasks {
+			if task.Status == "ERROR" {
+				log.Printf("⚠️  Task %s (%s) is in error state", task.Id, task.Type)
+			}
+		}
+
+		select {
+		case <-ctx.Done():
+			return errors.New("timeout waiting for resource to be ready")
+		case <-ticker.C:
+			log.Printf("Still waiting for resource to be ready (status=%s)…", resource.ResourceStatus)
+			continue
+		}
+	}
+}


### PR DESCRIPTION
# Description

Adds `cloud network security-group` (new, Cloud API v2) and migrates the `cloud network
gateway` core commands from the v1 region-based API to v2.

**security-group** (new, `cloud network security-group`, alias `sg`)
- list, get, create, edit, delete on `/v2/publicCloud/project/{id}/securityGroup`

**gateway** (migrated to v2)
- list, get, create, edit, delete repointed to `/v2/publicCloud/project/{id}/gateway` (project-scoped; the `create <region>` positional is replaced by `--region`)
- `expose` and the `interface` subcommands stay on v1 (no v2 equivalent)

Both support `--wait` (async provisioning) via `waitForCloudResourceReady`, and `--editor`/`--from-file`/`--init-file` for create/edit.

Tested end-to-end against the real v2 API (security-group full CRUD cycle; gateway list/get on existing resources).


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Improvement (improvement of existing commands)
- [ ] Breaking change (fix or feature that can break a current behavior)
- [X] Documentation update

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have commented my code
- [X] I ran `go mod tidy`
- [ ] I have added tests that prove my fix is effective or that my feature works
