### PR TITLE
feat(cli): add cloud key-manager (secrets & containers) on API v2

### DIFF
--- a/doc/ovhcloud_cloud.md
+++ b/doc/ovhcloud_cloud.md
@@ -34,6 +34,7 @@ Manage your projects and services in the Public Cloud universe (MKS, MPR, MRS, O
 * [ovhcloud cloud alerting](ovhcloud_cloud_alerting.md)	 - Manage billing alert configurations in the given cloud project
 * [ovhcloud cloud instance](ovhcloud_cloud_instance.md)	 - Manage instances in the given cloud project
 * [ovhcloud cloud ip](ovhcloud_cloud_ip.md)	 - Manage public IPs (floating and failover) in the given cloud project
+* [ovhcloud cloud key-manager](ovhcloud_cloud_key-manager.md)	 - Manage Key Management Service (KMS) resources in the given cloud project
 * [ovhcloud cloud loadbalancer](ovhcloud_cloud_loadbalancer.md)	 - Manage loadbalancers in the given cloud project
 * [ovhcloud cloud managed-analytics](ovhcloud_cloud_managed-analytics.md)	 - Manage managed analytics services in the given cloud project
 * [ovhcloud cloud managed-database](ovhcloud_cloud_managed-database.md)	 - Manage managed database services in the given cloud project

--- a/doc/ovhcloud_cloud_key-manager.md
+++ b/doc/ovhcloud_cloud_key-manager.md
@@ -1,0 +1,36 @@
+## ovhcloud cloud key-manager
+
+Manage Key Management Service (KMS) resources in the given cloud project
+
+### Options
+
+```
+      --cloud-project string   Cloud project ID
+  -h, --help                   help for key-manager
+```
+
+### Options inherited from parent commands
+
+```
+  -d, --debug            Activate debug mode (will log all HTTP requests details)
+  -e, --ignore-errors    Ignore errors in API calls when it is not fatal to the execution
+  -o, --output string    Output format: json, yaml, interactive, or a custom format expression (using https://github.com/PaesslerAG/gval syntax)
+                         Examples:
+                           --output json
+                           --output yaml
+                           --output interactive
+                           --output 'id' (to extract a single field)
+                           --output 'nested.field.subfield' (to extract a nested field)
+                           --output '[id, "name"]' (to extract multiple fields as an array)
+                           --output '{"newKey": oldKey, "otherKey": nested.field}' (to extract and rename fields in an object)
+                           --output 'name+","+type' (to extract and concatenate fields in a string)
+                           --output '(nbFieldA + nbFieldB) * 10' (to compute values from numeric fields)
+      --profile string   Use a specific profile from the configuration file
+```
+
+### SEE ALSO
+
+* [ovhcloud cloud](ovhcloud_cloud.md)	 - Manage your projects and services in the Public Cloud universe (MKS, MPR, MRS, Object Storage...)
+* [ovhcloud cloud key-manager container](ovhcloud_cloud_key-manager_container.md)	 - Manage Key Manager containers
+* [ovhcloud cloud key-manager secret](ovhcloud_cloud_key-manager_secret.md)	 - Manage Key Manager secrets
+

--- a/doc/ovhcloud_cloud_key-manager_container.md
+++ b/doc/ovhcloud_cloud_key-manager_container.md
@@ -1,0 +1,40 @@
+## ovhcloud cloud key-manager container
+
+Manage Key Manager containers
+
+### Options
+
+```
+  -h, --help   help for container
+```
+
+### Options inherited from parent commands
+
+```
+      --cloud-project string   Cloud project ID
+  -d, --debug                  Activate debug mode (will log all HTTP requests details)
+  -e, --ignore-errors          Ignore errors in API calls when it is not fatal to the execution
+  -o, --output string          Output format: json, yaml, interactive, or a custom format expression (using https://github.com/PaesslerAG/gval syntax)
+                               Examples:
+                                 --output json
+                                 --output yaml
+                                 --output interactive
+                                 --output 'id' (to extract a single field)
+                                 --output 'nested.field.subfield' (to extract a nested field)
+                                 --output '[id, "name"]' (to extract multiple fields as an array)
+                                 --output '{"newKey": oldKey, "otherKey": nested.field}' (to extract and rename fields in an object)
+                                 --output 'name+","+type' (to extract and concatenate fields in a string)
+                                 --output '(nbFieldA + nbFieldB) * 10' (to compute values from numeric fields)
+      --profile string         Use a specific profile from the configuration file
+```
+
+### SEE ALSO
+
+* [ovhcloud cloud key-manager](ovhcloud_cloud_key-manager.md)	 - Manage Key Management Service (KMS) resources in the given cloud project
+* [ovhcloud cloud key-manager container consumer](ovhcloud_cloud_key-manager_container_consumer.md)	 - Manage consumers of a Key Manager container
+* [ovhcloud cloud key-manager container create](ovhcloud_cloud_key-manager_container_create.md)	 - Create a new Key Manager container
+* [ovhcloud cloud key-manager container delete](ovhcloud_cloud_key-manager_container_delete.md)	 - Delete the given Key Manager container
+* [ovhcloud cloud key-manager container edit](ovhcloud_cloud_key-manager_container_edit.md)	 - Edit the given Key Manager container (only secret references are mutable)
+* [ovhcloud cloud key-manager container get](ovhcloud_cloud_key-manager_container_get.md)	 - Get a specific Key Manager container
+* [ovhcloud cloud key-manager container list](ovhcloud_cloud_key-manager_container_list.md)	 - List Key Manager containers
+

--- a/doc/ovhcloud_cloud_key-manager_container_consumer.md
+++ b/doc/ovhcloud_cloud_key-manager_container_consumer.md
@@ -1,0 +1,38 @@
+## ovhcloud cloud key-manager container consumer
+
+Manage consumers of a Key Manager container
+
+### Options
+
+```
+  -h, --help   help for consumer
+```
+
+### Options inherited from parent commands
+
+```
+      --cloud-project string   Cloud project ID
+  -d, --debug                  Activate debug mode (will log all HTTP requests details)
+  -e, --ignore-errors          Ignore errors in API calls when it is not fatal to the execution
+  -o, --output string          Output format: json, yaml, interactive, or a custom format expression (using https://github.com/PaesslerAG/gval syntax)
+                               Examples:
+                                 --output json
+                                 --output yaml
+                                 --output interactive
+                                 --output 'id' (to extract a single field)
+                                 --output 'nested.field.subfield' (to extract a nested field)
+                                 --output '[id, "name"]' (to extract multiple fields as an array)
+                                 --output '{"newKey": oldKey, "otherKey": nested.field}' (to extract and rename fields in an object)
+                                 --output 'name+","+type' (to extract and concatenate fields in a string)
+                                 --output '(nbFieldA + nbFieldB) * 10' (to compute values from numeric fields)
+      --profile string         Use a specific profile from the configuration file
+```
+
+### SEE ALSO
+
+* [ovhcloud cloud key-manager container](ovhcloud_cloud_key-manager_container.md)	 - Manage Key Manager containers
+* [ovhcloud cloud key-manager container consumer delete](ovhcloud_cloud_key-manager_container_consumer_delete.md)	 - Delete a consumer from the given container
+* [ovhcloud cloud key-manager container consumer get](ovhcloud_cloud_key-manager_container_consumer_get.md)	 - Get a specific consumer of the given container
+* [ovhcloud cloud key-manager container consumer list](ovhcloud_cloud_key-manager_container_consumer_list.md)	 - List consumers registered for the given container
+* [ovhcloud cloud key-manager container consumer register](ovhcloud_cloud_key-manager_container_consumer_register.md)	 - Register a consumer for the given container
+

--- a/doc/ovhcloud_cloud_key-manager_container_consumer_delete.md
+++ b/doc/ovhcloud_cloud_key-manager_container_consumer_delete.md
@@ -1,0 +1,38 @@
+## ovhcloud cloud key-manager container consumer delete
+
+Delete a consumer from the given container
+
+```
+ovhcloud cloud key-manager container consumer delete <container_id> <consumer_id> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for delete
+```
+
+### Options inherited from parent commands
+
+```
+      --cloud-project string   Cloud project ID
+  -d, --debug                  Activate debug mode (will log all HTTP requests details)
+  -e, --ignore-errors          Ignore errors in API calls when it is not fatal to the execution
+  -o, --output string          Output format: json, yaml, interactive, or a custom format expression (using https://github.com/PaesslerAG/gval syntax)
+                               Examples:
+                                 --output json
+                                 --output yaml
+                                 --output interactive
+                                 --output 'id' (to extract a single field)
+                                 --output 'nested.field.subfield' (to extract a nested field)
+                                 --output '[id, "name"]' (to extract multiple fields as an array)
+                                 --output '{"newKey": oldKey, "otherKey": nested.field}' (to extract and rename fields in an object)
+                                 --output 'name+","+type' (to extract and concatenate fields in a string)
+                                 --output '(nbFieldA + nbFieldB) * 10' (to compute values from numeric fields)
+      --profile string         Use a specific profile from the configuration file
+```
+
+### SEE ALSO
+
+* [ovhcloud cloud key-manager container consumer](ovhcloud_cloud_key-manager_container_consumer.md)	 - Manage consumers of a Key Manager container
+

--- a/doc/ovhcloud_cloud_key-manager_container_consumer_get.md
+++ b/doc/ovhcloud_cloud_key-manager_container_consumer_get.md
@@ -1,0 +1,38 @@
+## ovhcloud cloud key-manager container consumer get
+
+Get a specific consumer of the given container
+
+```
+ovhcloud cloud key-manager container consumer get <container_id> <consumer_id> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for get
+```
+
+### Options inherited from parent commands
+
+```
+      --cloud-project string   Cloud project ID
+  -d, --debug                  Activate debug mode (will log all HTTP requests details)
+  -e, --ignore-errors          Ignore errors in API calls when it is not fatal to the execution
+  -o, --output string          Output format: json, yaml, interactive, or a custom format expression (using https://github.com/PaesslerAG/gval syntax)
+                               Examples:
+                                 --output json
+                                 --output yaml
+                                 --output interactive
+                                 --output 'id' (to extract a single field)
+                                 --output 'nested.field.subfield' (to extract a nested field)
+                                 --output '[id, "name"]' (to extract multiple fields as an array)
+                                 --output '{"newKey": oldKey, "otherKey": nested.field}' (to extract and rename fields in an object)
+                                 --output 'name+","+type' (to extract and concatenate fields in a string)
+                                 --output '(nbFieldA + nbFieldB) * 10' (to compute values from numeric fields)
+      --profile string         Use a specific profile from the configuration file
+```
+
+### SEE ALSO
+
+* [ovhcloud cloud key-manager container consumer](ovhcloud_cloud_key-manager_container_consumer.md)	 - Manage consumers of a Key Manager container
+

--- a/doc/ovhcloud_cloud_key-manager_container_consumer_list.md
+++ b/doc/ovhcloud_cloud_key-manager_container_consumer_list.md
@@ -1,0 +1,45 @@
+## ovhcloud cloud key-manager container consumer list
+
+List consumers registered for the given container
+
+```
+ovhcloud cloud key-manager container consumer list <container_id> [flags]
+```
+
+### Options
+
+```
+      --filter stringArray   Filter results by any property using https://github.com/PaesslerAG/gval syntax
+                             Examples:
+                               --filter 'state=="running"'
+                               --filter 'name=~"^my.*"'
+                               --filter 'nested.property.subproperty>10'
+                               --filter 'startDate>="2023-12-01"'
+                               --filter 'name=~"something" && nbField>10'
+  -h, --help                 help for list
+```
+
+### Options inherited from parent commands
+
+```
+      --cloud-project string   Cloud project ID
+  -d, --debug                  Activate debug mode (will log all HTTP requests details)
+  -e, --ignore-errors          Ignore errors in API calls when it is not fatal to the execution
+  -o, --output string          Output format: json, yaml, interactive, or a custom format expression (using https://github.com/PaesslerAG/gval syntax)
+                               Examples:
+                                 --output json
+                                 --output yaml
+                                 --output interactive
+                                 --output 'id' (to extract a single field)
+                                 --output 'nested.field.subfield' (to extract a nested field)
+                                 --output '[id, "name"]' (to extract multiple fields as an array)
+                                 --output '{"newKey": oldKey, "otherKey": nested.field}' (to extract and rename fields in an object)
+                                 --output 'name+","+type' (to extract and concatenate fields in a string)
+                                 --output '(nbFieldA + nbFieldB) * 10' (to compute values from numeric fields)
+      --profile string         Use a specific profile from the configuration file
+```
+
+### SEE ALSO
+
+* [ovhcloud cloud key-manager container consumer](ovhcloud_cloud_key-manager_container_consumer.md)	 - Manage consumers of a Key Manager container
+

--- a/doc/ovhcloud_cloud_key-manager_container_consumer_register.md
+++ b/doc/ovhcloud_cloud_key-manager_container_consumer_register.md
@@ -1,0 +1,41 @@
+## ovhcloud cloud key-manager container consumer register
+
+Register a consumer for the given container
+
+```
+ovhcloud cloud key-manager container consumer register <container_id> [flags]
+```
+
+### Options
+
+```
+  -h, --help                   help for register
+      --resource-id string     UUID of the resource consuming the secret/container
+      --resource-type string   Type of the consuming resource (IMAGE, INSTANCE, LOADBALANCER)
+      --service string         OpenStack service type of the consumer (COMPUTE, IMAGE, LOADBALANCER, NETWORK)
+```
+
+### Options inherited from parent commands
+
+```
+      --cloud-project string   Cloud project ID
+  -d, --debug                  Activate debug mode (will log all HTTP requests details)
+  -e, --ignore-errors          Ignore errors in API calls when it is not fatal to the execution
+  -o, --output string          Output format: json, yaml, interactive, or a custom format expression (using https://github.com/PaesslerAG/gval syntax)
+                               Examples:
+                                 --output json
+                                 --output yaml
+                                 --output interactive
+                                 --output 'id' (to extract a single field)
+                                 --output 'nested.field.subfield' (to extract a nested field)
+                                 --output '[id, "name"]' (to extract multiple fields as an array)
+                                 --output '{"newKey": oldKey, "otherKey": nested.field}' (to extract and rename fields in an object)
+                                 --output 'name+","+type' (to extract and concatenate fields in a string)
+                                 --output '(nbFieldA + nbFieldB) * 10' (to compute values from numeric fields)
+      --profile string         Use a specific profile from the configuration file
+```
+
+### SEE ALSO
+
+* [ovhcloud cloud key-manager container consumer](ovhcloud_cloud_key-manager_container_consumer.md)	 - Manage consumers of a Key Manager container
+

--- a/doc/ovhcloud_cloud_key-manager_container_create.md
+++ b/doc/ovhcloud_cloud_key-manager_container_create.md
@@ -1,0 +1,48 @@
+## ovhcloud cloud key-manager container create
+
+Create a new Key Manager container
+
+```
+ovhcloud cloud key-manager container create [flags]
+```
+
+### Options
+
+```
+      --availability-zone string   Availability zone within the region
+      --editor                     Use a text editor to define parameters
+      --from-file string           File containing parameters
+  -h, --help                       help for create
+      --init-file string           Create a file with example parameters
+      --name string                Desired container name
+      --region string              Region code where the container is located
+      --replace                    Replace parameters file if it already exists
+      --secret-ref stringArray     Secret reference as '<name>=<secretId>' (repeatable)
+      --type string                Type of the container (CERTIFICATE, GENERIC, RSA)
+      --wait                       Wait for the container to be ready before exiting
+```
+
+### Options inherited from parent commands
+
+```
+      --cloud-project string   Cloud project ID
+  -d, --debug                  Activate debug mode (will log all HTTP requests details)
+  -e, --ignore-errors          Ignore errors in API calls when it is not fatal to the execution
+  -o, --output string          Output format: json, yaml, interactive, or a custom format expression (using https://github.com/PaesslerAG/gval syntax)
+                               Examples:
+                                 --output json
+                                 --output yaml
+                                 --output interactive
+                                 --output 'id' (to extract a single field)
+                                 --output 'nested.field.subfield' (to extract a nested field)
+                                 --output '[id, "name"]' (to extract multiple fields as an array)
+                                 --output '{"newKey": oldKey, "otherKey": nested.field}' (to extract and rename fields in an object)
+                                 --output 'name+","+type' (to extract and concatenate fields in a string)
+                                 --output '(nbFieldA + nbFieldB) * 10' (to compute values from numeric fields)
+      --profile string         Use a specific profile from the configuration file
+```
+
+### SEE ALSO
+
+* [ovhcloud cloud key-manager container](ovhcloud_cloud_key-manager_container.md)	 - Manage Key Manager containers
+

--- a/doc/ovhcloud_cloud_key-manager_container_delete.md
+++ b/doc/ovhcloud_cloud_key-manager_container_delete.md
@@ -1,0 +1,38 @@
+## ovhcloud cloud key-manager container delete
+
+Delete the given Key Manager container
+
+```
+ovhcloud cloud key-manager container delete <container_id> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for delete
+```
+
+### Options inherited from parent commands
+
+```
+      --cloud-project string   Cloud project ID
+  -d, --debug                  Activate debug mode (will log all HTTP requests details)
+  -e, --ignore-errors          Ignore errors in API calls when it is not fatal to the execution
+  -o, --output string          Output format: json, yaml, interactive, or a custom format expression (using https://github.com/PaesslerAG/gval syntax)
+                               Examples:
+                                 --output json
+                                 --output yaml
+                                 --output interactive
+                                 --output 'id' (to extract a single field)
+                                 --output 'nested.field.subfield' (to extract a nested field)
+                                 --output '[id, "name"]' (to extract multiple fields as an array)
+                                 --output '{"newKey": oldKey, "otherKey": nested.field}' (to extract and rename fields in an object)
+                                 --output 'name+","+type' (to extract and concatenate fields in a string)
+                                 --output '(nbFieldA + nbFieldB) * 10' (to compute values from numeric fields)
+      --profile string         Use a specific profile from the configuration file
+```
+
+### SEE ALSO
+
+* [ovhcloud cloud key-manager container](ovhcloud_cloud_key-manager_container.md)	 - Manage Key Manager containers
+

--- a/doc/ovhcloud_cloud_key-manager_container_edit.md
+++ b/doc/ovhcloud_cloud_key-manager_container_edit.md
@@ -1,0 +1,40 @@
+## ovhcloud cloud key-manager container edit
+
+Edit the given Key Manager container (only secret references are mutable)
+
+```
+ovhcloud cloud key-manager container edit <container_id> [flags]
+```
+
+### Options
+
+```
+      --editor                   Use a text editor to define parameters
+  -h, --help                     help for edit
+      --secret-ref stringArray   Secret reference as '<name>=<secretId>' (repeatable, replaces all existing references)
+```
+
+### Options inherited from parent commands
+
+```
+      --cloud-project string   Cloud project ID
+  -d, --debug                  Activate debug mode (will log all HTTP requests details)
+  -e, --ignore-errors          Ignore errors in API calls when it is not fatal to the execution
+  -o, --output string          Output format: json, yaml, interactive, or a custom format expression (using https://github.com/PaesslerAG/gval syntax)
+                               Examples:
+                                 --output json
+                                 --output yaml
+                                 --output interactive
+                                 --output 'id' (to extract a single field)
+                                 --output 'nested.field.subfield' (to extract a nested field)
+                                 --output '[id, "name"]' (to extract multiple fields as an array)
+                                 --output '{"newKey": oldKey, "otherKey": nested.field}' (to extract and rename fields in an object)
+                                 --output 'name+","+type' (to extract and concatenate fields in a string)
+                                 --output '(nbFieldA + nbFieldB) * 10' (to compute values from numeric fields)
+      --profile string         Use a specific profile from the configuration file
+```
+
+### SEE ALSO
+
+* [ovhcloud cloud key-manager container](ovhcloud_cloud_key-manager_container.md)	 - Manage Key Manager containers
+

--- a/doc/ovhcloud_cloud_key-manager_container_get.md
+++ b/doc/ovhcloud_cloud_key-manager_container_get.md
@@ -1,0 +1,38 @@
+## ovhcloud cloud key-manager container get
+
+Get a specific Key Manager container
+
+```
+ovhcloud cloud key-manager container get <container_id> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for get
+```
+
+### Options inherited from parent commands
+
+```
+      --cloud-project string   Cloud project ID
+  -d, --debug                  Activate debug mode (will log all HTTP requests details)
+  -e, --ignore-errors          Ignore errors in API calls when it is not fatal to the execution
+  -o, --output string          Output format: json, yaml, interactive, or a custom format expression (using https://github.com/PaesslerAG/gval syntax)
+                               Examples:
+                                 --output json
+                                 --output yaml
+                                 --output interactive
+                                 --output 'id' (to extract a single field)
+                                 --output 'nested.field.subfield' (to extract a nested field)
+                                 --output '[id, "name"]' (to extract multiple fields as an array)
+                                 --output '{"newKey": oldKey, "otherKey": nested.field}' (to extract and rename fields in an object)
+                                 --output 'name+","+type' (to extract and concatenate fields in a string)
+                                 --output '(nbFieldA + nbFieldB) * 10' (to compute values from numeric fields)
+      --profile string         Use a specific profile from the configuration file
+```
+
+### SEE ALSO
+
+* [ovhcloud cloud key-manager container](ovhcloud_cloud_key-manager_container.md)	 - Manage Key Manager containers
+

--- a/doc/ovhcloud_cloud_key-manager_container_list.md
+++ b/doc/ovhcloud_cloud_key-manager_container_list.md
@@ -1,0 +1,45 @@
+## ovhcloud cloud key-manager container list
+
+List Key Manager containers
+
+```
+ovhcloud cloud key-manager container list [flags]
+```
+
+### Options
+
+```
+      --filter stringArray   Filter results by any property using https://github.com/PaesslerAG/gval syntax
+                             Examples:
+                               --filter 'state=="running"'
+                               --filter 'name=~"^my.*"'
+                               --filter 'nested.property.subproperty>10'
+                               --filter 'startDate>="2023-12-01"'
+                               --filter 'name=~"something" && nbField>10'
+  -h, --help                 help for list
+```
+
+### Options inherited from parent commands
+
+```
+      --cloud-project string   Cloud project ID
+  -d, --debug                  Activate debug mode (will log all HTTP requests details)
+  -e, --ignore-errors          Ignore errors in API calls when it is not fatal to the execution
+  -o, --output string          Output format: json, yaml, interactive, or a custom format expression (using https://github.com/PaesslerAG/gval syntax)
+                               Examples:
+                                 --output json
+                                 --output yaml
+                                 --output interactive
+                                 --output 'id' (to extract a single field)
+                                 --output 'nested.field.subfield' (to extract a nested field)
+                                 --output '[id, "name"]' (to extract multiple fields as an array)
+                                 --output '{"newKey": oldKey, "otherKey": nested.field}' (to extract and rename fields in an object)
+                                 --output 'name+","+type' (to extract and concatenate fields in a string)
+                                 --output '(nbFieldA + nbFieldB) * 10' (to compute values from numeric fields)
+      --profile string         Use a specific profile from the configuration file
+```
+
+### SEE ALSO
+
+* [ovhcloud cloud key-manager container](ovhcloud_cloud_key-manager_container.md)	 - Manage Key Manager containers
+

--- a/doc/ovhcloud_cloud_key-manager_secret.md
+++ b/doc/ovhcloud_cloud_key-manager_secret.md
@@ -1,0 +1,41 @@
+## ovhcloud cloud key-manager secret
+
+Manage Key Manager secrets
+
+### Options
+
+```
+  -h, --help   help for secret
+```
+
+### Options inherited from parent commands
+
+```
+      --cloud-project string   Cloud project ID
+  -d, --debug                  Activate debug mode (will log all HTTP requests details)
+  -e, --ignore-errors          Ignore errors in API calls when it is not fatal to the execution
+  -o, --output string          Output format: json, yaml, interactive, or a custom format expression (using https://github.com/PaesslerAG/gval syntax)
+                               Examples:
+                                 --output json
+                                 --output yaml
+                                 --output interactive
+                                 --output 'id' (to extract a single field)
+                                 --output 'nested.field.subfield' (to extract a nested field)
+                                 --output '[id, "name"]' (to extract multiple fields as an array)
+                                 --output '{"newKey": oldKey, "otherKey": nested.field}' (to extract and rename fields in an object)
+                                 --output 'name+","+type' (to extract and concatenate fields in a string)
+                                 --output '(nbFieldA + nbFieldB) * 10' (to compute values from numeric fields)
+      --profile string         Use a specific profile from the configuration file
+```
+
+### SEE ALSO
+
+* [ovhcloud cloud key-manager](ovhcloud_cloud_key-manager.md)	 - Manage Key Management Service (KMS) resources in the given cloud project
+* [ovhcloud cloud key-manager secret consumer](ovhcloud_cloud_key-manager_secret_consumer.md)	 - Manage consumers of a Key Manager secret
+* [ovhcloud cloud key-manager secret create](ovhcloud_cloud_key-manager_secret_create.md)	 - Create a new Key Manager secret
+* [ovhcloud cloud key-manager secret delete](ovhcloud_cloud_key-manager_secret_delete.md)	 - Delete the given Key Manager secret
+* [ovhcloud cloud key-manager secret edit](ovhcloud_cloud_key-manager_secret_edit.md)	 - Edit the given Key Manager secret (only metadata is mutable)
+* [ovhcloud cloud key-manager secret get](ovhcloud_cloud_key-manager_secret_get.md)	 - Get a specific Key Manager secret
+* [ovhcloud cloud key-manager secret list](ovhcloud_cloud_key-manager_secret_list.md)	 - List Key Manager secrets
+* [ovhcloud cloud key-manager secret payload](ovhcloud_cloud_key-manager_secret_payload.md)	 - Fetch the payload (sensitive material) of the given Key Manager secret
+

--- a/doc/ovhcloud_cloud_key-manager_secret_consumer.md
+++ b/doc/ovhcloud_cloud_key-manager_secret_consumer.md
@@ -1,0 +1,38 @@
+## ovhcloud cloud key-manager secret consumer
+
+Manage consumers of a Key Manager secret
+
+### Options
+
+```
+  -h, --help   help for consumer
+```
+
+### Options inherited from parent commands
+
+```
+      --cloud-project string   Cloud project ID
+  -d, --debug                  Activate debug mode (will log all HTTP requests details)
+  -e, --ignore-errors          Ignore errors in API calls when it is not fatal to the execution
+  -o, --output string          Output format: json, yaml, interactive, or a custom format expression (using https://github.com/PaesslerAG/gval syntax)
+                               Examples:
+                                 --output json
+                                 --output yaml
+                                 --output interactive
+                                 --output 'id' (to extract a single field)
+                                 --output 'nested.field.subfield' (to extract a nested field)
+                                 --output '[id, "name"]' (to extract multiple fields as an array)
+                                 --output '{"newKey": oldKey, "otherKey": nested.field}' (to extract and rename fields in an object)
+                                 --output 'name+","+type' (to extract and concatenate fields in a string)
+                                 --output '(nbFieldA + nbFieldB) * 10' (to compute values from numeric fields)
+      --profile string         Use a specific profile from the configuration file
+```
+
+### SEE ALSO
+
+* [ovhcloud cloud key-manager secret](ovhcloud_cloud_key-manager_secret.md)	 - Manage Key Manager secrets
+* [ovhcloud cloud key-manager secret consumer delete](ovhcloud_cloud_key-manager_secret_consumer_delete.md)	 - Delete a consumer from the given secret
+* [ovhcloud cloud key-manager secret consumer get](ovhcloud_cloud_key-manager_secret_consumer_get.md)	 - Get a specific consumer of the given secret
+* [ovhcloud cloud key-manager secret consumer list](ovhcloud_cloud_key-manager_secret_consumer_list.md)	 - List consumers registered for the given secret
+* [ovhcloud cloud key-manager secret consumer register](ovhcloud_cloud_key-manager_secret_consumer_register.md)	 - Register a consumer for the given secret
+

--- a/doc/ovhcloud_cloud_key-manager_secret_consumer_delete.md
+++ b/doc/ovhcloud_cloud_key-manager_secret_consumer_delete.md
@@ -1,0 +1,38 @@
+## ovhcloud cloud key-manager secret consumer delete
+
+Delete a consumer from the given secret
+
+```
+ovhcloud cloud key-manager secret consumer delete <secret_id> <consumer_id> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for delete
+```
+
+### Options inherited from parent commands
+
+```
+      --cloud-project string   Cloud project ID
+  -d, --debug                  Activate debug mode (will log all HTTP requests details)
+  -e, --ignore-errors          Ignore errors in API calls when it is not fatal to the execution
+  -o, --output string          Output format: json, yaml, interactive, or a custom format expression (using https://github.com/PaesslerAG/gval syntax)
+                               Examples:
+                                 --output json
+                                 --output yaml
+                                 --output interactive
+                                 --output 'id' (to extract a single field)
+                                 --output 'nested.field.subfield' (to extract a nested field)
+                                 --output '[id, "name"]' (to extract multiple fields as an array)
+                                 --output '{"newKey": oldKey, "otherKey": nested.field}' (to extract and rename fields in an object)
+                                 --output 'name+","+type' (to extract and concatenate fields in a string)
+                                 --output '(nbFieldA + nbFieldB) * 10' (to compute values from numeric fields)
+      --profile string         Use a specific profile from the configuration file
+```
+
+### SEE ALSO
+
+* [ovhcloud cloud key-manager secret consumer](ovhcloud_cloud_key-manager_secret_consumer.md)	 - Manage consumers of a Key Manager secret
+

--- a/doc/ovhcloud_cloud_key-manager_secret_consumer_get.md
+++ b/doc/ovhcloud_cloud_key-manager_secret_consumer_get.md
@@ -1,0 +1,38 @@
+## ovhcloud cloud key-manager secret consumer get
+
+Get a specific consumer of the given secret
+
+```
+ovhcloud cloud key-manager secret consumer get <secret_id> <consumer_id> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for get
+```
+
+### Options inherited from parent commands
+
+```
+      --cloud-project string   Cloud project ID
+  -d, --debug                  Activate debug mode (will log all HTTP requests details)
+  -e, --ignore-errors          Ignore errors in API calls when it is not fatal to the execution
+  -o, --output string          Output format: json, yaml, interactive, or a custom format expression (using https://github.com/PaesslerAG/gval syntax)
+                               Examples:
+                                 --output json
+                                 --output yaml
+                                 --output interactive
+                                 --output 'id' (to extract a single field)
+                                 --output 'nested.field.subfield' (to extract a nested field)
+                                 --output '[id, "name"]' (to extract multiple fields as an array)
+                                 --output '{"newKey": oldKey, "otherKey": nested.field}' (to extract and rename fields in an object)
+                                 --output 'name+","+type' (to extract and concatenate fields in a string)
+                                 --output '(nbFieldA + nbFieldB) * 10' (to compute values from numeric fields)
+      --profile string         Use a specific profile from the configuration file
+```
+
+### SEE ALSO
+
+* [ovhcloud cloud key-manager secret consumer](ovhcloud_cloud_key-manager_secret_consumer.md)	 - Manage consumers of a Key Manager secret
+

--- a/doc/ovhcloud_cloud_key-manager_secret_consumer_list.md
+++ b/doc/ovhcloud_cloud_key-manager_secret_consumer_list.md
@@ -1,0 +1,45 @@
+## ovhcloud cloud key-manager secret consumer list
+
+List consumers registered for the given secret
+
+```
+ovhcloud cloud key-manager secret consumer list <secret_id> [flags]
+```
+
+### Options
+
+```
+      --filter stringArray   Filter results by any property using https://github.com/PaesslerAG/gval syntax
+                             Examples:
+                               --filter 'state=="running"'
+                               --filter 'name=~"^my.*"'
+                               --filter 'nested.property.subproperty>10'
+                               --filter 'startDate>="2023-12-01"'
+                               --filter 'name=~"something" && nbField>10'
+  -h, --help                 help for list
+```
+
+### Options inherited from parent commands
+
+```
+      --cloud-project string   Cloud project ID
+  -d, --debug                  Activate debug mode (will log all HTTP requests details)
+  -e, --ignore-errors          Ignore errors in API calls when it is not fatal to the execution
+  -o, --output string          Output format: json, yaml, interactive, or a custom format expression (using https://github.com/PaesslerAG/gval syntax)
+                               Examples:
+                                 --output json
+                                 --output yaml
+                                 --output interactive
+                                 --output 'id' (to extract a single field)
+                                 --output 'nested.field.subfield' (to extract a nested field)
+                                 --output '[id, "name"]' (to extract multiple fields as an array)
+                                 --output '{"newKey": oldKey, "otherKey": nested.field}' (to extract and rename fields in an object)
+                                 --output 'name+","+type' (to extract and concatenate fields in a string)
+                                 --output '(nbFieldA + nbFieldB) * 10' (to compute values from numeric fields)
+      --profile string         Use a specific profile from the configuration file
+```
+
+### SEE ALSO
+
+* [ovhcloud cloud key-manager secret consumer](ovhcloud_cloud_key-manager_secret_consumer.md)	 - Manage consumers of a Key Manager secret
+

--- a/doc/ovhcloud_cloud_key-manager_secret_consumer_register.md
+++ b/doc/ovhcloud_cloud_key-manager_secret_consumer_register.md
@@ -1,0 +1,41 @@
+## ovhcloud cloud key-manager secret consumer register
+
+Register a consumer for the given secret
+
+```
+ovhcloud cloud key-manager secret consumer register <secret_id> [flags]
+```
+
+### Options
+
+```
+  -h, --help                   help for register
+      --resource-id string     UUID of the resource consuming the secret/container
+      --resource-type string   Type of the consuming resource (IMAGE, INSTANCE, LOADBALANCER)
+      --service string         OpenStack service type of the consumer (COMPUTE, IMAGE, LOADBALANCER, NETWORK)
+```
+
+### Options inherited from parent commands
+
+```
+      --cloud-project string   Cloud project ID
+  -d, --debug                  Activate debug mode (will log all HTTP requests details)
+  -e, --ignore-errors          Ignore errors in API calls when it is not fatal to the execution
+  -o, --output string          Output format: json, yaml, interactive, or a custom format expression (using https://github.com/PaesslerAG/gval syntax)
+                               Examples:
+                                 --output json
+                                 --output yaml
+                                 --output interactive
+                                 --output 'id' (to extract a single field)
+                                 --output 'nested.field.subfield' (to extract a nested field)
+                                 --output '[id, "name"]' (to extract multiple fields as an array)
+                                 --output '{"newKey": oldKey, "otherKey": nested.field}' (to extract and rename fields in an object)
+                                 --output 'name+","+type' (to extract and concatenate fields in a string)
+                                 --output '(nbFieldA + nbFieldB) * 10' (to compute values from numeric fields)
+      --profile string         Use a specific profile from the configuration file
+```
+
+### SEE ALSO
+
+* [ovhcloud cloud key-manager secret consumer](ovhcloud_cloud_key-manager_secret_consumer.md)	 - Manage consumers of a Key Manager secret
+

--- a/doc/ovhcloud_cloud_key-manager_secret_create.md
+++ b/doc/ovhcloud_cloud_key-manager_secret_create.md
@@ -1,0 +1,54 @@
+## ovhcloud cloud key-manager secret create
+
+Create a new Key Manager secret
+
+```
+ovhcloud cloud key-manager secret create [flags]
+```
+
+### Options
+
+```
+      --algorithm string              Algorithm associated with the secret (AES, DH, DSA, EC, RSA)
+      --availability-zone string      Availability zone within the region
+      --bit-length int                Bit length of the secret (128, 256, 512, 1024, 2048, 4096)
+      --editor                        Use a text editor to define parameters
+      --expiration string             Expiration date and time of the secret (RFC3339)
+      --from-file string              File containing parameters
+  -h, --help                          help for create
+      --init-file string              Create a file with example parameters
+      --metadata stringToString       Metadata key-value pairs for the secret (default [])
+      --mode string                   Mode of the algorithm (CBC, CTR)
+      --name string                   Human-readable name of the secret
+      --payload string                Secret payload data (base64-encoded, write-only). Requires --payload-content-type
+      --payload-content-type string   Content type of the payload (APPLICATION_OCTET_STREAM, APPLICATION_PKCS8, APPLICATION_PKIX_CERT, TEXT_PLAIN)
+      --region string                 Region code where the secret is located
+      --replace                       Replace parameters file if it already exists
+      --secret-type string            Type of the secret (CERTIFICATE, OPAQUE, PASSPHRASE, PRIVATE, PUBLIC, SYMMETRIC)
+      --wait                          Wait for the secret to be ready before exiting
+```
+
+### Options inherited from parent commands
+
+```
+      --cloud-project string   Cloud project ID
+  -d, --debug                  Activate debug mode (will log all HTTP requests details)
+  -e, --ignore-errors          Ignore errors in API calls when it is not fatal to the execution
+  -o, --output string          Output format: json, yaml, interactive, or a custom format expression (using https://github.com/PaesslerAG/gval syntax)
+                               Examples:
+                                 --output json
+                                 --output yaml
+                                 --output interactive
+                                 --output 'id' (to extract a single field)
+                                 --output 'nested.field.subfield' (to extract a nested field)
+                                 --output '[id, "name"]' (to extract multiple fields as an array)
+                                 --output '{"newKey": oldKey, "otherKey": nested.field}' (to extract and rename fields in an object)
+                                 --output 'name+","+type' (to extract and concatenate fields in a string)
+                                 --output '(nbFieldA + nbFieldB) * 10' (to compute values from numeric fields)
+      --profile string         Use a specific profile from the configuration file
+```
+
+### SEE ALSO
+
+* [ovhcloud cloud key-manager secret](ovhcloud_cloud_key-manager_secret.md)	 - Manage Key Manager secrets
+

--- a/doc/ovhcloud_cloud_key-manager_secret_delete.md
+++ b/doc/ovhcloud_cloud_key-manager_secret_delete.md
@@ -1,0 +1,38 @@
+## ovhcloud cloud key-manager secret delete
+
+Delete the given Key Manager secret
+
+```
+ovhcloud cloud key-manager secret delete <secret_id> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for delete
+```
+
+### Options inherited from parent commands
+
+```
+      --cloud-project string   Cloud project ID
+  -d, --debug                  Activate debug mode (will log all HTTP requests details)
+  -e, --ignore-errors          Ignore errors in API calls when it is not fatal to the execution
+  -o, --output string          Output format: json, yaml, interactive, or a custom format expression (using https://github.com/PaesslerAG/gval syntax)
+                               Examples:
+                                 --output json
+                                 --output yaml
+                                 --output interactive
+                                 --output 'id' (to extract a single field)
+                                 --output 'nested.field.subfield' (to extract a nested field)
+                                 --output '[id, "name"]' (to extract multiple fields as an array)
+                                 --output '{"newKey": oldKey, "otherKey": nested.field}' (to extract and rename fields in an object)
+                                 --output 'name+","+type' (to extract and concatenate fields in a string)
+                                 --output '(nbFieldA + nbFieldB) * 10' (to compute values from numeric fields)
+      --profile string         Use a specific profile from the configuration file
+```
+
+### SEE ALSO
+
+* [ovhcloud cloud key-manager secret](ovhcloud_cloud_key-manager_secret.md)	 - Manage Key Manager secrets
+

--- a/doc/ovhcloud_cloud_key-manager_secret_edit.md
+++ b/doc/ovhcloud_cloud_key-manager_secret_edit.md
@@ -1,0 +1,40 @@
+## ovhcloud cloud key-manager secret edit
+
+Edit the given Key Manager secret (only metadata is mutable)
+
+```
+ovhcloud cloud key-manager secret edit <secret_id> [flags]
+```
+
+### Options
+
+```
+      --editor                    Use a text editor to define parameters
+  -h, --help                      help for edit
+      --metadata stringToString   Metadata key-value pairs (replaces all existing metadata) (default [])
+```
+
+### Options inherited from parent commands
+
+```
+      --cloud-project string   Cloud project ID
+  -d, --debug                  Activate debug mode (will log all HTTP requests details)
+  -e, --ignore-errors          Ignore errors in API calls when it is not fatal to the execution
+  -o, --output string          Output format: json, yaml, interactive, or a custom format expression (using https://github.com/PaesslerAG/gval syntax)
+                               Examples:
+                                 --output json
+                                 --output yaml
+                                 --output interactive
+                                 --output 'id' (to extract a single field)
+                                 --output 'nested.field.subfield' (to extract a nested field)
+                                 --output '[id, "name"]' (to extract multiple fields as an array)
+                                 --output '{"newKey": oldKey, "otherKey": nested.field}' (to extract and rename fields in an object)
+                                 --output 'name+","+type' (to extract and concatenate fields in a string)
+                                 --output '(nbFieldA + nbFieldB) * 10' (to compute values from numeric fields)
+      --profile string         Use a specific profile from the configuration file
+```
+
+### SEE ALSO
+
+* [ovhcloud cloud key-manager secret](ovhcloud_cloud_key-manager_secret.md)	 - Manage Key Manager secrets
+

--- a/doc/ovhcloud_cloud_key-manager_secret_get.md
+++ b/doc/ovhcloud_cloud_key-manager_secret_get.md
@@ -1,0 +1,38 @@
+## ovhcloud cloud key-manager secret get
+
+Get a specific Key Manager secret
+
+```
+ovhcloud cloud key-manager secret get <secret_id> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for get
+```
+
+### Options inherited from parent commands
+
+```
+      --cloud-project string   Cloud project ID
+  -d, --debug                  Activate debug mode (will log all HTTP requests details)
+  -e, --ignore-errors          Ignore errors in API calls when it is not fatal to the execution
+  -o, --output string          Output format: json, yaml, interactive, or a custom format expression (using https://github.com/PaesslerAG/gval syntax)
+                               Examples:
+                                 --output json
+                                 --output yaml
+                                 --output interactive
+                                 --output 'id' (to extract a single field)
+                                 --output 'nested.field.subfield' (to extract a nested field)
+                                 --output '[id, "name"]' (to extract multiple fields as an array)
+                                 --output '{"newKey": oldKey, "otherKey": nested.field}' (to extract and rename fields in an object)
+                                 --output 'name+","+type' (to extract and concatenate fields in a string)
+                                 --output '(nbFieldA + nbFieldB) * 10' (to compute values from numeric fields)
+      --profile string         Use a specific profile from the configuration file
+```
+
+### SEE ALSO
+
+* [ovhcloud cloud key-manager secret](ovhcloud_cloud_key-manager_secret.md)	 - Manage Key Manager secrets
+

--- a/doc/ovhcloud_cloud_key-manager_secret_list.md
+++ b/doc/ovhcloud_cloud_key-manager_secret_list.md
@@ -1,0 +1,45 @@
+## ovhcloud cloud key-manager secret list
+
+List Key Manager secrets
+
+```
+ovhcloud cloud key-manager secret list [flags]
+```
+
+### Options
+
+```
+      --filter stringArray   Filter results by any property using https://github.com/PaesslerAG/gval syntax
+                             Examples:
+                               --filter 'state=="running"'
+                               --filter 'name=~"^my.*"'
+                               --filter 'nested.property.subproperty>10'
+                               --filter 'startDate>="2023-12-01"'
+                               --filter 'name=~"something" && nbField>10'
+  -h, --help                 help for list
+```
+
+### Options inherited from parent commands
+
+```
+      --cloud-project string   Cloud project ID
+  -d, --debug                  Activate debug mode (will log all HTTP requests details)
+  -e, --ignore-errors          Ignore errors in API calls when it is not fatal to the execution
+  -o, --output string          Output format: json, yaml, interactive, or a custom format expression (using https://github.com/PaesslerAG/gval syntax)
+                               Examples:
+                                 --output json
+                                 --output yaml
+                                 --output interactive
+                                 --output 'id' (to extract a single field)
+                                 --output 'nested.field.subfield' (to extract a nested field)
+                                 --output '[id, "name"]' (to extract multiple fields as an array)
+                                 --output '{"newKey": oldKey, "otherKey": nested.field}' (to extract and rename fields in an object)
+                                 --output 'name+","+type' (to extract and concatenate fields in a string)
+                                 --output '(nbFieldA + nbFieldB) * 10' (to compute values from numeric fields)
+      --profile string         Use a specific profile from the configuration file
+```
+
+### SEE ALSO
+
+* [ovhcloud cloud key-manager secret](ovhcloud_cloud_key-manager_secret.md)	 - Manage Key Manager secrets
+

--- a/doc/ovhcloud_cloud_key-manager_secret_payload.md
+++ b/doc/ovhcloud_cloud_key-manager_secret_payload.md
@@ -1,0 +1,38 @@
+## ovhcloud cloud key-manager secret payload
+
+Fetch the payload (sensitive material) of the given Key Manager secret
+
+```
+ovhcloud cloud key-manager secret payload <secret_id> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for payload
+```
+
+### Options inherited from parent commands
+
+```
+      --cloud-project string   Cloud project ID
+  -d, --debug                  Activate debug mode (will log all HTTP requests details)
+  -e, --ignore-errors          Ignore errors in API calls when it is not fatal to the execution
+  -o, --output string          Output format: json, yaml, interactive, or a custom format expression (using https://github.com/PaesslerAG/gval syntax)
+                               Examples:
+                                 --output json
+                                 --output yaml
+                                 --output interactive
+                                 --output 'id' (to extract a single field)
+                                 --output 'nested.field.subfield' (to extract a nested field)
+                                 --output '[id, "name"]' (to extract multiple fields as an array)
+                                 --output '{"newKey": oldKey, "otherKey": nested.field}' (to extract and rename fields in an object)
+                                 --output 'name+","+type' (to extract and concatenate fields in a string)
+                                 --output '(nbFieldA + nbFieldB) * 10' (to compute values from numeric fields)
+      --profile string         Use a specific profile from the configuration file
+```
+
+### SEE ALSO
+
+* [ovhcloud cloud key-manager secret](ovhcloud_cloud_key-manager_secret.md)	 - Manage Key Manager secrets
+

--- a/doc/ovhcloud_cloud_key-manager_secret_payload.md
+++ b/doc/ovhcloud_cloud_key-manager_secret_payload.md
@@ -1,10 +1,6 @@
 ## ovhcloud cloud key-manager secret payload
 
-Fetch the payload (sensitive material) of the given Key Manager secret
-
-```
-ovhcloud cloud key-manager secret payload <secret_id> [flags]
-```
+Manage the payload (sensitive material) of a Key Manager secret
 
 ### Options
 
@@ -35,4 +31,5 @@ ovhcloud cloud key-manager secret payload <secret_id> [flags]
 ### SEE ALSO
 
 * [ovhcloud cloud key-manager secret](ovhcloud_cloud_key-manager_secret.md)	 - Manage Key Manager secrets
+* [ovhcloud cloud key-manager secret payload get](ovhcloud_cloud_key-manager_secret_payload_get.md)	 - Fetch the payload (sensitive material) of the given Key Manager secret
 

--- a/doc/ovhcloud_cloud_key-manager_secret_payload_get.md
+++ b/doc/ovhcloud_cloud_key-manager_secret_payload_get.md
@@ -1,11 +1,15 @@
-## ovhcloud cloud key-manager secret
+## ovhcloud cloud key-manager secret payload get
 
-Manage Key Manager secrets
+Fetch the payload (sensitive material) of the given Key Manager secret
+
+```
+ovhcloud cloud key-manager secret payload get <secret_id> [flags]
+```
 
 ### Options
 
 ```
-  -h, --help   help for secret
+  -h, --help   help for get
 ```
 
 ### Options inherited from parent commands
@@ -30,12 +34,5 @@ Manage Key Manager secrets
 
 ### SEE ALSO
 
-* [ovhcloud cloud key-manager](ovhcloud_cloud_key-manager.md)	 - Manage Key Management Service (KMS) resources in the given cloud project
-* [ovhcloud cloud key-manager secret consumer](ovhcloud_cloud_key-manager_secret_consumer.md)	 - Manage consumers of a Key Manager secret
-* [ovhcloud cloud key-manager secret create](ovhcloud_cloud_key-manager_secret_create.md)	 - Create a new Key Manager secret
-* [ovhcloud cloud key-manager secret delete](ovhcloud_cloud_key-manager_secret_delete.md)	 - Delete the given Key Manager secret
-* [ovhcloud cloud key-manager secret edit](ovhcloud_cloud_key-manager_secret_edit.md)	 - Edit the given Key Manager secret (only metadata is mutable)
-* [ovhcloud cloud key-manager secret get](ovhcloud_cloud_key-manager_secret_get.md)	 - Get a specific Key Manager secret
-* [ovhcloud cloud key-manager secret list](ovhcloud_cloud_key-manager_secret_list.md)	 - List Key Manager secrets
 * [ovhcloud cloud key-manager secret payload](ovhcloud_cloud_key-manager_secret_payload.md)	 - Manage the payload (sensitive material) of a Key Manager secret
 

--- a/internal/assets/api-schemas/cloud_v2.json
+++ b/internal/assets/api-schemas/cloud_v2.json
@@ -1157,6 +1157,825 @@
         "description": "Time (e.g., 15:04:05)",
         "format": "time",
         "example": "15:04:05"
+      },
+      "publicCloud.keyManager.SecretConsumerInput": {
+        "type": "object",
+        "description": "Payload to register or unregister a consumer for a Key Manager secret",
+        "properties": {
+          "resourceId": {
+            "type": "string",
+            "description": "UUID of the resource consuming the secret",
+            "format": "uuid"
+          },
+          "resourceType": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/publicCloud.keyManager.ConsumerResourceTypeEnum"
+              }
+            ],
+            "description": "Type of the resource consuming the secret"
+          },
+          "service": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/publicCloud.keyManager.ConsumerServiceEnum"
+              }
+            ],
+            "description": "OpenStack service type of the consumer"
+          }
+        },
+        "required": [
+          "resourceId",
+          "resourceType",
+          "service"
+        ]
+      },
+      "publicCloud.keyManager.ModeEnum": {
+        "type": "string",
+        "description": "Block cipher mode associated with a Key Manager secret",
+        "enum": [
+          "CBC",
+          "CTR"
+        ]
+      },
+      "publicCloud.keyManager.SecretCurrentState": {
+        "type": "object",
+        "description": "Current state of a Key Manager secret from OpenStack",
+        "properties": {
+          "algorithm": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/publicCloud.keyManager.AlgorithmEnum"
+              }
+            ],
+            "description": "Algorithm associated with the secret",
+            "nullable": true,
+            "readOnly": true
+          },
+          "bitLength": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/publicCloud.keyManager.BitLengthEnum"
+              }
+            ],
+            "description": "Bit length of the secret",
+            "nullable": true,
+            "readOnly": true
+          },
+          "creatorId": {
+            "type": "string",
+            "description": "Identifier of the user who created the secret",
+            "nullable": true,
+            "readOnly": true
+          },
+          "expiration": {
+            "type": "string",
+            "description": "Expiration date and time of the secret",
+            "nullable": true,
+            "format": "date-time",
+            "readOnly": true
+          },
+          "location": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/publicCloud.common.Location"
+              }
+            ],
+            "description": "Current location of the secret",
+            "readOnly": true
+          },
+          "metadata": {
+            "type": "object",
+            "description": "Key-value metadata pairs for the secret",
+            "nullable": true,
+            "additionalProperties": {
+              "type": "string"
+            },
+            "readOnly": true
+          },
+          "mode": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/publicCloud.keyManager.ModeEnum"
+              }
+            ],
+            "description": "Mode of the algorithm",
+            "nullable": true,
+            "readOnly": true
+          },
+          "name": {
+            "type": "string",
+            "description": "Human-readable name of the secret",
+            "nullable": true,
+            "readOnly": true
+          },
+          "payloadContentType": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/publicCloud.keyManager.PayloadContentTypeEnum"
+              }
+            ],
+            "description": "Content type of the secret payload",
+            "nullable": true,
+            "readOnly": true
+          },
+          "secretType": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/publicCloud.keyManager.SecretTypeEnum"
+              }
+            ],
+            "description": "Type of the secret",
+            "readOnly": true
+          },
+          "status": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/publicCloud.keyManager.SecretStatusEnum"
+              }
+            ],
+            "description": "OpenStack status of the secret",
+            "readOnly": true
+          }
+        }
+      },
+      "publicCloud.keyManager.AlgorithmEnum": {
+        "type": "string",
+        "description": "Algorithm associated with a Key Manager secret",
+        "enum": [
+          "AES",
+          "DH",
+          "DSA",
+          "EC",
+          "RSA"
+        ]
+      },
+      "publicCloud.keyManager.SecretUpdate": {
+        "type": "object",
+        "description": "Payload to update a Public Cloud Key Manager secret",
+        "properties": {
+          "checksum": {
+            "type": "string",
+            "description": "Computed hash controlling concurrent modifications"
+          },
+          "targetSpec": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/publicCloud.keyManager.SecretUpdateTargetSpec"
+              }
+            ],
+            "description": "Desired target specification for the secret"
+          }
+        },
+        "required": [
+          "checksum",
+          "targetSpec"
+        ]
+      },
+      "publicCloud.keyManager.ContainerCreation": {
+        "type": "object",
+        "description": "Payload to create a Public Cloud key manager container",
+        "properties": {
+          "targetSpec": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/publicCloud.keyManager.ContainerTargetSpec"
+              }
+            ],
+            "description": "Desired target specification for the container"
+          }
+        },
+        "required": [
+          "targetSpec"
+        ]
+      },
+      "publicCloud.keyManager.ContainerCurrentState": {
+        "type": "object",
+        "description": "Current state of a key manager container as observed from the infrastructure",
+        "properties": {
+          "creatorId": {
+            "type": "string",
+            "description": "Identifier of the user who created the container",
+            "nullable": true,
+            "readOnly": true
+          },
+          "location": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/publicCloud.common.Location"
+              }
+            ],
+            "description": "Current location",
+            "readOnly": true
+          },
+          "name": {
+            "type": "string",
+            "description": "Current container name",
+            "readOnly": true
+          },
+          "secretRefs": {
+            "type": "array",
+            "description": "Current secret references in the container",
+            "nullable": true,
+            "items": {
+              "$ref": "#/components/schemas/publicCloud.keyManager.ContainerSecretRef"
+            },
+            "readOnly": true
+          },
+          "status": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/publicCloud.keyManager.ContainerStatusEnum"
+              }
+            ],
+            "description": "OpenStack container status",
+            "readOnly": true
+          },
+          "type": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/publicCloud.keyManager.ContainerTypeEnum"
+              }
+            ],
+            "description": "Current container type",
+            "readOnly": true
+          }
+        }
+      },
+      "publicCloud.keyManager.ConsumerServiceEnum": {
+        "type": "string",
+        "description": "Type of service consuming a Key Manager secret",
+        "enum": [
+          "COMPUTE",
+          "IMAGE",
+          "LOADBALANCER",
+          "NETWORK"
+        ]
+      },
+      "publicCloud.keyManager.SecretStatusEnum": {
+        "type": "string",
+        "description": "Status of a Key Manager secret in OpenStack",
+        "enum": [
+          "ACTIVE",
+          "ERROR"
+        ]
+      },
+      "publicCloud.keyManager.Secret": {
+        "type": "object",
+        "description": "A Public Cloud Key Manager secret",
+        "properties": {
+          "checksum": {
+            "type": "string",
+            "description": "Computed hash representing the current target specification value",
+            "readOnly": true
+          },
+          "createdAt": {
+            "type": "string",
+            "description": "Creation date of the secret",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "currentState": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/publicCloud.keyManager.SecretCurrentState"
+              }
+            ],
+            "description": "Current state of the secret",
+            "nullable": true,
+            "readOnly": true
+          },
+          "currentTasks": {
+            "type": "array",
+            "description": "Ongoing asynchronous tasks related to the secret",
+            "nullable": true,
+            "items": {
+              "$ref": "#/components/schemas/common.CurrentTask"
+            },
+            "readOnly": true
+          },
+          "id": {
+            "type": "string",
+            "description": "Unique identifier of the secret",
+            "format": "uuid",
+            "readOnly": true
+          },
+          "resourceStatus": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/common.ResourceStatusEnum"
+              }
+            ],
+            "description": "Secret readiness in the system",
+            "readOnly": true
+          },
+          "targetSpec": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/publicCloud.keyManager.SecretTargetSpec"
+              }
+            ],
+            "description": "Last target specification of the secret",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "description": "Last update date of the secret",
+            "format": "date-time",
+            "readOnly": true
+          }
+        }
+      },
+      "publicCloud.keyManager.ConsumerResourceTypeEnum": {
+        "type": "string",
+        "description": "Type of resource consuming a Key Manager secret",
+        "enum": [
+          "IMAGE",
+          "INSTANCE",
+          "LOADBALANCER"
+        ]
+      },
+      "publicCloud.keyManager.ContainerSecretRefSecret": {
+        "type": "object",
+        "description": "Reference to a secret by ID",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Unique identifier of the referenced secret",
+            "format": "uuid"
+          }
+        },
+        "required": [
+          "id"
+        ]
+      },
+      "publicCloud.keyManager.ContainerUpdateTargetSpec": {
+        "type": "object",
+        "description": "Target specification for updating a Key Manager container (only secretRefs are mutable)",
+        "properties": {
+          "secretRefs": {
+            "type": "array",
+            "description": "Desired list of secret references. Replaces all existing references.",
+            "items": {
+              "$ref": "#/components/schemas/publicCloud.keyManager.ContainerSecretRef"
+            }
+          }
+        },
+        "required": [
+          "secretRefs"
+        ]
+      },
+      "publicCloud.keyManager.ContainerStatusEnum": {
+        "type": "string",
+        "description": "Status of a Key Manager container in OpenStack",
+        "enum": [
+          "ACTIVE",
+          "ERROR"
+        ]
+      },
+      "publicCloud.keyManager.SecretPayload": {
+        "type": "object",
+        "description": "Payload content of a Key Manager secret",
+        "properties": {
+          "payload": {
+            "type": "string",
+            "description": "Secret payload data",
+            "format": "password",
+            "readOnly": true
+          }
+        }
+      },
+      "publicCloud.keyManager.SecretConsumer": {
+        "type": "object",
+        "description": "A consumer registered for a Key Manager secret",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Computed consumer identifier",
+            "readOnly": true
+          },
+          "resourceId": {
+            "type": "string",
+            "description": "UUID of the resource consuming the secret",
+            "format": "uuid",
+            "readOnly": true
+          },
+          "resourceType": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/publicCloud.keyManager.ConsumerResourceTypeEnum"
+              }
+            ],
+            "description": "Type of the resource consuming the secret",
+            "readOnly": true
+          },
+          "service": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/publicCloud.keyManager.ConsumerServiceEnum"
+              }
+            ],
+            "description": "OpenStack service type of the consumer",
+            "readOnly": true
+          }
+        }
+      },
+      "publicCloud.keyManager.SecretTypeEnum": {
+        "type": "string",
+        "description": "Type of a Key Manager secret",
+        "enum": [
+          "CERTIFICATE",
+          "OPAQUE",
+          "PASSPHRASE",
+          "PRIVATE",
+          "PUBLIC",
+          "SYMMETRIC"
+        ]
+      },
+      "publicCloud.keyManager.ContainerTargetSpec": {
+        "type": "object",
+        "description": "Target specification for a key manager container",
+        "properties": {
+          "location": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/publicCloud.common.Location"
+              }
+            ],
+            "description": "Target location"
+          },
+          "name": {
+            "type": "string",
+            "description": "Desired container name"
+          },
+          "secretRefs": {
+            "type": "array",
+            "description": "Secret references to include in the container",
+            "nullable": true,
+            "items": {
+              "$ref": "#/components/schemas/publicCloud.keyManager.ContainerSecretRef"
+            }
+          },
+          "type": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/publicCloud.keyManager.ContainerTypeEnum"
+              }
+            ],
+            "description": "Type of the container"
+          }
+        },
+        "required": [
+          "location",
+          "name",
+          "type"
+        ]
+      },
+      "publicCloud.keyManager.ContainerTypeEnum": {
+        "type": "string",
+        "description": "Possible types for a key manager container",
+        "enum": [
+          "CERTIFICATE",
+          "GENERIC",
+          "RSA"
+        ]
+      },
+      "publicCloud.keyManager.ContainerConsumer": {
+        "type": "object",
+        "description": "A consumer registered for a Key Manager container",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Computed consumer identifier",
+            "readOnly": true
+          },
+          "resourceId": {
+            "type": "string",
+            "description": "UUID of the resource consuming the container",
+            "format": "uuid",
+            "readOnly": true
+          },
+          "resourceType": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/publicCloud.keyManager.ConsumerResourceTypeEnum"
+              }
+            ],
+            "description": "Type of the resource consuming the container",
+            "readOnly": true
+          },
+          "service": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/publicCloud.keyManager.ConsumerServiceEnum"
+              }
+            ],
+            "description": "OpenStack service type of the consumer",
+            "readOnly": true
+          }
+        }
+      },
+      "publicCloud.keyManager.ContainerUpdate": {
+        "type": "object",
+        "description": "Payload to update a Public Cloud key manager container",
+        "properties": {
+          "checksum": {
+            "type": "string",
+            "description": "Computed hash controlling concurrent modifications"
+          },
+          "targetSpec": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/publicCloud.keyManager.ContainerUpdateTargetSpec"
+              }
+            ],
+            "description": "Desired target specification for the container"
+          }
+        },
+        "required": [
+          "checksum",
+          "targetSpec"
+        ]
+      },
+      "publicCloud.keyManager.SecretTargetSpec": {
+        "type": "object",
+        "description": "Desired specification for a Key Manager secret",
+        "properties": {
+          "algorithm": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/publicCloud.keyManager.AlgorithmEnum"
+              }
+            ],
+            "description": "Algorithm associated with the secret",
+            "nullable": true
+          },
+          "bitLength": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/publicCloud.keyManager.BitLengthEnum"
+              }
+            ],
+            "description": "Bit length of the secret",
+            "nullable": true
+          },
+          "expiration": {
+            "type": "string",
+            "description": "Expiration date and time of the secret",
+            "nullable": true,
+            "format": "date-time"
+          },
+          "location": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/publicCloud.common.Location"
+              }
+            ],
+            "description": "Target location for the secret"
+          },
+          "metadata": {
+            "type": "object",
+            "description": "Key-value metadata pairs for the secret",
+            "nullable": true,
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "mode": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/publicCloud.keyManager.ModeEnum"
+              }
+            ],
+            "description": "Mode of the algorithm",
+            "nullable": true
+          },
+          "name": {
+            "type": "string",
+            "description": "Human-readable name of the secret",
+            "nullable": true
+          },
+          "payload": {
+            "type": "string",
+            "description": "Secret payload data (base64-encoded). Write-only, never returned in responses. Requires payloadContentType.",
+            "nullable": true,
+            "format": "password"
+          },
+          "payloadContentType": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/publicCloud.keyManager.PayloadContentTypeEnum"
+              }
+            ],
+            "description": "Content type of the secret payload",
+            "nullable": true
+          },
+          "secretType": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/publicCloud.keyManager.SecretTypeEnum"
+              }
+            ],
+            "description": "Type of the secret"
+          }
+        },
+        "required": [
+          "location",
+          "secretType"
+        ]
+      },
+      "publicCloud.keyManager.PayloadContentTypeEnum": {
+        "type": "string",
+        "description": "Content type of a Key Manager secret payload",
+        "enum": [
+          "APPLICATION_OCTET_STREAM",
+          "APPLICATION_PKCS8",
+          "APPLICATION_PKIX_CERT",
+          "TEXT_PLAIN"
+        ]
+      },
+      "publicCloud.common.Location": {
+        "type": "object",
+        "description": "Resource location",
+        "properties": {
+          "availabilityZone": {
+            "type": "string",
+            "description": "Availability zone within the region",
+            "nullable": true
+          },
+          "region": {
+            "type": "string",
+            "description": "Region code"
+          }
+        },
+        "required": [
+          "region"
+        ]
+      },
+      "publicCloud.keyManager.SecretCreation": {
+        "type": "object",
+        "description": "Payload to create a Key Manager secret",
+        "properties": {
+          "targetSpec": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/publicCloud.keyManager.SecretTargetSpec"
+              }
+            ],
+            "description": "Desired target specification for the secret to create"
+          }
+        },
+        "required": [
+          "targetSpec"
+        ]
+      },
+      "publicCloud.keyManager.Container": {
+        "type": "object",
+        "description": "A Public Cloud key manager container",
+        "properties": {
+          "checksum": {
+            "type": "string",
+            "description": "Computed hash representing the current target specification value",
+            "readOnly": true
+          },
+          "createdAt": {
+            "type": "string",
+            "description": "Creation date of the container",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "currentState": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/publicCloud.keyManager.ContainerCurrentState"
+              }
+            ],
+            "description": "Current observed state of the container from the infrastructure",
+            "nullable": true,
+            "readOnly": true
+          },
+          "currentTasks": {
+            "type": "array",
+            "description": "Ongoing asynchronous tasks related to the container",
+            "nullable": true,
+            "items": {
+              "$ref": "#/components/schemas/common.CurrentTask"
+            },
+            "readOnly": true
+          },
+          "id": {
+            "type": "string",
+            "description": "Unique identifier of the container",
+            "format": "uuid",
+            "readOnly": true
+          },
+          "resourceStatus": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/common.ResourceStatusEnum"
+              }
+            ],
+            "description": "Container readiness in the system",
+            "readOnly": true
+          },
+          "targetSpec": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/publicCloud.keyManager.ContainerTargetSpec"
+              }
+            ],
+            "description": "Last target specification of the container",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "description": "Last update date of the container",
+            "format": "date-time",
+            "readOnly": true
+          }
+        }
+      },
+      "publicCloud.keyManager.SecretUpdateTargetSpec": {
+        "type": "object",
+        "description": "Target specification for updating a Key Manager secret (only metadata is mutable)",
+        "properties": {
+          "metadata": {
+            "type": "object",
+            "description": "Metadata key-value pairs for the secret. Replaces all existing metadata.",
+            "additionalProperties": {
+              "type": "string"
+            }
+          }
+        },
+        "required": [
+          "metadata"
+        ]
+      },
+      "publicCloud.keyManager.BitLengthEnum": {
+        "type": "integer",
+        "description": "Bit length of a Key Manager secret",
+        "enum": [
+          128,
+          256,
+          512,
+          1024,
+          2048,
+          4096
+        ]
+      },
+      "publicCloud.keyManager.ContainerSecretRef": {
+        "type": "object",
+        "description": "A secret reference within a key manager container",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Role name of the secret reference (e.g. private_key, certificate, public_key)"
+          },
+          "secret": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/publicCloud.keyManager.ContainerSecretRefSecret"
+              }
+            ],
+            "description": "Reference to the secret"
+          }
+        },
+        "required": [
+          "name",
+          "secret"
+        ]
+      },
+      "publicCloud.keyManager.ContainerConsumerInput": {
+        "type": "object",
+        "description": "Payload to register or unregister a consumer for a Key Manager container",
+        "properties": {
+          "resourceId": {
+            "type": "string",
+            "description": "UUID of the resource consuming the container",
+            "format": "uuid"
+          },
+          "resourceType": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/publicCloud.keyManager.ConsumerResourceTypeEnum"
+              }
+            ],
+            "description": "Type of the resource consuming the container"
+          },
+          "service": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/publicCloud.keyManager.ConsumerServiceEnum"
+              }
+            ],
+            "description": "OpenStack service type of the consumer"
+          }
+        },
+        "required": [
+          "resourceId",
+          "resourceType",
+          "service"
+        ]
       }
     },
     "securitySchemes": {
@@ -3189,6 +4008,2069 @@
           {
             "color": "red",
             "label": "Deprecated, will be removed"
+          }
+        ]
+      }
+    },
+    "/publicCloud/project/{projectId}/keyManager/container": {
+      "get": {
+        "summary": "List Public Cloud key manager containers",
+        "security": [
+          {
+            "oAuth2AuthCode": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "header",
+            "name": "X-Pagination-Cursor",
+            "description": "Pagination cursor",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Pagination-Size",
+            "description": "Pagination size",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "in": "path",
+            "name": "projectId",
+            "description": "Project ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/publicCloud.keyManager.Container"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Key Manager"
+        ],
+        "x-badges": [
+          {
+            "color": "blue",
+            "label": "Alpha version"
+          }
+        ],
+        "x-iam-actions": [
+          {
+            "name": "publicCloudProject:apiovh:keyManager/container/get",
+            "required": true
+          }
+        ],
+        "x-response-identifier": "id",
+        "x-expanded-response": "PublicCloudKeyManagerContainer"
+      },
+      "post": {
+        "summary": "Create a new Public Cloud key manager container",
+        "security": [
+          {
+            "oAuth2AuthCode": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "projectId",
+            "description": "Project ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/publicCloud.keyManager.ContainerCreation"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/publicCloud.keyManager.Container"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Error 400 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Common error model",
+                  "properties": {
+                    "class": {
+                      "type": "string",
+                      "description": "Class of the error"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "Error message"
+                    }
+                  }
+                },
+                "examples": {
+                  "Client::BadRequest::ServiceNotAvailableInRegion": {
+                    "value": {
+                      "class": "Client::BadRequest::ServiceNotAvailableInRegion",
+                      "message": "This service is not available in the selected region"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Error 409 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Common error model",
+                  "properties": {
+                    "class": {
+                      "type": "string",
+                      "description": "Class of the error"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "Error message"
+                    }
+                  }
+                },
+                "examples": {
+                  "Client::Conflict::RegionInMaintenance": {
+                    "value": {
+                      "class": "Client::Conflict::RegionInMaintenance",
+                      "message": "This region is currently in maintenance"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Key Manager"
+        ],
+        "x-badges": [
+          {
+            "color": "blue",
+            "label": "Alpha version"
+          }
+        ],
+        "x-iam-actions": [
+          {
+            "name": "publicCloudProject:apiovh:keyManager/container/create",
+            "required": true
+          }
+        ]
+      }
+    },
+    "/publicCloud/project/{projectId}/keyManager/container/{containerId}": {
+      "delete": {
+        "summary": "Delete a Public Cloud key manager container",
+        "security": [
+          {
+            "oAuth2AuthCode": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "containerId",
+            "description": "Container ID",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "in": "path",
+            "name": "projectId",
+            "description": "Project ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/publicCloud.keyManager.Container"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Error 404 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Common error model",
+                  "properties": {
+                    "class": {
+                      "type": "string",
+                      "description": "Class of the error"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "Error message"
+                    }
+                  }
+                },
+                "examples": {
+                  "Client::NotFound::ContainerDoesNotExist": {
+                    "value": {
+                      "class": "Client::NotFound::ContainerDoesNotExist",
+                      "message": "Container not found"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Error 409 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Common error model",
+                  "properties": {
+                    "class": {
+                      "type": "string",
+                      "description": "Class of the error"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "Error message"
+                    }
+                  }
+                },
+                "examples": {
+                  "Client::Conflict::ResourceAlreadyBeingDeleted": {
+                    "value": {
+                      "class": "Client::Conflict::ResourceAlreadyBeingDeleted",
+                      "message": "Resource is already being deleted"
+                    }
+                  },
+                  "Client::Conflict::ResourceInInvalidState": {
+                    "value": {
+                      "class": "Client::Conflict::ResourceInInvalidState",
+                      "message": "Resource cannot be modified in its current state"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Key Manager"
+        ],
+        "x-badges": [
+          {
+            "color": "blue",
+            "label": "Alpha version"
+          }
+        ],
+        "x-iam-actions": [
+          {
+            "name": "publicCloudProject:apiovh:keyManager/container/delete",
+            "required": true
+          }
+        ]
+      },
+      "get": {
+        "summary": "Get a Public Cloud key manager container",
+        "security": [
+          {
+            "oAuth2AuthCode": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "containerId",
+            "description": "Container ID",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "in": "path",
+            "name": "projectId",
+            "description": "Project ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/publicCloud.keyManager.Container"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Error 404 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Common error model",
+                  "properties": {
+                    "class": {
+                      "type": "string",
+                      "description": "Class of the error"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "Error message"
+                    }
+                  }
+                },
+                "examples": {
+                  "Client::NotFound::ContainerDoesNotExist": {
+                    "value": {
+                      "class": "Client::NotFound::ContainerDoesNotExist",
+                      "message": "Container not found"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Key Manager"
+        ],
+        "x-badges": [
+          {
+            "color": "blue",
+            "label": "Alpha version"
+          }
+        ],
+        "x-iam-actions": [
+          {
+            "name": "publicCloudProject:apiovh:keyManager/container/get",
+            "required": true
+          }
+        ],
+        "x-response-identifier": "id"
+      },
+      "put": {
+        "summary": "Update a Public Cloud key manager container",
+        "security": [
+          {
+            "oAuth2AuthCode": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "containerId",
+            "description": "Container ID",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "in": "path",
+            "name": "projectId",
+            "description": "Project ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/publicCloud.keyManager.ContainerUpdate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/publicCloud.keyManager.Container"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Error 404 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Common error model",
+                  "properties": {
+                    "class": {
+                      "type": "string",
+                      "description": "Class of the error"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "Error message"
+                    }
+                  }
+                },
+                "examples": {
+                  "Client::NotFound::ContainerDoesNotExist": {
+                    "value": {
+                      "class": "Client::NotFound::ContainerDoesNotExist",
+                      "message": "Container not found"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Error 409 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Common error model",
+                  "properties": {
+                    "class": {
+                      "type": "string",
+                      "description": "Class of the error"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "Error message"
+                    }
+                  }
+                },
+                "examples": {
+                  "Client::Conflict::ChecksumMismatch": {
+                    "value": {
+                      "class": "Client::Conflict::ChecksumMismatch",
+                      "message": "Checksum mismatch — a concurrent update was detected. Refresh the resource and retry"
+                    }
+                  },
+                  "Client::Conflict::ResourceInInvalidState": {
+                    "value": {
+                      "class": "Client::Conflict::ResourceInInvalidState",
+                      "message": "Resource cannot be modified in its current state"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Key Manager"
+        ],
+        "x-badges": [
+          {
+            "color": "blue",
+            "label": "Alpha version"
+          }
+        ],
+        "x-iam-actions": [
+          {
+            "name": "publicCloudProject:apiovh:keyManager/container/edit",
+            "required": true
+          }
+        ]
+      }
+    },
+    "/publicCloud/project/{projectId}/keyManager/container/{containerId}/consumer": {
+      "get": {
+        "summary": "List consumers of a Key Manager container",
+        "security": [
+          {
+            "oAuth2AuthCode": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "header",
+            "name": "X-Pagination-Cursor",
+            "description": "Pagination cursor",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Pagination-Size",
+            "description": "Pagination size",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "in": "path",
+            "name": "containerId",
+            "description": "Container ID",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "in": "path",
+            "name": "projectId",
+            "description": "Project ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/publicCloud.keyManager.ContainerConsumer"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Key Manager"
+        ],
+        "x-badges": [
+          {
+            "color": "blue",
+            "label": "Alpha version"
+          }
+        ],
+        "x-iam-actions": [
+          {
+            "name": "publicCloudProject:apiovh:keyManager/container/consumer/get",
+            "required": true
+          }
+        ],
+        "x-response-identifier": "id",
+        "x-expanded-response": "PublicCloudKeyManagerContainerConsumer"
+      },
+      "post": {
+        "summary": "Register a consumer for a Key Manager container",
+        "security": [
+          {
+            "oAuth2AuthCode": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "containerId",
+            "description": "Container ID",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "in": "path",
+            "name": "projectId",
+            "description": "Project ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/publicCloud.keyManager.ContainerConsumerInput"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/publicCloud.keyManager.ContainerConsumer"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Error 400 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Common error model",
+                  "properties": {
+                    "class": {
+                      "type": "string",
+                      "description": "Class of the error"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "Error message"
+                    }
+                  }
+                },
+                "examples": {
+                  "Client::BadRequest::InvalidParameter": {
+                    "value": {
+                      "class": "Client::BadRequest::InvalidParameter",
+                      "message": "Invalid parameter in the request"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Error 404 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Common error model",
+                  "properties": {
+                    "class": {
+                      "type": "string",
+                      "description": "Class of the error"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "Error message"
+                    }
+                  }
+                },
+                "examples": {
+                  "Client::NotFound::ContainerDoesNotExist": {
+                    "value": {
+                      "class": "Client::NotFound::ContainerDoesNotExist",
+                      "message": "Container not found"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Error 409 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Common error model",
+                  "properties": {
+                    "class": {
+                      "type": "string",
+                      "description": "Class of the error"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "Error message"
+                    }
+                  }
+                },
+                "examples": {
+                  "Client::Conflict::RegionInMaintenance": {
+                    "value": {
+                      "class": "Client::Conflict::RegionInMaintenance",
+                      "message": "This region is currently in maintenance"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Key Manager"
+        ],
+        "x-badges": [
+          {
+            "color": "blue",
+            "label": "Alpha version"
+          }
+        ],
+        "x-iam-actions": [
+          {
+            "name": "publicCloudProject:apiovh:keyManager/container/consumer/create",
+            "required": true
+          }
+        ]
+      }
+    },
+    "/publicCloud/project/{projectId}/keyManager/container/{containerId}/consumer/{consumerId}": {
+      "delete": {
+        "summary": "Delete a consumer from a Key Manager container",
+        "security": [
+          {
+            "oAuth2AuthCode": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "consumerId",
+            "description": "Consumer ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "containerId",
+            "description": "Container ID",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "in": "path",
+            "name": "projectId",
+            "description": "Project ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/publicCloud.keyManager.ContainerConsumer"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Error 404 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Common error model",
+                  "properties": {
+                    "class": {
+                      "type": "string",
+                      "description": "Class of the error"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "Error message"
+                    }
+                  }
+                },
+                "examples": {
+                  "Client::NotFound::ConsumerDoesNotExist": {
+                    "value": {
+                      "class": "Client::NotFound::ConsumerDoesNotExist",
+                      "message": "Consumer not found"
+                    }
+                  },
+                  "Client::NotFound::ContainerDoesNotExist": {
+                    "value": {
+                      "class": "Client::NotFound::ContainerDoesNotExist",
+                      "message": "Container not found"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Key Manager"
+        ],
+        "x-badges": [
+          {
+            "color": "blue",
+            "label": "Alpha version"
+          }
+        ],
+        "x-iam-actions": [
+          {
+            "name": "publicCloudProject:apiovh:keyManager/container/consumer/delete",
+            "required": true
+          }
+        ]
+      },
+      "get": {
+        "summary": "Get a consumer of a Key Manager container",
+        "security": [
+          {
+            "oAuth2AuthCode": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "consumerId",
+            "description": "Consumer ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "containerId",
+            "description": "Container ID",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "in": "path",
+            "name": "projectId",
+            "description": "Project ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/publicCloud.keyManager.ContainerConsumer"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Error 404 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Common error model",
+                  "properties": {
+                    "class": {
+                      "type": "string",
+                      "description": "Class of the error"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "Error message"
+                    }
+                  }
+                },
+                "examples": {
+                  "Client::NotFound::ConsumerDoesNotExist": {
+                    "value": {
+                      "class": "Client::NotFound::ConsumerDoesNotExist",
+                      "message": "Consumer not found"
+                    }
+                  },
+                  "Client::NotFound::ContainerDoesNotExist": {
+                    "value": {
+                      "class": "Client::NotFound::ContainerDoesNotExist",
+                      "message": "Container not found"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Key Manager"
+        ],
+        "x-badges": [
+          {
+            "color": "blue",
+            "label": "Alpha version"
+          }
+        ],
+        "x-iam-actions": [
+          {
+            "name": "publicCloudProject:apiovh:keyManager/container/consumer/get",
+            "required": true
+          }
+        ],
+        "x-response-identifier": "id"
+      }
+    },
+    "/publicCloud/project/{projectId}/keyManager/secret": {
+      "get": {
+        "summary": "List Public Cloud Key Manager secrets",
+        "security": [
+          {
+            "oAuth2AuthCode": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "header",
+            "name": "X-Pagination-Cursor",
+            "description": "Pagination cursor",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Pagination-Size",
+            "description": "Pagination size",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "in": "path",
+            "name": "projectId",
+            "description": "Project ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/publicCloud.keyManager.Secret"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Key Manager"
+        ],
+        "x-badges": [
+          {
+            "color": "blue",
+            "label": "Alpha version"
+          }
+        ],
+        "x-iam-actions": [
+          {
+            "name": "publicCloudProject:apiovh:keyManager/secret/get",
+            "required": true
+          }
+        ],
+        "x-response-identifier": "id",
+        "x-expanded-response": "PublicCloudKeyManagerSecret"
+      },
+      "post": {
+        "summary": "Create a new Public Cloud Key Manager secret",
+        "security": [
+          {
+            "oAuth2AuthCode": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "projectId",
+            "description": "Project ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/publicCloud.keyManager.SecretCreation"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/publicCloud.keyManager.Secret"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Error 400 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Common error model",
+                  "properties": {
+                    "class": {
+                      "type": "string",
+                      "description": "Class of the error"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "Error message"
+                    }
+                  }
+                },
+                "examples": {
+                  "Client::BadRequest::InvalidParameter": {
+                    "value": {
+                      "class": "Client::BadRequest::InvalidParameter",
+                      "message": "Invalid parameter in the request"
+                    }
+                  },
+                  "Client::BadRequest::ServiceNotAvailableInRegion": {
+                    "value": {
+                      "class": "Client::BadRequest::ServiceNotAvailableInRegion",
+                      "message": "This service is not available in the selected region"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Error 409 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Common error model",
+                  "properties": {
+                    "class": {
+                      "type": "string",
+                      "description": "Class of the error"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "Error message"
+                    }
+                  }
+                },
+                "examples": {
+                  "Client::Conflict::RegionInMaintenance": {
+                    "value": {
+                      "class": "Client::Conflict::RegionInMaintenance",
+                      "message": "This region is currently in maintenance"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Key Manager"
+        ],
+        "x-badges": [
+          {
+            "color": "blue",
+            "label": "Alpha version"
+          }
+        ],
+        "x-iam-actions": [
+          {
+            "name": "publicCloudProject:apiovh:keyManager/secret/create",
+            "required": true
+          }
+        ]
+      }
+    },
+    "/publicCloud/project/{projectId}/keyManager/secret/{secretId}": {
+      "delete": {
+        "summary": "Delete a Public Cloud Key Manager secret",
+        "security": [
+          {
+            "oAuth2AuthCode": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "projectId",
+            "description": "Project ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "secretId",
+            "description": "Secret ID",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/publicCloud.keyManager.Secret"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Error 404 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Common error model",
+                  "properties": {
+                    "class": {
+                      "type": "string",
+                      "description": "Class of the error"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "Error message"
+                    }
+                  }
+                },
+                "examples": {
+                  "Client::NotFound::SecretDoesNotExist": {
+                    "value": {
+                      "class": "Client::NotFound::SecretDoesNotExist",
+                      "message": "Secret not found"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Error 409 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Common error model",
+                  "properties": {
+                    "class": {
+                      "type": "string",
+                      "description": "Class of the error"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "Error message"
+                    }
+                  }
+                },
+                "examples": {
+                  "Client::Conflict::ResourceAlreadyBeingDeleted": {
+                    "value": {
+                      "class": "Client::Conflict::ResourceAlreadyBeingDeleted",
+                      "message": "Resource is already being deleted"
+                    }
+                  },
+                  "Client::Conflict::ResourceInInvalidState": {
+                    "value": {
+                      "class": "Client::Conflict::ResourceInInvalidState",
+                      "message": "Resource cannot be modified in its current state"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Key Manager"
+        ],
+        "x-badges": [
+          {
+            "color": "blue",
+            "label": "Alpha version"
+          }
+        ],
+        "x-iam-actions": [
+          {
+            "name": "publicCloudProject:apiovh:keyManager/secret/delete",
+            "required": true
+          }
+        ]
+      },
+      "get": {
+        "summary": "Get a Public Cloud Key Manager secret",
+        "security": [
+          {
+            "oAuth2AuthCode": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "projectId",
+            "description": "Project ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "secretId",
+            "description": "Secret ID",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/publicCloud.keyManager.Secret"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Error 404 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Common error model",
+                  "properties": {
+                    "class": {
+                      "type": "string",
+                      "description": "Class of the error"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "Error message"
+                    }
+                  }
+                },
+                "examples": {
+                  "Client::NotFound::SecretDoesNotExist": {
+                    "value": {
+                      "class": "Client::NotFound::SecretDoesNotExist",
+                      "message": "Secret not found"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Key Manager"
+        ],
+        "x-badges": [
+          {
+            "color": "blue",
+            "label": "Alpha version"
+          }
+        ],
+        "x-iam-actions": [
+          {
+            "name": "publicCloudProject:apiovh:keyManager/secret/get",
+            "required": true
+          }
+        ],
+        "x-response-identifier": "id"
+      },
+      "put": {
+        "summary": "Update a Public Cloud Key Manager secret",
+        "security": [
+          {
+            "oAuth2AuthCode": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "projectId",
+            "description": "Project ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "secretId",
+            "description": "Secret ID",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/publicCloud.keyManager.SecretUpdate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/publicCloud.keyManager.Secret"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Error 400 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Common error model",
+                  "properties": {
+                    "class": {
+                      "type": "string",
+                      "description": "Class of the error"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "Error message"
+                    }
+                  }
+                },
+                "examples": {
+                  "Client::BadRequest::InvalidParameter": {
+                    "value": {
+                      "class": "Client::BadRequest::InvalidParameter",
+                      "message": "Invalid parameter in the request"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Error 404 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Common error model",
+                  "properties": {
+                    "class": {
+                      "type": "string",
+                      "description": "Class of the error"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "Error message"
+                    }
+                  }
+                },
+                "examples": {
+                  "Client::NotFound::SecretDoesNotExist": {
+                    "value": {
+                      "class": "Client::NotFound::SecretDoesNotExist",
+                      "message": "Secret not found"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Error 409 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Common error model",
+                  "properties": {
+                    "class": {
+                      "type": "string",
+                      "description": "Class of the error"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "Error message"
+                    }
+                  }
+                },
+                "examples": {
+                  "Client::Conflict::ChecksumMismatch": {
+                    "value": {
+                      "class": "Client::Conflict::ChecksumMismatch",
+                      "message": "Checksum mismatch — a concurrent update was detected. Refresh the resource and retry"
+                    }
+                  },
+                  "Client::Conflict::ResourceInInvalidState": {
+                    "value": {
+                      "class": "Client::Conflict::ResourceInInvalidState",
+                      "message": "Resource cannot be modified in its current state"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Key Manager"
+        ],
+        "x-badges": [
+          {
+            "color": "blue",
+            "label": "Alpha version"
+          }
+        ],
+        "x-iam-actions": [
+          {
+            "name": "publicCloudProject:apiovh:keyManager/secret/edit",
+            "required": true
+          }
+        ]
+      }
+    },
+    "/publicCloud/project/{projectId}/keyManager/secret/{secretId}/consumer": {
+      "get": {
+        "summary": "List consumers of a Key Manager secret",
+        "security": [
+          {
+            "oAuth2AuthCode": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "header",
+            "name": "X-Pagination-Cursor",
+            "description": "Pagination cursor",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Pagination-Size",
+            "description": "Pagination size",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "in": "path",
+            "name": "projectId",
+            "description": "Project ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "secretId",
+            "description": "Secret ID",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/publicCloud.keyManager.SecretConsumer"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Key Manager"
+        ],
+        "x-badges": [
+          {
+            "color": "blue",
+            "label": "Alpha version"
+          }
+        ],
+        "x-iam-actions": [
+          {
+            "name": "publicCloudProject:apiovh:keyManager/secret/consumer/get",
+            "required": true
+          }
+        ],
+        "x-response-identifier": "id",
+        "x-expanded-response": "PublicCloudKeyManagerSecretConsumer"
+      },
+      "post": {
+        "summary": "Register a consumer for a Key Manager secret",
+        "security": [
+          {
+            "oAuth2AuthCode": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "projectId",
+            "description": "Project ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "secretId",
+            "description": "Secret ID",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/publicCloud.keyManager.SecretConsumerInput"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/publicCloud.keyManager.SecretConsumer"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Error 400 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Common error model",
+                  "properties": {
+                    "class": {
+                      "type": "string",
+                      "description": "Class of the error"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "Error message"
+                    }
+                  }
+                },
+                "examples": {
+                  "Client::BadRequest::InvalidParameter": {
+                    "value": {
+                      "class": "Client::BadRequest::InvalidParameter",
+                      "message": "Invalid parameter in the request"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Error 404 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Common error model",
+                  "properties": {
+                    "class": {
+                      "type": "string",
+                      "description": "Class of the error"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "Error message"
+                    }
+                  }
+                },
+                "examples": {
+                  "Client::NotFound::SecretDoesNotExist": {
+                    "value": {
+                      "class": "Client::NotFound::SecretDoesNotExist",
+                      "message": "Secret not found"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Error 409 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Common error model",
+                  "properties": {
+                    "class": {
+                      "type": "string",
+                      "description": "Class of the error"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "Error message"
+                    }
+                  }
+                },
+                "examples": {
+                  "Client::Conflict::RegionInMaintenance": {
+                    "value": {
+                      "class": "Client::Conflict::RegionInMaintenance",
+                      "message": "This region is currently in maintenance"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Key Manager"
+        ],
+        "x-badges": [
+          {
+            "color": "blue",
+            "label": "Alpha version"
+          }
+        ],
+        "x-iam-actions": [
+          {
+            "name": "publicCloudProject:apiovh:keyManager/secret/consumer/create",
+            "required": true
+          }
+        ]
+      }
+    },
+    "/publicCloud/project/{projectId}/keyManager/secret/{secretId}/consumer/{consumerId}": {
+      "delete": {
+        "summary": "Delete a consumer from a Key Manager secret",
+        "security": [
+          {
+            "oAuth2AuthCode": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "consumerId",
+            "description": "Consumer ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "projectId",
+            "description": "Project ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "secretId",
+            "description": "Secret ID",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/publicCloud.keyManager.SecretConsumer"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Error 404 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Common error model",
+                  "properties": {
+                    "class": {
+                      "type": "string",
+                      "description": "Class of the error"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "Error message"
+                    }
+                  }
+                },
+                "examples": {
+                  "Client::NotFound::ConsumerDoesNotExist": {
+                    "value": {
+                      "class": "Client::NotFound::ConsumerDoesNotExist",
+                      "message": "Consumer not found"
+                    }
+                  },
+                  "Client::NotFound::SecretDoesNotExist": {
+                    "value": {
+                      "class": "Client::NotFound::SecretDoesNotExist",
+                      "message": "Secret not found"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Key Manager"
+        ],
+        "x-badges": [
+          {
+            "color": "blue",
+            "label": "Alpha version"
+          }
+        ],
+        "x-iam-actions": [
+          {
+            "name": "publicCloudProject:apiovh:keyManager/secret/consumer/delete",
+            "required": true
+          }
+        ]
+      },
+      "get": {
+        "summary": "Get a consumer of a Key Manager secret",
+        "security": [
+          {
+            "oAuth2AuthCode": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "consumerId",
+            "description": "Consumer ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "projectId",
+            "description": "Project ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "secretId",
+            "description": "Secret ID",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/publicCloud.keyManager.SecretConsumer"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Error 404 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Common error model",
+                  "properties": {
+                    "class": {
+                      "type": "string",
+                      "description": "Class of the error"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "Error message"
+                    }
+                  }
+                },
+                "examples": {
+                  "Client::NotFound::ConsumerDoesNotExist": {
+                    "value": {
+                      "class": "Client::NotFound::ConsumerDoesNotExist",
+                      "message": "Consumer not found"
+                    }
+                  },
+                  "Client::NotFound::SecretDoesNotExist": {
+                    "value": {
+                      "class": "Client::NotFound::SecretDoesNotExist",
+                      "message": "Secret not found"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Key Manager"
+        ],
+        "x-badges": [
+          {
+            "color": "blue",
+            "label": "Alpha version"
+          }
+        ],
+        "x-iam-actions": [
+          {
+            "name": "publicCloudProject:apiovh:keyManager/secret/consumer/get",
+            "required": true
+          }
+        ],
+        "x-response-identifier": "id"
+      }
+    },
+    "/publicCloud/project/{projectId}/keyManager/secret/{secretId}/payload": {
+      "post": {
+        "summary": "Fetch the payload of a Key Manager secret",
+        "security": [
+          {
+            "oAuth2AuthCode": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "projectId",
+            "description": "Project ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "secretId",
+            "description": "Secret ID",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/publicCloud.keyManager.SecretPayload"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Error 404 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Common error model",
+                  "properties": {
+                    "class": {
+                      "type": "string",
+                      "description": "Class of the error"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "Error message"
+                    }
+                  }
+                },
+                "examples": {
+                  "Client::NotFound::SecretDoesNotExist": {
+                    "value": {
+                      "class": "Client::NotFound::SecretDoesNotExist",
+                      "message": "Secret not found"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Error 409 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Common error model",
+                  "properties": {
+                    "class": {
+                      "type": "string",
+                      "description": "Class of the error"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "Error message"
+                    }
+                  }
+                },
+                "examples": {
+                  "Client::Conflict::RegionInMaintenance": {
+                    "value": {
+                      "class": "Client::Conflict::RegionInMaintenance",
+                      "message": "This region is currently in maintenance"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Key Manager"
+        ],
+        "x-badges": [
+          {
+            "color": "blue",
+            "label": "Alpha version"
+          }
+        ],
+        "x-iam-actions": [
+          {
+            "name": "publicCloudProject:apiovh:keyManager/secret/payload/get",
+            "required": true
           }
         ]
       }

--- a/internal/cmd/cloud_key_manager.go
+++ b/internal/cmd/cloud_key_manager.go
@@ -1,0 +1,273 @@
+// SPDX-FileCopyrightText: 2025 OVH SAS <opensource@ovh.net>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"github.com/ovh/ovhcloud-cli/internal/assets"
+	"github.com/ovh/ovhcloud-cli/internal/flags"
+	"github.com/ovh/ovhcloud-cli/internal/services/cloud"
+	"github.com/spf13/cobra"
+)
+
+func initCloudKeyManagerCommand(cloudCmd *cobra.Command) {
+	keyManagerCmd := &cobra.Command{
+		Use:     "key-manager",
+		Aliases: []string{"kms"},
+		Short:   "Manage Key Management Service (KMS) resources in the given cloud project",
+	}
+	keyManagerCmd.PersistentFlags().StringVar(&cloud.CloudProject, "cloud-project", "", "Cloud project ID")
+
+	keyManagerCmd.AddCommand(getKeyManagerSecretCmd())
+	keyManagerCmd.AddCommand(getKeyManagerContainerCmd())
+
+	cloudCmd.AddCommand(keyManagerCmd)
+}
+
+//
+// Secret command tree
+//
+
+func getKeyManagerSecretCmd() *cobra.Command {
+	secretCmd := &cobra.Command{
+		Use:   "secret",
+		Short: "Manage Key Manager secrets",
+	}
+
+	secretListCmd := &cobra.Command{
+		Use:     "list",
+		Aliases: []string{"ls"},
+		Short:   "List Key Manager secrets",
+		Run:     cloud.ListKeyManagerSecrets,
+	}
+	secretCmd.AddCommand(withFilterFlag(secretListCmd))
+
+	secretCmd.AddCommand(&cobra.Command{
+		Use:   "get <secret_id>",
+		Short: "Get a specific Key Manager secret",
+		Run:   cloud.GetKeyManagerSecret,
+		Args:  cobra.ExactArgs(1),
+	})
+
+	secretCmd.AddCommand(getKeyManagerSecretCreateCmd())
+
+	secretEditCmd := &cobra.Command{
+		Use:   "edit <secret_id>",
+		Short: "Edit the given Key Manager secret (only metadata is mutable)",
+		Run:   cloud.EditKeyManagerSecret,
+		Args:  cobra.ExactArgs(1),
+	}
+	secretEditCmd.Flags().StringToStringVar(&cloud.KeyManagerSecretEditSpec.TargetSpec.Metadata, "metadata", nil, "Metadata key-value pairs (replaces all existing metadata)")
+	addInteractiveEditorFlag(secretEditCmd)
+	secretCmd.AddCommand(secretEditCmd)
+
+	secretCmd.AddCommand(&cobra.Command{
+		Use:   "delete <secret_id>",
+		Short: "Delete the given Key Manager secret",
+		Run:   cloud.DeleteKeyManagerSecret,
+		Args:  cobra.ExactArgs(1),
+	})
+
+	secretCmd.AddCommand(&cobra.Command{
+		Use:   "payload <secret_id>",
+		Short: "Fetch the payload (sensitive material) of the given Key Manager secret",
+		Run:   cloud.GetKeyManagerSecretPayload,
+		Args:  cobra.ExactArgs(1),
+	})
+
+	// Consumer subcommands
+	secretCmd.AddCommand(getKeyManagerSecretConsumerCmd())
+
+	return secretCmd
+}
+
+func getKeyManagerSecretCreateCmd() *cobra.Command {
+	secretCreateCmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a new Key Manager secret",
+		Run:   cloud.CreateKeyManagerSecret,
+	}
+
+	spec := &cloud.KeyManagerSecretSpec.TargetSpec
+	secretCreateCmd.Flags().StringVar(&spec.Name, "name", "", "Human-readable name of the secret")
+	secretCreateCmd.Flags().StringVar(&spec.SecretType, "secret-type", "", "Type of the secret (CERTIFICATE, OPAQUE, PASSPHRASE, PRIVATE, PUBLIC, SYMMETRIC)")
+	secretCreateCmd.Flags().StringVar(&spec.Algorithm, "algorithm", "", "Algorithm associated with the secret (AES, DH, DSA, EC, RSA)")
+	secretCreateCmd.Flags().IntVar(&spec.BitLength, "bit-length", 0, "Bit length of the secret (128, 256, 512, 1024, 2048, 4096)")
+	secretCreateCmd.Flags().StringVar(&spec.Mode, "mode", "", "Mode of the algorithm (CBC, CTR)")
+	secretCreateCmd.Flags().StringVar(&spec.Expiration, "expiration", "", "Expiration date and time of the secret (RFC3339)")
+	secretCreateCmd.Flags().StringVar(&spec.Payload, "payload", "", "Secret payload data (base64-encoded, write-only). Requires --payload-content-type")
+	secretCreateCmd.Flags().StringVar(&spec.PayloadContentType, "payload-content-type", "", "Content type of the payload (APPLICATION_OCTET_STREAM, APPLICATION_PKCS8, APPLICATION_PKIX_CERT, TEXT_PLAIN)")
+	secretCreateCmd.Flags().StringToStringVar(&spec.Metadata, "metadata", nil, "Metadata key-value pairs for the secret")
+	secretCreateCmd.Flags().StringVar(&cloud.KeyManagerSecretCreateRegion, "region", "", "Region code where the secret is located")
+	secretCreateCmd.Flags().StringVar(&cloud.KeyManagerSecretCreateAvailabilityZone, "availability-zone", "", "Availability zone within the region")
+	secretCreateCmd.Flags().BoolVar(&flags.WaitForTask, "wait", false, "Wait for the secret to be ready before exiting")
+
+	addParameterFileFlags(secretCreateCmd, false, assets.CloudV2OpenapiSchema, "/publicCloud/project/{projectId}/keyManager/secret", "post", cloud.KeyManagerSecretCreateExample, nil)
+	addInteractiveEditorFlag(secretCreateCmd)
+	markFlagsMutuallyExclusive(secretCreateCmd, "from-file", "editor")
+
+	return secretCreateCmd
+}
+
+func getKeyManagerSecretConsumerCmd() *cobra.Command {
+	consumerCmd := &cobra.Command{
+		Use:   "consumer",
+		Short: "Manage consumers of a Key Manager secret",
+	}
+
+	consumerListCmd := &cobra.Command{
+		Use:     "list <secret_id>",
+		Aliases: []string{"ls"},
+		Short:   "List consumers registered for the given secret",
+		Run:     cloud.ListKeyManagerSecretConsumers,
+		Args:    cobra.ExactArgs(1),
+	}
+	consumerCmd.AddCommand(withFilterFlag(consumerListCmd))
+
+	consumerCmd.AddCommand(&cobra.Command{
+		Use:   "get <secret_id> <consumer_id>",
+		Short: "Get a specific consumer of the given secret",
+		Run:   cloud.GetKeyManagerSecretConsumer,
+		Args:  cobra.ExactArgs(2),
+	})
+
+	consumerRegisterCmd := &cobra.Command{
+		Use:     "register <secret_id>",
+		Aliases: []string{"create"},
+		Short:   "Register a consumer for the given secret",
+		Run:     cloud.RegisterKeyManagerSecretConsumer,
+		Args:    cobra.ExactArgs(1),
+	}
+	addKeyManagerConsumerFlags(consumerRegisterCmd)
+	consumerCmd.AddCommand(consumerRegisterCmd)
+
+	consumerCmd.AddCommand(&cobra.Command{
+		Use:   "delete <secret_id> <consumer_id>",
+		Short: "Delete a consumer from the given secret",
+		Run:   cloud.DeleteKeyManagerSecretConsumer,
+		Args:  cobra.ExactArgs(2),
+	})
+
+	return consumerCmd
+}
+
+//
+// Container command tree
+//
+
+func getKeyManagerContainerCmd() *cobra.Command {
+	containerCmd := &cobra.Command{
+		Use:   "container",
+		Short: "Manage Key Manager containers",
+	}
+
+	containerListCmd := &cobra.Command{
+		Use:     "list",
+		Aliases: []string{"ls"},
+		Short:   "List Key Manager containers",
+		Run:     cloud.ListKeyManagerContainers,
+	}
+	containerCmd.AddCommand(withFilterFlag(containerListCmd))
+
+	containerCmd.AddCommand(&cobra.Command{
+		Use:   "get <container_id>",
+		Short: "Get a specific Key Manager container",
+		Run:   cloud.GetKeyManagerContainer,
+		Args:  cobra.ExactArgs(1),
+	})
+
+	containerCmd.AddCommand(getKeyManagerContainerCreateCmd())
+
+	containerEditCmd := &cobra.Command{
+		Use:   "edit <container_id>",
+		Short: "Edit the given Key Manager container (only secret references are mutable)",
+		Run:   cloud.EditKeyManagerContainer,
+		Args:  cobra.ExactArgs(1),
+	}
+	containerEditCmd.Flags().StringArrayVar(&cloud.KeyManagerContainerSecretRefs, "secret-ref", nil, "Secret reference as '<name>=<secretId>' (repeatable, replaces all existing references)")
+	addInteractiveEditorFlag(containerEditCmd)
+	containerCmd.AddCommand(containerEditCmd)
+
+	containerCmd.AddCommand(&cobra.Command{
+		Use:   "delete <container_id>",
+		Short: "Delete the given Key Manager container",
+		Run:   cloud.DeleteKeyManagerContainer,
+		Args:  cobra.ExactArgs(1),
+	})
+
+	// Consumer subcommands
+	containerCmd.AddCommand(getKeyManagerContainerConsumerCmd())
+
+	return containerCmd
+}
+
+func getKeyManagerContainerCreateCmd() *cobra.Command {
+	containerCreateCmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a new Key Manager container",
+		Run:   cloud.CreateKeyManagerContainer,
+	}
+
+	spec := &cloud.KeyManagerContainerSpec.TargetSpec
+	containerCreateCmd.Flags().StringVar(&spec.Name, "name", "", "Desired container name")
+	containerCreateCmd.Flags().StringVar(&spec.Type, "type", "", "Type of the container (CERTIFICATE, GENERIC, RSA)")
+	containerCreateCmd.Flags().StringArrayVar(&cloud.KeyManagerContainerSecretRefs, "secret-ref", nil, "Secret reference as '<name>=<secretId>' (repeatable)")
+	containerCreateCmd.Flags().StringVar(&cloud.KeyManagerContainerCreateRegion, "region", "", "Region code where the container is located")
+	containerCreateCmd.Flags().StringVar(&cloud.KeyManagerContainerCreateAvailabilityZone, "availability-zone", "", "Availability zone within the region")
+	containerCreateCmd.Flags().BoolVar(&flags.WaitForTask, "wait", false, "Wait for the container to be ready before exiting")
+
+	addParameterFileFlags(containerCreateCmd, false, assets.CloudV2OpenapiSchema, "/publicCloud/project/{projectId}/keyManager/container", "post", cloud.KeyManagerContainerCreateExample, nil)
+	addInteractiveEditorFlag(containerCreateCmd)
+	markFlagsMutuallyExclusive(containerCreateCmd, "from-file", "editor")
+
+	return containerCreateCmd
+}
+
+func getKeyManagerContainerConsumerCmd() *cobra.Command {
+	consumerCmd := &cobra.Command{
+		Use:   "consumer",
+		Short: "Manage consumers of a Key Manager container",
+	}
+
+	consumerListCmd := &cobra.Command{
+		Use:     "list <container_id>",
+		Aliases: []string{"ls"},
+		Short:   "List consumers registered for the given container",
+		Run:     cloud.ListKeyManagerContainerConsumers,
+		Args:    cobra.ExactArgs(1),
+	}
+	consumerCmd.AddCommand(withFilterFlag(consumerListCmd))
+
+	consumerCmd.AddCommand(&cobra.Command{
+		Use:   "get <container_id> <consumer_id>",
+		Short: "Get a specific consumer of the given container",
+		Run:   cloud.GetKeyManagerContainerConsumer,
+		Args:  cobra.ExactArgs(2),
+	})
+
+	consumerRegisterCmd := &cobra.Command{
+		Use:     "register <container_id>",
+		Aliases: []string{"create"},
+		Short:   "Register a consumer for the given container",
+		Run:     cloud.RegisterKeyManagerContainerConsumer,
+		Args:    cobra.ExactArgs(1),
+	}
+	addKeyManagerConsumerFlags(consumerRegisterCmd)
+	consumerCmd.AddCommand(consumerRegisterCmd)
+
+	consumerCmd.AddCommand(&cobra.Command{
+		Use:   "delete <container_id> <consumer_id>",
+		Short: "Delete a consumer from the given container",
+		Run:   cloud.DeleteKeyManagerContainerConsumer,
+		Args:  cobra.ExactArgs(2),
+	})
+
+	return consumerCmd
+}
+
+func addKeyManagerConsumerFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVar(&cloud.KeyManagerConsumerSpec.ResourceId, "resource-id", "", "UUID of the resource consuming the secret/container")
+	cmd.Flags().StringVar(&cloud.KeyManagerConsumerSpec.ResourceType, "resource-type", "", "Type of the consuming resource (IMAGE, INSTANCE, LOADBALANCER)")
+	cmd.Flags().StringVar(&cloud.KeyManagerConsumerSpec.Service, "service", "", "OpenStack service type of the consumer (COMPUTE, IMAGE, LOADBALANCER, NETWORK)")
+}

--- a/internal/cmd/cloud_key_manager.go
+++ b/internal/cmd/cloud_key_manager.go
@@ -69,12 +69,18 @@ func getKeyManagerSecretCmd() *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 	})
 
-	secretCmd.AddCommand(&cobra.Command{
-		Use:   "payload <secret_id>",
+	// Payload subcommands
+	payloadCmd := &cobra.Command{
+		Use:   "payload",
+		Short: "Manage the payload (sensitive material) of a Key Manager secret",
+	}
+	payloadCmd.AddCommand(&cobra.Command{
+		Use:   "get <secret_id>",
 		Short: "Fetch the payload (sensitive material) of the given Key Manager secret",
 		Run:   cloud.GetKeyManagerSecretPayload,
 		Args:  cobra.ExactArgs(1),
 	})
+	secretCmd.AddCommand(payloadCmd)
 
 	// Consumer subcommands
 	secretCmd.AddCommand(getKeyManagerSecretConsumerCmd())

--- a/internal/cmd/cloud_key_manager_test.go
+++ b/internal/cmd/cloud_key_manager_test.go
@@ -1,0 +1,363 @@
+// SPDX-FileCopyrightText: 2025 OVH SAS <opensource@ovh.net>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd_test
+
+import (
+	"net/http"
+
+	"github.com/jarcoal/httpmock"
+	"github.com/maxatome/go-testdeep/td"
+	"github.com/maxatome/tdhttpmock"
+	"github.com/ovh/ovhcloud-cli/internal/cmd"
+)
+
+//
+// Secret tests
+//
+
+func (ms *MockSuite) TestCloudKeyManagerSecretListCmd(assert, require *td.T) {
+	httpmock.RegisterResponder(http.MethodGet,
+		"https://eu.api.ovh.com/v2/publicCloud/project/fakeProjectID/keyManager/secret",
+		httpmock.NewStringResponder(200, `[
+			{
+				"id": "secret-1",
+				"resourceStatus": "READY",
+				"currentState": {
+					"name": "my-secret",
+					"secretType": "OPAQUE",
+					"location": {"region": "GRA"}
+				}
+			}
+		]`))
+
+	out, err := cmd.Execute("cloud", "key-manager", "secret", "list", "--cloud-project", "fakeProjectID")
+
+	require.CmpNoError(err)
+	assert.Cmp(out, td.Contains("secret-1"))
+	assert.Cmp(out, td.Contains("my-secret"))
+}
+
+func (ms *MockSuite) TestCloudKeyManagerSecretGetCmd(assert, require *td.T) {
+	httpmock.RegisterResponder(http.MethodGet,
+		"https://eu.api.ovh.com/v2/publicCloud/project/fakeProjectID/keyManager/secret/secret-1",
+		httpmock.NewStringResponder(200, `{
+			"id": "secret-1",
+			"resourceStatus": "READY",
+			"currentState": {
+				"name": "my-secret",
+				"secretType": "OPAQUE",
+				"location": {"region": "GRA"}
+			}
+		}`))
+
+	out, err := cmd.Execute("cloud", "key-manager", "secret", "get", "secret-1", "--cloud-project", "fakeProjectID")
+
+	require.CmpNoError(err)
+	assert.Cmp(out, td.Contains("secret-1"))
+	assert.Cmp(out, td.Contains("my-secret"))
+}
+
+func (ms *MockSuite) TestCloudKeyManagerSecretCreateCmd(assert, require *td.T) {
+	httpmock.RegisterMatcherResponder(http.MethodPost,
+		"https://eu.api.ovh.com/v2/publicCloud/project/fakeProjectID/keyManager/secret",
+		tdhttpmock.JSONBody(td.JSON(`
+			{
+				"targetSpec": {
+					"name": "my-secret",
+					"secretType": "OPAQUE",
+					"location": {"region": "GRA"}
+				}
+			}`),
+		),
+		httpmock.NewStringResponder(200, `{"id": "secret-123"}`),
+	)
+
+	out, err := cmd.Execute("cloud", "key-manager", "secret", "create", "--cloud-project", "fakeProjectID",
+		"--name", "my-secret", "--secret-type", "OPAQUE", "--region", "GRA")
+
+	require.CmpNoError(err)
+	assert.String(out, `✅ Key Manager secret created successfully (id: secret-123)`)
+}
+
+func (ms *MockSuite) TestCloudKeyManagerSecretCreateErrorCmd(assert, require *td.T) {
+	httpmock.RegisterResponder(http.MethodPost,
+		"https://eu.api.ovh.com/v2/publicCloud/project/fakeProjectID/keyManager/secret",
+		httpmock.NewStringResponder(400, `{"message": "invalid secret type"}`),
+	)
+
+	out, err := cmd.Execute("cloud", "key-manager", "secret", "create", "--cloud-project", "fakeProjectID",
+		"--name", "my-secret", "--secret-type", "OPAQUE", "--region", "GRA")
+
+	assert.CmpError(err)
+	assert.Cmp(out, td.Contains("failed to create Key Manager secret"))
+}
+
+func (ms *MockSuite) TestCloudKeyManagerSecretDeleteCmd(assert, require *td.T) {
+	httpmock.RegisterResponder(http.MethodDelete,
+		"https://eu.api.ovh.com/v2/publicCloud/project/fakeProjectID/keyManager/secret/secret-1",
+		httpmock.NewStringResponder(200, ``))
+
+	out, err := cmd.Execute("cloud", "key-manager", "secret", "delete", "secret-1", "--cloud-project", "fakeProjectID")
+
+	require.CmpNoError(err)
+	assert.Cmp(out, td.Contains("deleted successfully"))
+}
+
+func (ms *MockSuite) TestCloudKeyManagerSecretPayloadCmd(assert, require *td.T) {
+	httpmock.RegisterResponder(http.MethodPost,
+		"https://eu.api.ovh.com/v2/publicCloud/project/fakeProjectID/keyManager/secret/secret-1/payload",
+		httpmock.NewStringResponder(200, `{"payload": "super-secret-value"}`))
+
+	out, err := cmd.Execute("cloud", "key-manager", "secret", "payload", "secret-1", "--cloud-project", "fakeProjectID")
+
+	require.CmpNoError(err)
+	assert.Cmp(out, td.Contains("super-secret-value"))
+}
+
+func (ms *MockSuite) TestCloudKeyManagerSecretConsumerRegisterCmd(assert, require *td.T) {
+	httpmock.RegisterMatcherResponder(http.MethodPost,
+		"https://eu.api.ovh.com/v2/publicCloud/project/fakeProjectID/keyManager/secret/secret-1/consumer",
+		tdhttpmock.JSONBody(td.JSON(`
+			{
+				"resourceId": "11111111-1111-1111-1111-111111111111",
+				"resourceType": "INSTANCE",
+				"service": "COMPUTE"
+			}`),
+		),
+		httpmock.NewStringResponder(200, `{"id": "consumer-1"}`),
+	)
+
+	out, err := cmd.Execute("cloud", "key-manager", "secret", "consumer", "register", "secret-1", "--cloud-project", "fakeProjectID",
+		"--resource-id", "11111111-1111-1111-1111-111111111111", "--resource-type", "INSTANCE", "--service", "COMPUTE")
+
+	require.CmpNoError(err)
+	assert.Cmp(out, td.Contains("Consumer registered successfully for secret secret-1 (id: consumer-1)"))
+}
+
+func (ms *MockSuite) TestCloudKeyManagerSecretConsumerListCmd(assert, require *td.T) {
+	httpmock.RegisterResponder(http.MethodGet,
+		"https://eu.api.ovh.com/v2/publicCloud/project/fakeProjectID/keyManager/secret/secret-1/consumer",
+		httpmock.NewStringResponder(200, `[
+			{
+				"id": "consumer-1",
+				"resourceId": "11111111-1111-1111-1111-111111111111",
+				"resourceType": "INSTANCE",
+				"service": "COMPUTE"
+			}
+		]`))
+
+	out, err := cmd.Execute("cloud", "key-manager", "secret", "consumer", "list", "secret-1", "--cloud-project", "fakeProjectID")
+
+	require.CmpNoError(err)
+	assert.Cmp(out, td.Contains("consumer-1"))
+}
+
+func (ms *MockSuite) TestCloudKeyManagerSecretConsumerDeleteCmd(assert, require *td.T) {
+	httpmock.RegisterResponder(http.MethodDelete,
+		"https://eu.api.ovh.com/v2/publicCloud/project/fakeProjectID/keyManager/secret/secret-1/consumer/consumer-1",
+		httpmock.NewStringResponder(200, ``))
+
+	out, err := cmd.Execute("cloud", "key-manager", "secret", "consumer", "delete", "secret-1", "consumer-1", "--cloud-project", "fakeProjectID")
+
+	require.CmpNoError(err)
+	assert.Cmp(out, td.Contains("deleted successfully"))
+}
+
+func (ms *MockSuite) TestCloudKeyManagerSecretEditCmd(assert, require *td.T) {
+	httpmock.RegisterResponder(http.MethodGet,
+		"https://eu.api.ovh.com/v2/publicCloud/project/fakeProjectID/keyManager/secret/secret-1",
+		httpmock.NewStringResponder(200, `{
+			"id": "secret-1",
+			"checksum": "abc123",
+			"resourceStatus": "READY",
+			"targetSpec": {
+				"name": "my-secret",
+				"secretType": "OPAQUE",
+				"location": {"region": "GRA"},
+				"metadata": {"old": "value"}
+			}
+		}`))
+
+	httpmock.RegisterMatcherResponder(http.MethodPut,
+		"https://eu.api.ovh.com/v2/publicCloud/project/fakeProjectID/keyManager/secret/secret-1",
+		tdhttpmock.JSONBody(td.JSON(`
+			{
+				"checksum": "abc123",
+				"targetSpec": {
+					"metadata": {"old": "value", "env": "prod"}
+				}
+			}`),
+		),
+		httpmock.NewStringResponder(200, ``))
+
+	out, err := cmd.Execute("cloud", "key-manager", "secret", "edit", "secret-1", "--cloud-project", "fakeProjectID", "--metadata", "env=prod")
+
+	require.CmpNoError(err)
+	assert.Cmp(out, td.Contains("updated successfully"))
+}
+
+func (ms *MockSuite) TestCloudKeyManagerContainerEditCmd(assert, require *td.T) {
+	httpmock.RegisterResponder(http.MethodGet,
+		"https://eu.api.ovh.com/v2/publicCloud/project/fakeProjectID/keyManager/container/container-1",
+		httpmock.NewStringResponder(200, `{
+			"id": "container-1",
+			"checksum": "def456",
+			"resourceStatus": "READY",
+			"targetSpec": {
+				"name": "my-container",
+				"type": "GENERIC",
+				"location": {"region": "GRA"},
+				"secretRefs": []
+			}
+		}`))
+
+	httpmock.RegisterMatcherResponder(http.MethodPut,
+		"https://eu.api.ovh.com/v2/publicCloud/project/fakeProjectID/keyManager/container/container-1",
+		tdhttpmock.JSONBody(td.JSON(`
+			{
+				"checksum": "def456",
+				"targetSpec": {
+					"secretRefs": [
+						{"name": "private_key", "secret": {"id": "secret-9"}}
+					]
+				}
+			}`),
+		),
+		httpmock.NewStringResponder(200, ``))
+
+	out, err := cmd.Execute("cloud", "key-manager", "container", "edit", "container-1", "--cloud-project", "fakeProjectID", "--secret-ref", "private_key=secret-9")
+
+	require.CmpNoError(err)
+	assert.Cmp(out, td.Contains("updated successfully"))
+}
+
+//
+// Container tests
+//
+
+func (ms *MockSuite) TestCloudKeyManagerContainerListCmd(assert, require *td.T) {
+	httpmock.RegisterResponder(http.MethodGet,
+		"https://eu.api.ovh.com/v2/publicCloud/project/fakeProjectID/keyManager/container",
+		httpmock.NewStringResponder(200, `[
+			{
+				"id": "container-1",
+				"resourceStatus": "READY",
+				"currentState": {
+					"name": "my-container",
+					"type": "GENERIC",
+					"location": {"region": "GRA"}
+				}
+			}
+		]`))
+
+	out, err := cmd.Execute("cloud", "key-manager", "container", "list", "--cloud-project", "fakeProjectID")
+
+	require.CmpNoError(err)
+	assert.Cmp(out, td.Contains("container-1"))
+	assert.Cmp(out, td.Contains("my-container"))
+}
+
+func (ms *MockSuite) TestCloudKeyManagerContainerGetCmd(assert, require *td.T) {
+	httpmock.RegisterResponder(http.MethodGet,
+		"https://eu.api.ovh.com/v2/publicCloud/project/fakeProjectID/keyManager/container/container-1",
+		httpmock.NewStringResponder(200, `{
+			"id": "container-1",
+			"resourceStatus": "READY",
+			"currentState": {
+				"name": "my-container",
+				"type": "GENERIC",
+				"location": {"region": "GRA"}
+			}
+		}`))
+
+	out, err := cmd.Execute("cloud", "key-manager", "container", "get", "container-1", "--cloud-project", "fakeProjectID")
+
+	require.CmpNoError(err)
+	assert.Cmp(out, td.Contains("container-1"))
+	assert.Cmp(out, td.Contains("my-container"))
+}
+
+func (ms *MockSuite) TestCloudKeyManagerContainerCreateCmd(assert, require *td.T) {
+	httpmock.RegisterMatcherResponder(http.MethodPost,
+		"https://eu.api.ovh.com/v2/publicCloud/project/fakeProjectID/keyManager/container",
+		tdhttpmock.JSONBody(td.JSON(`
+			{
+				"targetSpec": {
+					"name": "my-container",
+					"type": "GENERIC",
+					"location": {"region": "GRA"},
+					"secretRefs": [
+						{
+							"name": "private_key",
+							"secret": {"id": "secret-1"}
+						}
+					]
+				}
+			}`),
+		),
+		httpmock.NewStringResponder(200, `{"id": "container-123"}`),
+	)
+
+	out, err := cmd.Execute("cloud", "key-manager", "container", "create", "--cloud-project", "fakeProjectID",
+		"--name", "my-container", "--type", "GENERIC", "--region", "GRA", "--secret-ref", "private_key=secret-1")
+
+	require.CmpNoError(err)
+	assert.String(out, `✅ Key Manager container created successfully (id: container-123)`)
+}
+
+func (ms *MockSuite) TestCloudKeyManagerContainerCreateErrorCmd(assert, require *td.T) {
+	httpmock.RegisterResponder(http.MethodPost,
+		"https://eu.api.ovh.com/v2/publicCloud/project/fakeProjectID/keyManager/container",
+		httpmock.NewStringResponder(400, `{"message": "invalid container type"}`),
+	)
+
+	out, err := cmd.Execute("cloud", "key-manager", "container", "create", "--cloud-project", "fakeProjectID",
+		"--name", "my-container", "--type", "GENERIC", "--region", "GRA")
+
+	assert.CmpError(err)
+	assert.Cmp(out, td.Contains("failed to create Key Manager container"))
+}
+
+func (ms *MockSuite) TestCloudKeyManagerContainerDeleteCmd(assert, require *td.T) {
+	httpmock.RegisterResponder(http.MethodDelete,
+		"https://eu.api.ovh.com/v2/publicCloud/project/fakeProjectID/keyManager/container/container-1",
+		httpmock.NewStringResponder(200, ``))
+
+	out, err := cmd.Execute("cloud", "key-manager", "container", "delete", "container-1", "--cloud-project", "fakeProjectID")
+
+	require.CmpNoError(err)
+	assert.Cmp(out, td.Contains("deleted successfully"))
+}
+
+func (ms *MockSuite) TestCloudKeyManagerContainerConsumerRegisterCmd(assert, require *td.T) {
+	httpmock.RegisterMatcherResponder(http.MethodPost,
+		"https://eu.api.ovh.com/v2/publicCloud/project/fakeProjectID/keyManager/container/container-1/consumer",
+		tdhttpmock.JSONBody(td.JSON(`
+			{
+				"resourceId": "22222222-2222-2222-2222-222222222222",
+				"resourceType": "LOADBALANCER",
+				"service": "LOADBALANCER"
+			}`),
+		),
+		httpmock.NewStringResponder(200, `{"id": "consumer-2"}`),
+	)
+
+	out, err := cmd.Execute("cloud", "key-manager", "container", "consumer", "register", "container-1", "--cloud-project", "fakeProjectID",
+		"--resource-id", "22222222-2222-2222-2222-222222222222", "--resource-type", "LOADBALANCER", "--service", "LOADBALANCER")
+
+	require.CmpNoError(err)
+	assert.Cmp(out, td.Contains("Consumer registered successfully for container container-1 (id: consumer-2)"))
+}
+
+func (ms *MockSuite) TestCloudKeyManagerContainerConsumerDeleteCmd(assert, require *td.T) {
+	httpmock.RegisterResponder(http.MethodDelete,
+		"https://eu.api.ovh.com/v2/publicCloud/project/fakeProjectID/keyManager/container/container-1/consumer/consumer-2",
+		httpmock.NewStringResponder(200, ``))
+
+	out, err := cmd.Execute("cloud", "key-manager", "container", "consumer", "delete", "container-1", "consumer-2", "--cloud-project", "fakeProjectID")
+
+	require.CmpNoError(err)
+	assert.Cmp(out, td.Contains("deleted successfully"))
+}

--- a/internal/cmd/cloud_key_manager_test.go
+++ b/internal/cmd/cloud_key_manager_test.go
@@ -35,8 +35,13 @@ func (ms *MockSuite) TestCloudKeyManagerSecretListCmd(assert, require *td.T) {
 	out, err := cmd.Execute("cloud", "key-manager", "secret", "list", "--cloud-project", "fakeProjectID")
 
 	require.CmpNoError(err)
-	assert.Cmp(out, td.Contains("secret-1"))
-	assert.Cmp(out, td.Contains("my-secret"))
+	assert.String(out, `
+┌──────────┬───────────┬────────┬────────┬────────────────┐
+│    id    │   name    │ region │  type  │ resourceStatus │
+├──────────┼───────────┼────────┼────────┼────────────────┤
+│ secret-1 │ my-secret │ GRA    │ OPAQUE │ READY          │
+└──────────┴───────────┴────────┴────────┴────────────────┘
+💡 Use option -o json or -o yaml to get the raw output with all information`[1:])
 }
 
 func (ms *MockSuite) TestCloudKeyManagerSecretGetCmd(assert, require *td.T) {
@@ -110,7 +115,7 @@ func (ms *MockSuite) TestCloudKeyManagerSecretPayloadCmd(assert, require *td.T) 
 		"https://eu.api.ovh.com/v2/publicCloud/project/fakeProjectID/keyManager/secret/secret-1/payload",
 		httpmock.NewStringResponder(200, `{"payload": "super-secret-value"}`))
 
-	out, err := cmd.Execute("cloud", "key-manager", "secret", "payload", "secret-1", "--cloud-project", "fakeProjectID")
+	out, err := cmd.Execute("cloud", "key-manager", "secret", "payload", "get", "secret-1", "--cloud-project", "fakeProjectID")
 
 	require.CmpNoError(err)
 	assert.Cmp(out, td.Contains("super-secret-value"))

--- a/internal/cmd/cloud_project.go
+++ b/internal/cmd/cloud_project.go
@@ -116,6 +116,7 @@ func init() {
 	initCloudUserCommand(cloudCmd)
 	initCloudStorageCommand(cloudCmd)
 	initCloudRancherCommand(cloudCmd)
+	initCloudKeyManagerCommand(cloudCmd)
 	initCloudSavingsPlanCommand(cloudCmd)
 	initCloudIPCommand(cloudCmd)
 	initCloudAlertingCommand(cloudCmd)

--- a/internal/services/cloud/cloud_key_manager.go
+++ b/internal/services/cloud/cloud_key_manager.go
@@ -1,0 +1,494 @@
+// SPDX-FileCopyrightText: 2025 OVH SAS <opensource@ovh.net>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cloud
+
+import (
+	_ "embed"
+	"fmt"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/ovh/ovhcloud-cli/internal/assets"
+	"github.com/ovh/ovhcloud-cli/internal/display"
+	"github.com/ovh/ovhcloud-cli/internal/flags"
+	httpLib "github.com/ovh/ovhcloud-cli/internal/http"
+	"github.com/ovh/ovhcloud-cli/internal/services/common"
+	"github.com/spf13/cobra"
+)
+
+var (
+	keyManagerSecretColumnsToDisplay    = []string{"id", "currentState.name name", "currentState.location.region region", "currentState.secretType type", "resourceStatus"}
+	keyManagerContainerColumnsToDisplay = []string{"id", "currentState.name name", "currentState.location.region region", "currentState.type type", "resourceStatus"}
+	keyManagerConsumerColumnsToDisplay  = []string{"id", "resourceId", "resourceType", "service"}
+
+	//go:embed templates/cloud_key_manager_secret.tmpl
+	keyManagerSecretTemplate string
+
+	//go:embed templates/cloud_key_manager_container.tmpl
+	keyManagerContainerTemplate string
+
+	//go:embed parameter-samples/key-manager-secret-create.json
+	KeyManagerSecretCreateExample string
+
+	//go:embed parameter-samples/key-manager-container-create.json
+	KeyManagerContainerCreateExample string
+
+	// Secret creation parameters
+	KeyManagerSecretSpec struct {
+		TargetSpec struct {
+			Algorithm          string              `json:"algorithm,omitempty"`
+			BitLength          int                 `json:"bitLength,omitempty"`
+			Expiration         string              `json:"expiration,omitempty"`
+			Location           *keyManagerLocation `json:"location,omitempty"`
+			Metadata           map[string]string   `json:"metadata,omitempty"`
+			Mode               string              `json:"mode,omitempty"`
+			Name               string              `json:"name,omitempty"`
+			Payload            string              `json:"payload,omitempty"`
+			PayloadContentType string              `json:"payloadContentType,omitempty"`
+			SecretType         string              `json:"secretType,omitempty"`
+		} `json:"targetSpec"`
+	}
+	KeyManagerSecretCreateRegion           string
+	KeyManagerSecretCreateAvailabilityZone string
+
+	// Secret edit parameters (only metadata is mutable)
+	KeyManagerSecretEditSpec struct {
+		TargetSpec struct {
+			Metadata map[string]string `json:"metadata,omitempty"`
+		} `json:"targetSpec"`
+	}
+
+	// Container creation parameters
+	KeyManagerContainerSpec struct {
+		TargetSpec struct {
+			Location   *keyManagerLocation   `json:"location,omitempty"`
+			Name       string                `json:"name,omitempty"`
+			SecretRefs []keyManagerSecretRef `json:"secretRefs,omitempty"`
+			Type       string                `json:"type,omitempty"`
+		} `json:"targetSpec"`
+	}
+	KeyManagerContainerCreateRegion           string
+	KeyManagerContainerCreateAvailabilityZone string
+	KeyManagerContainerSecretRefs             []string
+
+	// Container edit parameters (only secretRefs are mutable)
+	KeyManagerContainerEditSpec struct {
+		TargetSpec struct {
+			SecretRefs []keyManagerSecretRef `json:"secretRefs"`
+		} `json:"targetSpec"`
+	}
+
+	// Consumer register parameters (shared by secret and container)
+	KeyManagerConsumerSpec struct {
+		ResourceId   string `json:"resourceId,omitempty"`
+		ResourceType string `json:"resourceType,omitempty"`
+		Service      string `json:"service,omitempty"`
+	}
+)
+
+type (
+	keyManagerLocation struct {
+		Region           string `json:"region,omitempty"`
+		AvailabilityZone string `json:"availabilityZone,omitempty"`
+	}
+
+	keyManagerSecretRef struct {
+		Name   string `json:"name"`
+		Secret struct {
+			Id string `json:"id"`
+		} `json:"secret"`
+	}
+)
+
+// parseSecretRefs converts "role=secretId" (or "role:secretId") strings into
+// keyManagerSecretRef structures.
+func parseSecretRefs(refs []string) ([]keyManagerSecretRef, error) {
+	result := make([]keyManagerSecretRef, 0, len(refs))
+	for _, ref := range refs {
+		sep := strings.IndexAny(ref, "=:")
+		if sep <= 0 || sep == len(ref)-1 {
+			return nil, fmt.Errorf("invalid secret reference %q, expected format '<name>=<secretId>'", ref)
+		}
+		var r keyManagerSecretRef
+		r.Name = ref[:sep]
+		r.Secret.Id = ref[sep+1:]
+		result = append(result, r)
+	}
+	return result, nil
+}
+
+//
+// Secret commands
+//
+
+func ListKeyManagerSecrets(_ *cobra.Command, _ []string) {
+	projectID, err := getConfiguredCloudProject()
+	if err != nil {
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
+		return
+	}
+
+	common.ManageListRequestNoExpand(fmt.Sprintf("/v2/publicCloud/project/%s/keyManager/secret", projectID), keyManagerSecretColumnsToDisplay, flags.GenericFilters)
+}
+
+func GetKeyManagerSecret(_ *cobra.Command, args []string) {
+	projectID, err := getConfiguredCloudProject()
+	if err != nil {
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
+		return
+	}
+
+	common.ManageObjectRequest(fmt.Sprintf("/v2/publicCloud/project/%s/keyManager/secret", projectID), args[0], keyManagerSecretTemplate)
+}
+
+func CreateKeyManagerSecret(cmd *cobra.Command, _ []string) {
+	projectID, err := getConfiguredCloudProject()
+	if err != nil {
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
+		return
+	}
+
+	if KeyManagerSecretCreateRegion != "" || KeyManagerSecretCreateAvailabilityZone != "" {
+		KeyManagerSecretSpec.TargetSpec.Location = &keyManagerLocation{
+			Region:           KeyManagerSecretCreateRegion,
+			AvailabilityZone: KeyManagerSecretCreateAvailabilityZone,
+		}
+	}
+
+	endpoint := fmt.Sprintf("/v2/publicCloud/project/%s/keyManager/secret", projectID)
+	secret, err := common.CreateResource(
+		cmd,
+		"/publicCloud/project/{projectId}/keyManager/secret",
+		endpoint,
+		KeyManagerSecretCreateExample,
+		KeyManagerSecretSpec,
+		assets.CloudV2OpenapiSchema,
+		[]string{"targetSpec"},
+	)
+	if err != nil {
+		display.OutputError(&flags.OutputFormatConfig, "failed to create Key Manager secret: %s", err)
+		return
+	}
+
+	secretID, _ := secret["id"].(string)
+
+	if !flags.WaitForTask {
+		display.OutputInfo(&flags.OutputFormatConfig, secret, "✅ Key Manager secret created successfully (id: %s)", secretID)
+		return
+	}
+
+	if err := waitForCloudResourceReady(fmt.Sprintf("%s/%s", endpoint, url.PathEscape(secretID)), 20*time.Minute); err != nil {
+		display.OutputError(&flags.OutputFormatConfig, "failed to wait for Key Manager secret to be ready: %s", err)
+		return
+	}
+
+	display.OutputInfo(&flags.OutputFormatConfig, secret, "✅ Key Manager secret %s is now ready", secretID)
+}
+
+func EditKeyManagerSecret(cmd *cobra.Command, args []string) {
+	projectID, err := getConfiguredCloudProject()
+	if err != nil {
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
+		return
+	}
+
+	if err := common.EditResource(
+		cmd,
+		"/publicCloud/project/{projectId}/keyManager/secret/{secretId}",
+		fmt.Sprintf("/v2/publicCloud/project/%s/keyManager/secret/%s", projectID, url.PathEscape(args[0])),
+		KeyManagerSecretEditSpec,
+		assets.CloudV2OpenapiSchema,
+	); err != nil {
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
+		return
+	}
+}
+
+func DeleteKeyManagerSecret(_ *cobra.Command, args []string) {
+	projectID, err := getConfiguredCloudProject()
+	if err != nil {
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
+		return
+	}
+
+	endpoint := fmt.Sprintf("/v2/publicCloud/project/%s/keyManager/secret/%s", projectID, url.PathEscape(args[0]))
+	if err := httpLib.Client.Delete(endpoint, nil); err != nil {
+		display.OutputError(&flags.OutputFormatConfig, "failed to delete Key Manager secret: %s", err)
+		return
+	}
+
+	display.OutputInfo(&flags.OutputFormatConfig, nil, "✅ Key Manager secret %s deleted successfully", args[0])
+}
+
+// GetKeyManagerSecretPayload fetches the payload (sensitive material) of a secret.
+// The API exposes this as a POST that returns the payload in its response body.
+func GetKeyManagerSecretPayload(_ *cobra.Command, args []string) {
+	projectID, err := getConfiguredCloudProject()
+	if err != nil {
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
+		return
+	}
+
+	endpoint := fmt.Sprintf("/v2/publicCloud/project/%s/keyManager/secret/%s/payload", projectID, url.PathEscape(args[0]))
+	var response map[string]any
+	if err := httpLib.Client.Post(endpoint, nil, &response); err != nil {
+		display.OutputError(&flags.OutputFormatConfig, "failed to fetch Key Manager secret payload: %s", err)
+		return
+	}
+
+	display.OutputInfo(&flags.OutputFormatConfig, response, "%s", response["payload"])
+}
+
+//
+// Secret consumer commands
+//
+
+func ListKeyManagerSecretConsumers(_ *cobra.Command, args []string) {
+	projectID, err := getConfiguredCloudProject()
+	if err != nil {
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
+		return
+	}
+
+	common.ManageListRequestNoExpand(
+		fmt.Sprintf("/v2/publicCloud/project/%s/keyManager/secret/%s/consumer", projectID, url.PathEscape(args[0])),
+		keyManagerConsumerColumnsToDisplay,
+		flags.GenericFilters,
+	)
+}
+
+func GetKeyManagerSecretConsumer(_ *cobra.Command, args []string) {
+	projectID, err := getConfiguredCloudProject()
+	if err != nil {
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
+		return
+	}
+
+	common.ManageObjectRequest(
+		fmt.Sprintf("/v2/publicCloud/project/%s/keyManager/secret/%s/consumer", projectID, url.PathEscape(args[0])),
+		args[1],
+		"",
+	)
+}
+
+func RegisterKeyManagerSecretConsumer(_ *cobra.Command, args []string) {
+	projectID, err := getConfiguredCloudProject()
+	if err != nil {
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
+		return
+	}
+
+	endpoint := fmt.Sprintf("/v2/publicCloud/project/%s/keyManager/secret/%s/consumer", projectID, url.PathEscape(args[0]))
+	var response map[string]any
+	if err := httpLib.Client.Post(endpoint, KeyManagerConsumerSpec, &response); err != nil {
+		display.OutputError(&flags.OutputFormatConfig, "failed to register consumer for Key Manager secret: %s", err)
+		return
+	}
+
+	display.OutputInfo(&flags.OutputFormatConfig, response, "✅ Consumer registered successfully for secret %s (id: %s)", args[0], response["id"])
+}
+
+func DeleteKeyManagerSecretConsumer(_ *cobra.Command, args []string) {
+	projectID, err := getConfiguredCloudProject()
+	if err != nil {
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
+		return
+	}
+
+	endpoint := fmt.Sprintf("/v2/publicCloud/project/%s/keyManager/secret/%s/consumer/%s", projectID, url.PathEscape(args[0]), url.PathEscape(args[1]))
+	if err := httpLib.Client.Delete(endpoint, nil); err != nil {
+		display.OutputError(&flags.OutputFormatConfig, "failed to delete consumer from Key Manager secret: %s", err)
+		return
+	}
+
+	display.OutputInfo(&flags.OutputFormatConfig, nil, "✅ Consumer %s deleted successfully from secret %s", args[1], args[0])
+}
+
+//
+// Container commands
+//
+
+func ListKeyManagerContainers(_ *cobra.Command, _ []string) {
+	projectID, err := getConfiguredCloudProject()
+	if err != nil {
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
+		return
+	}
+
+	common.ManageListRequestNoExpand(fmt.Sprintf("/v2/publicCloud/project/%s/keyManager/container", projectID), keyManagerContainerColumnsToDisplay, flags.GenericFilters)
+}
+
+func GetKeyManagerContainer(_ *cobra.Command, args []string) {
+	projectID, err := getConfiguredCloudProject()
+	if err != nil {
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
+		return
+	}
+
+	common.ManageObjectRequest(fmt.Sprintf("/v2/publicCloud/project/%s/keyManager/container", projectID), args[0], keyManagerContainerTemplate)
+}
+
+func CreateKeyManagerContainer(cmd *cobra.Command, _ []string) {
+	projectID, err := getConfiguredCloudProject()
+	if err != nil {
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
+		return
+	}
+
+	if KeyManagerContainerCreateRegion != "" || KeyManagerContainerCreateAvailabilityZone != "" {
+		KeyManagerContainerSpec.TargetSpec.Location = &keyManagerLocation{
+			Region:           KeyManagerContainerCreateRegion,
+			AvailabilityZone: KeyManagerContainerCreateAvailabilityZone,
+		}
+	}
+
+	if len(KeyManagerContainerSecretRefs) > 0 {
+		refs, err := parseSecretRefs(KeyManagerContainerSecretRefs)
+		if err != nil {
+			display.OutputError(&flags.OutputFormatConfig, "%s", err)
+			return
+		}
+		KeyManagerContainerSpec.TargetSpec.SecretRefs = refs
+	}
+
+	endpoint := fmt.Sprintf("/v2/publicCloud/project/%s/keyManager/container", projectID)
+	container, err := common.CreateResource(
+		cmd,
+		"/publicCloud/project/{projectId}/keyManager/container",
+		endpoint,
+		KeyManagerContainerCreateExample,
+		KeyManagerContainerSpec,
+		assets.CloudV2OpenapiSchema,
+		[]string{"targetSpec"},
+	)
+	if err != nil {
+		display.OutputError(&flags.OutputFormatConfig, "failed to create Key Manager container: %s", err)
+		return
+	}
+
+	containerID, _ := container["id"].(string)
+
+	if !flags.WaitForTask {
+		display.OutputInfo(&flags.OutputFormatConfig, container, "✅ Key Manager container created successfully (id: %s)", containerID)
+		return
+	}
+
+	if err := waitForCloudResourceReady(fmt.Sprintf("%s/%s", endpoint, url.PathEscape(containerID)), 20*time.Minute); err != nil {
+		display.OutputError(&flags.OutputFormatConfig, "failed to wait for Key Manager container to be ready: %s", err)
+		return
+	}
+
+	display.OutputInfo(&flags.OutputFormatConfig, container, "✅ Key Manager container %s is now ready", containerID)
+}
+
+func EditKeyManagerContainer(cmd *cobra.Command, args []string) {
+	projectID, err := getConfiguredCloudProject()
+	if err != nil {
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
+		return
+	}
+
+	if len(KeyManagerContainerSecretRefs) > 0 {
+		refs, err := parseSecretRefs(KeyManagerContainerSecretRefs)
+		if err != nil {
+			display.OutputError(&flags.OutputFormatConfig, "%s", err)
+			return
+		}
+		KeyManagerContainerEditSpec.TargetSpec.SecretRefs = refs
+	}
+
+	if err := common.EditResource(
+		cmd,
+		"/publicCloud/project/{projectId}/keyManager/container/{containerId}",
+		fmt.Sprintf("/v2/publicCloud/project/%s/keyManager/container/%s", projectID, url.PathEscape(args[0])),
+		KeyManagerContainerEditSpec,
+		assets.CloudV2OpenapiSchema,
+	); err != nil {
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
+		return
+	}
+}
+
+func DeleteKeyManagerContainer(_ *cobra.Command, args []string) {
+	projectID, err := getConfiguredCloudProject()
+	if err != nil {
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
+		return
+	}
+
+	endpoint := fmt.Sprintf("/v2/publicCloud/project/%s/keyManager/container/%s", projectID, url.PathEscape(args[0]))
+	if err := httpLib.Client.Delete(endpoint, nil); err != nil {
+		display.OutputError(&flags.OutputFormatConfig, "failed to delete Key Manager container: %s", err)
+		return
+	}
+
+	display.OutputInfo(&flags.OutputFormatConfig, nil, "✅ Key Manager container %s deleted successfully", args[0])
+}
+
+//
+// Container consumer commands
+//
+
+func ListKeyManagerContainerConsumers(_ *cobra.Command, args []string) {
+	projectID, err := getConfiguredCloudProject()
+	if err != nil {
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
+		return
+	}
+
+	common.ManageListRequestNoExpand(
+		fmt.Sprintf("/v2/publicCloud/project/%s/keyManager/container/%s/consumer", projectID, url.PathEscape(args[0])),
+		keyManagerConsumerColumnsToDisplay,
+		flags.GenericFilters,
+	)
+}
+
+func GetKeyManagerContainerConsumer(_ *cobra.Command, args []string) {
+	projectID, err := getConfiguredCloudProject()
+	if err != nil {
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
+		return
+	}
+
+	common.ManageObjectRequest(
+		fmt.Sprintf("/v2/publicCloud/project/%s/keyManager/container/%s/consumer", projectID, url.PathEscape(args[0])),
+		args[1],
+		"",
+	)
+}
+
+func RegisterKeyManagerContainerConsumer(_ *cobra.Command, args []string) {
+	projectID, err := getConfiguredCloudProject()
+	if err != nil {
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
+		return
+	}
+
+	endpoint := fmt.Sprintf("/v2/publicCloud/project/%s/keyManager/container/%s/consumer", projectID, url.PathEscape(args[0]))
+	var response map[string]any
+	if err := httpLib.Client.Post(endpoint, KeyManagerConsumerSpec, &response); err != nil {
+		display.OutputError(&flags.OutputFormatConfig, "failed to register consumer for Key Manager container: %s", err)
+		return
+	}
+
+	display.OutputInfo(&flags.OutputFormatConfig, response, "✅ Consumer registered successfully for container %s (id: %s)", args[0], response["id"])
+}
+
+func DeleteKeyManagerContainerConsumer(_ *cobra.Command, args []string) {
+	projectID, err := getConfiguredCloudProject()
+	if err != nil {
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
+		return
+	}
+
+	endpoint := fmt.Sprintf("/v2/publicCloud/project/%s/keyManager/container/%s/consumer/%s", projectID, url.PathEscape(args[0]), url.PathEscape(args[1]))
+	if err := httpLib.Client.Delete(endpoint, nil); err != nil {
+		display.OutputError(&flags.OutputFormatConfig, "failed to delete consumer from Key Manager container: %s", err)
+		return
+	}
+
+	display.OutputInfo(&flags.OutputFormatConfig, nil, "✅ Consumer %s deleted successfully from container %s", args[1], args[0])
+}

--- a/internal/services/cloud/parameter-samples/key-manager-container-create.json
+++ b/internal/services/cloud/parameter-samples/key-manager-container-create.json
@@ -1,0 +1,17 @@
+{
+  "targetSpec": {
+    "name": "my-container",
+    "type": "GENERIC",
+    "location": {
+      "region": "GRA"
+    },
+    "secretRefs": [
+      {
+        "name": "private_key",
+        "secret": {
+          "id": "00000000-0000-0000-0000-000000000000"
+        }
+      }
+    ]
+  }
+}

--- a/internal/services/cloud/parameter-samples/key-manager-secret-create.json
+++ b/internal/services/cloud/parameter-samples/key-manager-secret-create.json
@@ -1,0 +1,11 @@
+{
+  "targetSpec": {
+    "name": "my-secret",
+    "secretType": "OPAQUE",
+    "payload": "bXktc2VjcmV0LXBheWxvYWQ=",
+    "payloadContentType": "APPLICATION_OCTET_STREAM",
+    "location": {
+      "region": "GRA"
+    }
+  }
+}

--- a/internal/services/cloud/templates/cloud_key_manager_container.tmpl
+++ b/internal/services/cloud/templates/cloud_key_manager_container.tmpl
@@ -1,0 +1,29 @@
+📦 Key Manager Container {{.ServiceName}}
+=======
+
+_{{index .Result "currentState" "name"}}_
+
+## General information
+
+**ID**:            {{index .Result "id"}}
+**Status**:        {{index .Result "resourceStatus"}}
+**Creation date**: {{index .Result "createdAt"}}
+**Update date**:   {{index .Result "updatedAt"}}
+
+## Current state
+
+**Name**:         {{index .Result "currentState" "name"}}
+**Type**:         {{index .Result "currentState" "type"}}
+**Status**:       {{index .Result "currentState" "status"}}
+{{if index .Result "currentState" "location"}}**Region**:       {{index .Result "currentState" "location" "region"}}{{end}}
+
+{{if index .Result "currentState" "secretRefs"}}
+### Secret references
+
+| Name | Secret ID |
+| --- | --- |
+{{range index .Result "currentState" "secretRefs"}}| {{.name}} | {{.secret.id}} |
+{{end}}
+{{end}}
+
+💡 Use option -o json or -o yaml to get the raw output with all information

--- a/internal/services/cloud/templates/cloud_key_manager_secret.tmpl
+++ b/internal/services/cloud/templates/cloud_key_manager_secret.tmpl
@@ -1,0 +1,24 @@
+🔐 Key Manager Secret {{.ServiceName}}
+=======
+
+_{{index .Result "currentState" "name"}}_
+
+## General information
+
+**ID**:            {{index .Result "id"}}
+**Status**:        {{index .Result "resourceStatus"}}
+**Creation date**: {{index .Result "createdAt"}}
+**Update date**:   {{index .Result "updatedAt"}}
+
+## Current state
+
+**Name**:         {{index .Result "currentState" "name"}}
+**Type**:         {{index .Result "currentState" "secretType"}}
+**Status**:       {{index .Result "currentState" "status"}}
+**Algorithm**:    {{index .Result "currentState" "algorithm"}}
+**Bit length**:   {{index .Result "currentState" "bitLength"}}
+**Mode**:         {{index .Result "currentState" "mode"}}
+**Expiration**:   {{index .Result "currentState" "expiration"}}
+{{if index .Result "currentState" "location"}}**Region**:       {{index .Result "currentState" "location" "region"}}{{end}}
+
+💡 Use option -o json or -o yaml to get the raw output with all information

--- a/internal/services/cloud/utils.go
+++ b/internal/services/cloud/utils.go
@@ -116,6 +116,53 @@ func runFlavorSelector(projectID string, region string) (string, string, error) 
 	return selectedFlavor, selectedID, nil
 }
 
+// waitForCloudResourceReady polls a Cloud API v2 managed resource until its
+// resourceStatus reaches READY. Tasks reported in error are logged but do not
+// abort the wait; only a resource-level ERROR status is fatal. It times out
+// after retryDuration.
+func waitForCloudResourceReady(endpoint string, retryDuration time.Duration) error {
+	ctx, cancel := context.WithTimeout(context.Background(), retryDuration)
+	defer cancel()
+
+	ticker := time.NewTicker(5 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		var resource struct {
+			ResourceStatus string `json:"resourceStatus"`
+			CurrentTasks   []struct {
+				ID     string `json:"id"`
+				Type   string `json:"type"`
+				Status string `json:"status"`
+			} `json:"currentTasks"`
+		}
+		if err := httpLib.Client.Get(endpoint, &resource); err != nil {
+			return fmt.Errorf("error fetching resource: %w", err)
+		}
+
+		switch resource.ResourceStatus {
+		case "READY":
+			return nil
+		case "ERROR":
+			return fmt.Errorf("resource ended in error state")
+		}
+
+		for _, task := range resource.CurrentTasks {
+			if task.Status == "ERROR" {
+				log.Printf("Task %s (%s) is in error, still waiting for resource to recover…", task.ID, task.Type)
+			}
+		}
+
+		select {
+		case <-ctx.Done():
+			return errors.New("timeout waiting for resource to be ready")
+		case <-ticker.C:
+			log.Printf("Still waiting for resource to be ready (status=%s)…", resource.ResourceStatus)
+			continue
+		}
+	}
+}
+
 func waitForCloudOperation(projectID, operationID, action string, retryDuration time.Duration) (string, error) {
 	endpoint := fmt.Sprintf("/v1/cloud/project/%s/operation/%s", url.PathEscape(projectID), url.PathEscape(operationID))
 	resourceID := ""


### PR DESCRIPTION
# Description

Adds the `cloud key-manager` command (Key Management Service) on Cloud API v2 — a new
product, no v1 equivalent.

**`cloud key-manager secret`** (`/v2/publicCloud/project/{id}/keyManager/secret`)
- list, get, create, edit (metadata only — the v2 API makes secrets otherwise immutable), delete
- `payload <id>` — reveals the secret payload
- `consumer` subcommand — list, get, register, delete

**`cloud key-manager container`** (`.../keyManager/container`)
- list, get, create, edit (secret references only), delete
- `consumer` subcommand — list, get, register, delete

Create/edit go through `common.CreateResource`/`EditResource` (so `--editor`/`--from-file`/`--init-file` work); `--wait` polls until READY via `waitForCloudResourceReady`.

Tested end-to-end against the real v2 API (secret + container full CRUD, payload reveal, metadata edit).



## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Improvement (improvement of existing commands)
- [ ] Breaking change (fix or feature that can break a current behavior)
- [X] Documentation update

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have commented my code
- [X] I ran `go mod tidy`
- [ ] I have added tests that prove my fix is effective or that my feature works
