### PR TITLE
fix: return regions with available services if the service is up rega…

### DIFF
--- a/internal/services/cloud/cloud_project.go
+++ b/internal/services/cloud/cloud_project.go
@@ -99,10 +99,9 @@ func getCloudRegionsWithFeatureAvailable(projectID string, features ...string) (
 	// Filter regions having given feature available
 	var regionIDs []any
 	for _, region := range regions {
-		if region["status"] != "UP" {
-			continue
-		}
-
+		// Skip checking for region's own status
+		// in case region reports DOWN but the
+		// requested service reports UP
 		services := region["services"].([]any)
 		for _, service := range services {
 			service := service.(map[string]any)


### PR DESCRIPTION
…rdless of region's top level status

# Description

Made getCloudRegionsWithFeatureAvailable skip checking for region status to prevent omission of services with status 'up'  despite the region's status being 'down'.

Fixes #220. 

## Type of change

- [ x ] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ x ] My code follows the style guidelines of this project
- [ x ] I have commented my code
- [ x ] I ran `go mod tidy`
- [ Not applicable ] I have added tests that prove my fix is effective or that my feature works
