### PR TITLE
feat(doc,config,display,http): Custom HTTP headers when using a custom endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,9 @@ OVH_CONSUMER_KEY=xxx
 OVH_CLOUD_PROJECT_SERVICE=<public cloud project ID> 
 ```
 
+* Using a custom endpoint that requires extra HTTP headers (e.g. an internal routing header), see the
+  [authentication page](./doc/authentication.md#custom-http-headers) for `ovhcloud config set-header`.
+
 ## Examples
 
 | Task                                     | Command                                         |

--- a/doc/authentication.md
+++ b/doc/authentication.md
@@ -96,6 +96,30 @@ Depending on the API you want to use, you may set the `endpoint` to:
 * `ovh-us` for OVHcloud US API
 * `ovh-ca` for OVHcloud Canada API
 
+### Custom HTTP headers
+
+When using a custom endpoint (an arbitrary URL instead of one of the built-in regions), that endpoint may
+require extra HTTP headers to be sent on every API request (e.g. an internal routing header). You can
+declare them either interactively during `ovhcloud login` (when picking "Custom endpoint", an optional
+"Custom headers" field accepts a comma-separated `Name: value` list), or afterwards with:
+
+```sh
+ovhcloud config set-header X-Routing-Key abc123
+ovhcloud config unset-header X-Routing-Key
+```
+
+These commands apply to the currently active endpoint (or active profile, if you're using
+[profiles](./profiles.md)). Headers are stored in the configuration file next to the endpoint's
+credentials, as `header.<Name>` keys:
+
+```ini
+[https://api.eu.ovhcloud.com/1.0]
+application_key=my_app_key
+application_secret=my_application_secret
+consumer_key=my_consumer_key
+header.X-Routing-Key=abc123
+```
+
 ### Region/company limitations
 
 ~> **WARNING**: some products are not available for `soyoustart` and `kimsufi`, or for some endpoints. If you try to use a product that is not available, you will encounter the following error: `Client::NotFound: "Got an invalid (or empty) URL"`.

--- a/doc/ovhcloud_config_set-header.md
+++ b/doc/ovhcloud_config_set-header.md
@@ -1,11 +1,21 @@
-## ovhcloud config
+## ovhcloud config set-header
 
-Manage your CLI configuration
+Set a custom HTTP header to send on every API request
+
+```
+ovhcloud config set-header <name> <value>
+```
+
+### Examples
+
+```
+ovhcloud config set-header X-Routing-Key abc123
+```
 
 ### Options
 
 ```
-  -h, --help   help for config
+  -h, --help   help for set-header
 ```
 
 ### Options inherited from parent commands
@@ -29,11 +39,5 @@ Manage your CLI configuration
 
 ### SEE ALSO
 
-* [ovhcloud](ovhcloud.md)	 - CLI to manage your OVHcloud services
-* [ovhcloud config profile](ovhcloud_config_profile.md)	 - Manage CLI profiles for multiple accounts
-* [ovhcloud config set](ovhcloud_config_set.md)	 - Set a value in the CLI configuration
-* [ovhcloud config set-endpoint](ovhcloud_config_set-endpoint.md)	 - Configure CLI to use the given API endpoint (EU, CA, US), or a specific URL (e.g. https://eu.api.ovh.com/v1)
-* [ovhcloud config set-header](ovhcloud_config_set-header.md)	 - Set a custom HTTP header to send on every API request
-* [ovhcloud config show](ovhcloud_config_show.md)	 - Show CLI configuration
-* [ovhcloud config unset-header](ovhcloud_config_unset-header.md)	 - Remove a previously configured custom HTTP header
+* [ovhcloud config](ovhcloud_config.md)	 - Manage your CLI configuration
 

--- a/doc/ovhcloud_config_unset-header.md
+++ b/doc/ovhcloud_config_unset-header.md
@@ -1,11 +1,21 @@
-## ovhcloud config
+## ovhcloud config unset-header
 
-Manage your CLI configuration
+Remove a previously configured custom HTTP header
+
+```
+ovhcloud config unset-header <name>
+```
+
+### Examples
+
+```
+ovhcloud config unset-header X-Routing-Key
+```
 
 ### Options
 
 ```
-  -h, --help   help for config
+  -h, --help   help for unset-header
 ```
 
 ### Options inherited from parent commands
@@ -29,11 +39,5 @@ Manage your CLI configuration
 
 ### SEE ALSO
 
-* [ovhcloud](ovhcloud.md)	 - CLI to manage your OVHcloud services
-* [ovhcloud config profile](ovhcloud_config_profile.md)	 - Manage CLI profiles for multiple accounts
-* [ovhcloud config set](ovhcloud_config_set.md)	 - Set a value in the CLI configuration
-* [ovhcloud config set-endpoint](ovhcloud_config_set-endpoint.md)	 - Configure CLI to use the given API endpoint (EU, CA, US), or a specific URL (e.g. https://eu.api.ovh.com/v1)
-* [ovhcloud config set-header](ovhcloud_config_set-header.md)	 - Set a custom HTTP header to send on every API request
-* [ovhcloud config show](ovhcloud_config_show.md)	 - Show CLI configuration
-* [ovhcloud config unset-header](ovhcloud_config_unset-header.md)	 - Remove a previously configured custom HTTP header
+* [ovhcloud config](ovhcloud_config.md)	 - Manage your CLI configuration
 

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -44,6 +44,24 @@ func init() {
 		DisableFlagsInUseLine: true,
 	})
 
+	configCmd.AddCommand(&cobra.Command{
+		Example:               "ovhcloud config set-header X-Routing-Key abc123",
+		Use:                   "set-header <name> <value>",
+		Short:                 "Set a custom HTTP header to send on every API request",
+		Run:                   config.SetHeader,
+		Args:                  cobra.ExactArgs(2),
+		DisableFlagsInUseLine: true,
+	})
+
+	configCmd.AddCommand(&cobra.Command{
+		Example:               "ovhcloud config unset-header X-Routing-Key",
+		Use:                   "unset-header <name>",
+		Short:                 "Remove a previously configured custom HTTP header",
+		Run:                   config.UnsetHeader,
+		Args:                  cobra.ExactArgs(1),
+		DisableFlagsInUseLine: true,
+	})
+
 	// Profile management subcommands
 	profileCmd := &cobra.Command{
 		Use:   "profile",

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -29,6 +29,10 @@ var (
 	}
 )
 
+// HeaderKeyPrefix prefixes INI keys used to store custom HTTP headers
+// (e.g. "header.X-Routing-Key = abc123") in a profile or endpoint section.
+const HeaderKeyPrefix = "header."
+
 // currentUserHome attempts to get current user's home directory.
 func currentUserHome() (string, error) {
 	usr, err := user.Current()
@@ -164,6 +168,66 @@ func SetConfigValue(cfg *ini.File, path, sectionName, keyName, value string) err
 	return cfg.SaveTo(path)
 }
 
+// DeleteConfigValue removes a key from the given section. If sectionName is
+// empty, it is resolved via ConfigurableFields like SetConfigValue does.
+func DeleteConfigValue(cfg *ini.File, path, sectionName, keyName string) error {
+	if path == "" {
+		path = ConfigPaths[0]
+	}
+
+	if sectionName == "" {
+		sectionName = ConfigurableFields[keyName]
+		if sectionName == "" {
+			return fmt.Errorf("unknown configuration field %q", keyName)
+		}
+	}
+
+	if section := cfg.Section(sectionName); section != nil {
+		section.DeleteKey(keyName)
+	}
+
+	return cfg.SaveTo(path)
+}
+
+// GetCustomHeaders returns the custom HTTP headers configured in the given
+// section (an endpoint-named legacy section), stored as "header.<Name>" INI
+// keys. Returns an empty map if cfg is nil, sectionName is empty, or the
+// section has no such keys.
+func GetCustomHeaders(cfg *ini.File, sectionName string) map[string]string {
+	if cfg == nil || sectionName == "" {
+		return map[string]string{}
+	}
+	return customHeadersFromSection(cfg.Section(sectionName))
+}
+
+// GetProfileCustomHeaders returns the custom HTTP headers configured for the
+// given profile, stored as "header.<Name>" INI keys in its profile section.
+func GetProfileCustomHeaders(cfg *ini.File, profileName string) map[string]string {
+	if cfg == nil {
+		return map[string]string{}
+	}
+	section, err := GetProfileSection(cfg, profileName)
+	if err != nil {
+		return map[string]string{}
+	}
+	return customHeadersFromSection(section)
+}
+
+func customHeadersFromSection(section *ini.Section) map[string]string {
+	headers := map[string]string{}
+	if section == nil {
+		return headers
+	}
+
+	for _, key := range section.Keys() {
+		if name, ok := strings.CutPrefix(key.Name(), HeaderKeyPrefix); ok {
+			headers[name] = key.Value()
+		}
+	}
+
+	return headers
+}
+
 // ActiveProfileOverride is set from the --profile CLI flag by the root command's
 // PersistentPreRun. It allows GetConfigValue to respect the --profile flag without
 // the config package needing to import the flags package.
@@ -179,7 +243,7 @@ func ProfileSectionName(profileName string) string {
 }
 
 // DeleteCredentials removes the API credential keys (application_key,
-// application_secret, consumer_key) 
+// application_secret, consumer_key)
 func DeleteCredentials(cfg *ini.File, path, sectionName string) error {
 	if path == "" {
 		path = ConfigPaths[0]
@@ -353,5 +417,18 @@ func SetProfileConfigValue(cfg *ini.File, path, profileName, keyName, value stri
 	}
 
 	section.Key(keyName).SetValue(value)
+	return cfg.SaveTo(path)
+}
+
+// DeleteProfileConfigValue removes a key from a profile section.
+func DeleteProfileConfigValue(cfg *ini.File, path, profileName, keyName string) error {
+	if path == "" {
+		path = ConfigPaths[0]
+	}
+
+	if section := cfg.Section(profileSectionPrefix + profileName); section != nil {
+		section.DeleteKey(keyName)
+	}
+
 	return cfg.SaveTo(path)
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -29,6 +29,10 @@ var (
 	}
 )
 
+// HeaderKeyPrefix prefixes INI keys used to store custom HTTP headers
+// (e.g. "header.X-Routing-Key = abc123") in a profile or endpoint section.
+const HeaderKeyPrefix = "header."
+
 // currentUserHome attempts to get current user's home directory.
 func currentUserHome() (string, error) {
 	usr, err := user.Current()
@@ -162,6 +166,66 @@ func SetConfigValue(cfg *ini.File, path, sectionName, keyName, value string) err
 	}
 
 	return cfg.SaveTo(path)
+}
+
+// DeleteConfigValue removes a key from the given section. If sectionName is
+// empty, it is resolved via ConfigurableFields like SetConfigValue does.
+func DeleteConfigValue(cfg *ini.File, path, sectionName, keyName string) error {
+	if path == "" {
+		path = ConfigPaths[0]
+	}
+
+	if sectionName == "" {
+		sectionName = ConfigurableFields[keyName]
+		if sectionName == "" {
+			return fmt.Errorf("unknown configuration field %q", keyName)
+		}
+	}
+
+	if section := cfg.Section(sectionName); section != nil {
+		section.DeleteKey(keyName)
+	}
+
+	return cfg.SaveTo(path)
+}
+
+// GetCustomHeaders returns the custom HTTP headers configured in the given
+// section (an endpoint-named legacy section), stored as "header.<Name>" INI
+// keys. Returns an empty map if cfg is nil, sectionName is empty, or the
+// section has no such keys.
+func GetCustomHeaders(cfg *ini.File, sectionName string) map[string]string {
+	if cfg == nil || sectionName == "" {
+		return map[string]string{}
+	}
+	return customHeadersFromSection(cfg.Section(sectionName))
+}
+
+// GetProfileCustomHeaders returns the custom HTTP headers configured for the
+// given profile, stored as "header.<Name>" INI keys in its profile section.
+func GetProfileCustomHeaders(cfg *ini.File, profileName string) map[string]string {
+	if cfg == nil {
+		return map[string]string{}
+	}
+	section, err := GetProfileSection(cfg, profileName)
+	if err != nil {
+		return map[string]string{}
+	}
+	return customHeadersFromSection(section)
+}
+
+func customHeadersFromSection(section *ini.Section) map[string]string {
+	headers := map[string]string{}
+	if section == nil {
+		return headers
+	}
+
+	for _, key := range section.Keys() {
+		if name, ok := strings.CutPrefix(key.Name(), HeaderKeyPrefix); ok {
+			headers[name] = key.Value()
+		}
+	}
+
+	return headers
 }
 
 // ActiveProfileOverride is set from the --profile CLI flag by the root command's
@@ -327,5 +391,18 @@ func SetProfileConfigValue(cfg *ini.File, path, profileName, keyName, value stri
 	}
 
 	section.Key(keyName).SetValue(value)
+	return cfg.SaveTo(path)
+}
+
+// DeleteProfileConfigValue removes a key from a profile section.
+func DeleteProfileConfigValue(cfg *ini.File, path, profileName, keyName string) error {
+	if path == "" {
+		path = ConfigPaths[0]
+	}
+
+	if section := cfg.Section(profileSectionPrefix + profileName); section != nil {
+		section.DeleteKey(keyName)
+	}
+
 	return cfg.SaveTo(path)
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -295,6 +295,87 @@ endpoint=ovh-eu
 	td.CmpNot(t, profiles, td.Contains(DefaultProfileName))
 }
 
+func TestGetCustomHeaders(t *testing.T) {
+	cfg := newTestConfig(`
+[https://api.eu.ovhcloud.com/1.0]
+application_key      = ak123
+header.X-Routing-Key  = internal-build-eu
+header.X-Debug-Bypass = true
+`)
+
+	headers := GetCustomHeaders(cfg, "https://api.eu.ovhcloud.com/1.0")
+	td.Cmp(t, headers, map[string]string{
+		"X-Routing-Key":  "internal-build-eu",
+		"X-Debug-Bypass": "true",
+	})
+}
+
+func TestGetCustomHeaders_NoHeaders(t *testing.T) {
+	cfg := newTestConfig(`
+[ovh-eu]
+application_key = ak123
+`)
+
+	td.Cmp(t, GetCustomHeaders(cfg, "ovh-eu"), map[string]string{})
+}
+
+func TestGetCustomHeaders_NilOrEmpty(t *testing.T) {
+	td.Cmp(t, GetCustomHeaders(nil, "ovh-eu"), map[string]string{})
+	td.Cmp(t, GetCustomHeaders(newTestConfig(""), ""), map[string]string{})
+	td.Cmp(t, GetCustomHeaders(newTestConfig(""), "does-not-exist"), map[string]string{})
+}
+
+func TestGetProfileCustomHeaders(t *testing.T) {
+	cfg := newTestConfig(`
+[profile:work]
+endpoint             = https://api.eu.ovhcloud.com/1.0
+application_key      = ak123
+header.X-Routing-Key = internal-build-eu
+`)
+
+	td.Cmp(t, GetProfileCustomHeaders(cfg, "work"), map[string]string{"X-Routing-Key": "internal-build-eu"})
+}
+
+func TestGetProfileCustomHeaders_NotFound(t *testing.T) {
+	cfg := newTestConfig(`
+[default]
+endpoint = ovh-eu
+`)
+
+	td.Cmp(t, GetProfileCustomHeaders(cfg, "nonexistent"), map[string]string{})
+	td.Cmp(t, GetProfileCustomHeaders(nil, "nonexistent"), map[string]string{})
+}
+
+func TestDeleteConfigValue(t *testing.T) {
+	cfg := newTestConfig(`
+[ovh-eu]
+application_key      = ak123
+header.X-Routing-Key = internal-build-eu
+`)
+	tmpFile := filepath.Join(t.TempDir(), "test.conf")
+
+	td.Require(t).CmpNoError(DeleteConfigValue(cfg, tmpFile, "ovh-eu", "header.X-Routing-Key"))
+	td.Cmp(t, GetCustomHeaders(cfg, "ovh-eu"), map[string]string{})
+
+	// Unrelated key untouched
+	val, err := GetConfigValue(cfg, "ovh-eu", "application_key")
+	td.Require(t).CmpNoError(err)
+	td.Cmp(t, val, "ak123")
+}
+
+func TestDeleteProfileConfigValue(t *testing.T) {
+	cfg := newTestConfig(`
+[profile:work]
+application_key      = ak123
+header.X-Routing-Key = internal-build-eu
+`)
+	tmpFile := filepath.Join(t.TempDir(), "test.conf")
+
+	td.Require(t).CmpNoError(DeleteProfileConfigValue(cfg, tmpFile, "work", "header.X-Routing-Key"))
+	td.Cmp(t, GetProfileCustomHeaders(cfg, "work"), map[string]string{})
+	td.Cmp(t, GetProfileConfigValue(cfg, "work", "application_key"), "ak123")
+}
+
 func TestGetConfigValue_ActiveProfileOverride(t *testing.T) {
 	// When ActiveProfileOverride is set (simulating --profile flag),
 	// GetConfigValue should read from the overridden profile

--- a/internal/display/login.go
+++ b/internal/display/login.go
@@ -52,6 +52,14 @@ func RunLoginInput(customEndpoint bool) map[string]string {
 	consumerKeyInput.Prompt = ""
 	inputs = append(inputs, consumerKeyInput)
 
+	if customEndpoint {
+		headersInput := textinput.New()
+		headersInput.Placeholder = "X-Header: value, X-Other: value2 (optional)"
+		headersInput.Width = 60
+		headersInput.Prompt = ""
+		inputs = append(inputs, headersInput)
+	}
+
 	mod := inputModel{
 		withCustomEndpoint: customEndpoint,
 		inputs:             inputs,
@@ -71,6 +79,7 @@ func RunLoginInput(customEndpoint bool) map[string]string {
 			"application_key":    mod.inputs[1].Value(),
 			"application_secret": mod.inputs[2].Value(),
 			"consumer_key":       mod.inputs[3].Value(),
+			"headers":            mod.inputs[4].Value(),
 		}
 	}
 
@@ -155,6 +164,9 @@ func (m inputModel) View() string {
  %s
 
  %s
+ %s
+
+ %s
 `,
 			inputStyle.Width(30).Render("API endpoint"),
 			m.inputs[0].View(),
@@ -164,6 +176,8 @@ func (m inputModel) View() string {
 			m.inputs[2].View(),
 			inputStyle.Width(30).Render("Consumer key"),
 			m.inputs[3].View(),
+			inputStyle.Width(30).Render("Custom headers"),
+			m.inputs[4].View(),
 			continueStyle.Render("Press enter to validate ->"),
 		) + "\n"
 	}

--- a/internal/http/client.go
+++ b/internal/http/client.go
@@ -31,6 +31,7 @@ func InitClient() {
 
 func InitClientWithProfile(cfg *ini.File, profileOverride string) {
 	var err error
+	var headers map[string]string
 
 	// Init API client
 	if runtime.GOARCH == "wasm" && runtime.GOOS == "js" {
@@ -48,10 +49,16 @@ func InitClientWithProfile(cfg *ini.File, profileOverride string) {
 			endpoint, appKey, appSecret, consumerKey, err = config.GetProfileCredentials(cfg, profileName)
 			if err == nil {
 				Client, err = ovh.NewClient(endpoint, appKey, appSecret, consumerKey)
+				headers = config.GetProfileCustomHeaders(cfg, profileName)
 			}
 		} else {
 			// Legacy mode: let go-ovh read from env/config files
 			Client, err = ovh.NewDefaultClient()
+			if err == nil && cfg != nil {
+				if endpoint, _ := config.GetConfigValue(cfg, "default", "endpoint"); endpoint != "" {
+					headers = config.GetCustomHeaders(cfg, endpoint)
+				}
+			}
 		}
 		if Client != nil {
 			Client.UserAgent = "ovh-cli/" + version.Version
@@ -60,9 +67,11 @@ func InitClientWithProfile(cfg *ini.File, profileOverride string) {
 	if err != nil {
 		log.Printf(`OVHcloud API client not initialized, please run "ovhcloud login" to authenticate (%s)`, err)
 	} else if Client != nil {
-		// Chain transports: schemasVersion (adds X-Schemas-Version for /v2/ paths)
-		// → debug logging (logs request/response) → default transport (sends over the wire).
-		Client.Client.Transport = newSchemasVersionTransport(NewTransport("OVH", http.DefaultTransport))
+		// Chain transports: customHeaders (injects user-configured headers) → schemasVersion
+		// (adds X-Schemas-Version for /v2/ paths) → debug logging (logs request/response)
+		// → default transport (sends over the wire).
+		Client.Client.Transport = newCustomHeadersTransport(
+			newSchemasVersionTransport(NewTransport("OVH", http.DefaultTransport)), headers)
 	}
 }
 

--- a/internal/http/custom_headers_transport.go
+++ b/internal/http/custom_headers_transport.go
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: 2026 OVH SAS <opensource@ovh.net>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package http
+
+import "net/http"
+
+// customHeadersTransport is an http.RoundTripper middleware that injects
+// user-configured custom HTTP headers on every request. It is used to
+// support custom API endpoints that require extra headers (e.g. an internal
+// routing header) that the built-in OVHcloud regions don't need.
+type customHeadersTransport struct {
+	next    http.RoundTripper
+	headers map[string]string
+}
+
+func (t *customHeadersTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if len(t.headers) == 0 {
+		return t.next.RoundTrip(req)
+	}
+
+	// Clone the request so we don't mutate the caller's original.
+	req = req.Clone(req.Context())
+	for name, value := range t.headers {
+		req.Header.Set(name, value)
+	}
+
+	return t.next.RoundTrip(req)
+}
+
+// newCustomHeadersTransport wraps the given RoundTripper with injection of
+// the given custom headers on every request.
+func newCustomHeadersTransport(next http.RoundTripper, headers map[string]string) http.RoundTripper {
+	return &customHeadersTransport{next: next, headers: headers}
+}

--- a/internal/http/custom_headers_transport_test.go
+++ b/internal/http/custom_headers_transport_test.go
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: 2026 OVH SAS <opensource@ovh.net>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package http
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/maxatome/go-testdeep/td"
+)
+
+func TestCustomHeadersTransport_AppliesHeaders(t *testing.T) {
+	recorder := &recordingTransport{}
+	transport := newCustomHeadersTransport(recorder, map[string]string{
+		"X-Routing-Key": "internal-build-eu",
+	})
+
+	req, _ := http.NewRequest(http.MethodGet, "https://api.eu.ovhcloud.com/1.0/me", nil)
+	_, err := transport.RoundTrip(req)
+	td.Require(t).CmpNoError(err)
+	td.Cmp(t, recorder.req.Header.Get("X-Routing-Key"), "internal-build-eu")
+}
+
+func TestCustomHeadersTransport_NoopWhenEmpty(t *testing.T) {
+	recorder := &recordingTransport{}
+	transport := newCustomHeadersTransport(recorder, nil)
+
+	req, _ := http.NewRequest(http.MethodGet, "https://eu.api.ovh.com/v1/me", nil)
+	_, err := transport.RoundTrip(req)
+	td.Require(t).CmpNoError(err)
+	// Passed through untouched: same *http.Request instance, no headers added.
+	td.Cmp(t, recorder.req, req)
+}
+
+func TestCustomHeadersTransport_DoesNotMutateOriginal(t *testing.T) {
+	recorder := &recordingTransport{}
+	transport := newCustomHeadersTransport(recorder, map[string]string{"X-Routing-Key": "internal-build-eu"})
+
+	req, _ := http.NewRequest(http.MethodGet, "https://api.eu.ovhcloud.com/1.0/me", nil)
+	_, err := transport.RoundTrip(req)
+	td.Require(t).CmpNoError(err)
+	// The original request must not have been mutated.
+	td.Cmp(t, req.Header.Get("X-Routing-Key"), "")
+}

--- a/internal/services/baremetal/baremetal_test.go
+++ b/internal/services/baremetal/baremetal_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 OVH SAS <opensource@ovh.net>
+// SPDX-FileCopyrightText: 2026 OVH SAS <opensource@ovh.net>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -11,6 +11,8 @@ import (
 	"github.com/jarcoal/httpmock"
 	"github.com/maxatome/go-testdeep/td"
 	"github.com/ovh/go-ovh/ovh"
+	"github.com/ovh/ovhcloud-cli/internal/display"
+	"github.com/ovh/ovhcloud-cli/internal/flags"
 	httpLib "github.com/ovh/ovhcloud-cli/internal/http"
 )
 
@@ -68,4 +70,58 @@ func TestWaitForTask_TimeoutPrintsAReadableIdentifier(t *testing.T) {
 	td.Require(t).CmpError(err)
 	td.Cmp(t, err.Error(), td.Contains("156839472"))
 	td.Cmp(t, err.Error(), td.Not(td.Contains("%!")))
+}
+
+// baseBaremetalObject mirrors the keys GetBaremetal always sets on the
+// result map ("network", "serviceInfo", "tasks"), regardless of what the
+// dedicated server API response itself contains.
+func baseBaremetalObject() map[string]any {
+	return map[string]any{
+		"name":        "sd42-42",
+		"region":      "EU",
+		"os":          "debian12_64",
+		"state":       "ok",
+		"network":     map[string]any{},
+		"serviceInfo": map[string]any{},
+		"tasks":       []any{},
+	}
+}
+
+// Regression test: some endpoints (e.g. dev/staging environments) don't
+// populate "iam" on the dedicated server API response, either omitting the
+// key entirely or returning it as null. The baremetal.tmpl template used to
+// unconditionally chain-index into it (e.g. `index .Result "iam"
+// "displayName"`), which made text/template fail with "index of nil
+// pointer" as soon as "iam" was missing.
+func TestBaremetalTemplate_RendersWithoutIAM(t *testing.T) {
+	prevExitFunc := display.ExitFunc
+	display.ExitFunc = func(int) {}
+	t.Cleanup(func() { display.ExitFunc = prevExitFunc })
+
+	object := baseBaremetalObject()
+	// "iam" intentionally absent, as returned by some custom endpoints
+
+	display.ResultError = nil
+	display.OutputObject(object, "sd42-42", baremetalTemplate, &flags.OutputFormatConfig)
+
+	td.CmpNoError(t, display.ResultError)
+	td.Cmp(t, display.ResultString, td.Not(td.Contains("<no value>")))
+}
+
+func TestBaremetalTemplate_RendersWithIAM(t *testing.T) {
+	prevExitFunc := display.ExitFunc
+	display.ExitFunc = func(int) {}
+	t.Cleanup(func() { display.ExitFunc = prevExitFunc })
+
+	object := baseBaremetalObject()
+	object["iam"] = map[string]any{
+		"displayName": "my-server",
+		"urn":         "urn:v1:eu:resource:dedicatedServer:sd42-42",
+	}
+
+	display.ResultError = nil
+	display.OutputObject(object, "sd42-42", baremetalTemplate, &flags.OutputFormatConfig)
+
+	td.CmpNoError(t, display.ResultError)
+	td.Cmp(t, display.ResultString, td.Contains("my-server"))
 }

--- a/internal/services/baremetal/baremetal_test.go
+++ b/internal/services/baremetal/baremetal_test.go
@@ -1,0 +1,67 @@
+// SPDX-FileCopyrightText: 2026 OVH SAS <opensource@ovh.net>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package baremetal
+
+import (
+	"testing"
+
+	"github.com/maxatome/go-testdeep/td"
+	"github.com/ovh/ovhcloud-cli/internal/display"
+	"github.com/ovh/ovhcloud-cli/internal/flags"
+)
+
+// baseBaremetalObject mirrors the keys GetBaremetal always sets on the
+// result map ("network", "serviceInfo", "tasks"), regardless of what the
+// dedicated server API response itself contains.
+func baseBaremetalObject() map[string]any {
+	return map[string]any{
+		"name":        "sd42-42",
+		"region":      "EU",
+		"os":          "debian12_64",
+		"state":       "ok",
+		"network":     map[string]any{},
+		"serviceInfo": map[string]any{},
+		"tasks":       []any{},
+	}
+}
+
+// Regression test: some endpoints (e.g. dev/staging environments) don't
+// populate "iam" on the dedicated server API response, either omitting the
+// key entirely or returning it as null. The baremetal.tmpl template used to
+// unconditionally chain-index into it (e.g. `index .Result "iam"
+// "displayName"`), which made text/template fail with "index of nil
+// pointer" as soon as "iam" was missing.
+func TestBaremetalTemplate_RendersWithoutIAM(t *testing.T) {
+	prevExitFunc := display.ExitFunc
+	display.ExitFunc = func(int) {}
+	t.Cleanup(func() { display.ExitFunc = prevExitFunc })
+
+	object := baseBaremetalObject()
+	// "iam" intentionally absent, as returned by some custom endpoints
+
+	display.ResultError = nil
+	display.OutputObject(object, "sd42-42", baremetalTemplate, &flags.OutputFormatConfig)
+
+	td.CmpNoError(t, display.ResultError)
+	td.Cmp(t, display.ResultString, td.Not(td.Contains("<no value>")))
+}
+
+func TestBaremetalTemplate_RendersWithIAM(t *testing.T) {
+	prevExitFunc := display.ExitFunc
+	display.ExitFunc = func(int) {}
+	t.Cleanup(func() { display.ExitFunc = prevExitFunc })
+
+	object := baseBaremetalObject()
+	object["iam"] = map[string]any{
+		"displayName": "my-server",
+		"urn":         "urn:v1:eu:resource:dedicatedServer:sd42-42",
+	}
+
+	display.ResultError = nil
+	display.OutputObject(object, "sd42-42", baremetalTemplate, &flags.OutputFormatConfig)
+
+	td.CmpNoError(t, display.ResultError)
+	td.Cmp(t, display.ResultString, td.Contains("my-server"))
+}

--- a/internal/services/baremetal/templates/baremetal.tmpl
+++ b/internal/services/baremetal/templates/baremetal.tmpl
@@ -1,7 +1,14 @@
+{{- $iam := index .Result "iam" }}
+{{- $routing := "" }}
+{{- if index .Result "network" }}{{ $routing = index (index .Result "network") "routing" }}{{ end }}
+{{- $ipv6 := "" }}
+{{- if $routing }}{{ $ipv6 = index $routing "ipv6" }}{{ end }}
+{{- $renew := "" }}
+{{- if index .Result "serviceInfo" }}{{ $renew = index (index .Result "serviceInfo") "renew" }}{{ end }}
 🚀 Dedicated server {{.ServiceName}}
 =======
 
-_{{index .Result "iam" "displayName"}}_
+{{if $iam}}_{{index $iam "displayName"}}_{{end}}
 
 ## Location
 
@@ -17,7 +24,7 @@ _{{index .Result "iam" "displayName"}}_
 | State | {{index .Result "state"}} |
 | Operating system | {{index .Result "os"}} |
 | IPv4 | {{index .Result "ip"}} |
-{{if index .Result "network" "routing" "ipv6"}}| IPv6 | {{index .Result "network" "routing" "ipv6" "ip"}} |{{end}}
+{{if $ipv6}}| IPv6 | {{index $ipv6 "ip"}} |{{end}}
 | Reverse | {{index .Result "reverse"}} |
 | Power state | {{index .Result "powerState"}} |
 
@@ -34,17 +41,19 @@ _{{index .Result "iam" "displayName"}}_
 ## Billing information
 
 Expiration:        {{index .Result "serviceInfo" "expiration"}}
-Automatic renewal: {{index .Result "serviceInfo" "renew" "automatic"}}
+Automatic renewal: {{if $renew}}{{index $renew "automatic"}}{{end}}
 {{if index .Result "serviceInfo" "engagedUpTo"}}Engaged up to:     {{index .Result "serviceInfo" "engagedUpTo"}}{{end}}
 
+{{if $iam}}
 ## IAM information
 
-**URN**: {{index .Result "iam" "urn"}}
-{{if index .Result "iam" "tags"}}
+**URN**: {{index $iam "urn"}}
+{{if index $iam "tags"}}
 **Tags**:
 | Key | Value |
 | --- | --- |
-{{ range $key, $value := (index .Result "iam" "tags") }}| {{$key}} | {{$value}} |
+{{ range $key, $value := (index $iam "tags") }}| {{$key}} | {{$value}} |
+{{end}}
 {{end}}
 {{end}}
 

--- a/internal/services/config/config.go
+++ b/internal/services/config/config.go
@@ -84,3 +84,53 @@ func SetEndpoint(_ *cobra.Command, args []string) {
 		return
 	}
 }
+
+// SetHeader configures a custom HTTP header to be sent on every API request,
+// for the active profile, or for the currently configured endpoint in legacy mode.
+func SetHeader(_ *cobra.Command, args []string) {
+	name, value := args[0], args[1]
+	keyName := config.HeaderKeyPrefix + name
+
+	// In profile mode, write to the active profile section (unless it's the default profile)
+	if profileName := config.GetActiveProfileName(flags.CliConfig, flags.Profile); profileName != "" && !config.IsDefaultProfile(profileName) {
+		if err := config.SetProfileConfigValue(flags.CliConfig, flags.CliConfigPath, profileName, keyName, value); err != nil {
+			display.OutputError(&flags.OutputFormatConfig, "failed to set header %q: %s", name, err)
+		}
+		return
+	}
+
+	endpoint, err := config.GetConfigValue(flags.CliConfig, "default", "endpoint")
+	if err != nil || endpoint == "" {
+		display.OutputError(&flags.OutputFormatConfig, `no API endpoint configured, please run "ovhcloud login" first`)
+		return
+	}
+
+	if err := config.SetConfigValue(flags.CliConfig, flags.CliConfigPath, endpoint, keyName, value); err != nil {
+		display.OutputError(&flags.OutputFormatConfig, "failed to set header %q: %s", name, err)
+		return
+	}
+}
+
+// UnsetHeader removes a previously configured custom HTTP header.
+func UnsetHeader(_ *cobra.Command, args []string) {
+	name := args[0]
+	keyName := config.HeaderKeyPrefix + name
+
+	if profileName := config.GetActiveProfileName(flags.CliConfig, flags.Profile); profileName != "" && !config.IsDefaultProfile(profileName) {
+		if err := config.DeleteProfileConfigValue(flags.CliConfig, flags.CliConfigPath, profileName, keyName); err != nil {
+			display.OutputError(&flags.OutputFormatConfig, "failed to unset header %q: %s", name, err)
+		}
+		return
+	}
+
+	endpoint, err := config.GetConfigValue(flags.CliConfig, "default", "endpoint")
+	if err != nil || endpoint == "" {
+		display.OutputError(&flags.OutputFormatConfig, `no API endpoint configured, please run "ovhcloud login" first`)
+		return
+	}
+
+	if err := config.DeleteConfigValue(flags.CliConfig, flags.CliConfigPath, endpoint, keyName); err != nil {
+		display.OutputError(&flags.OutputFormatConfig, "failed to unset header %q: %s", name, err)
+		return
+	}
+}

--- a/internal/services/config/config_test.go
+++ b/internal/services/config/config_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/maxatome/go-testdeep/td"
+	baseconfig "github.com/ovh/ovhcloud-cli/internal/config"
 	"github.com/ovh/ovhcloud-cli/internal/display"
 	"github.com/ovh/ovhcloud-cli/internal/flags"
 	"gopkg.in/ini.v1"
@@ -58,10 +59,65 @@ func TestSetEndpoint_InvalidScheme(t *testing.T) {
 
 	// A value that isn't one of the known region names and isn't a
 	// valid http(s) URL (e.g. the menu label "Custom endpoint" that
-	// used to leak into this call, see the login package's regression
-	// test) must not be stored.
+	// used to leak into this call from the login flow) must not be stored.
 	SetEndpoint(nil, []string{"Custom endpoint"})
 
 	_, err := flags.CliConfig.Section("default").GetKey("endpoint")
 	td.CmpError(t, err)
+}
+
+func TestSetHeader_LegacyMode(t *testing.T) {
+	withTestConfig(t)
+
+	SetEndpoint(nil, []string{"https://api.eu.ovhcloud.com/1.0"})
+	SetHeader(nil, []string{"X-Routing-Key", "internal-build-eu"})
+
+	val, err := flags.CliConfig.Section("https://api.eu.ovhcloud.com/1.0").GetKey("header.X-Routing-Key")
+	td.Require(t).CmpNoError(err)
+	td.Cmp(t, val.String(), "internal-build-eu")
+}
+
+func TestSetHeader_LegacyMode_NoEndpoint(t *testing.T) {
+	withTestConfig(t)
+
+	// No endpoint configured yet: setting a header should fail cleanly,
+	// not write anything.
+	SetHeader(nil, []string{"X-Routing-Key", "internal-build-eu"})
+
+	val, err := baseconfig.GetConfigValue(flags.CliConfig, "default", "endpoint")
+	td.Require(t).CmpNoError(err)
+	td.Cmp(t, val, "")
+}
+
+func TestUnsetHeader_LegacyMode(t *testing.T) {
+	withTestConfig(t)
+
+	SetEndpoint(nil, []string{"https://api.eu.ovhcloud.com/1.0"})
+	SetHeader(nil, []string{"X-Routing-Key", "internal-build-eu"})
+	UnsetHeader(nil, []string{"X-Routing-Key"})
+
+	td.CmpFalse(t, flags.CliConfig.Section("https://api.eu.ovhcloud.com/1.0").HasKey("header.X-Routing-Key"))
+}
+
+func TestSetHeader_ProfileMode(t *testing.T) {
+	withTestConfig(t)
+	flags.CliConfig.Section("default").Key("profile").SetValue("work")
+	flags.CliConfig.Section("profile:work").Key("endpoint").SetValue("ovh-eu")
+
+	SetHeader(nil, []string{"X-Routing-Key", "internal-build-eu"})
+
+	val, err := flags.CliConfig.Section("profile:work").GetKey("header.X-Routing-Key")
+	td.Require(t).CmpNoError(err)
+	td.Cmp(t, val.String(), "internal-build-eu")
+}
+
+func TestUnsetHeader_ProfileMode(t *testing.T) {
+	withTestConfig(t)
+	flags.CliConfig.Section("default").Key("profile").SetValue("work")
+	flags.CliConfig.Section("profile:work").Key("endpoint").SetValue("ovh-eu")
+
+	SetHeader(nil, []string{"X-Routing-Key", "internal-build-eu"})
+	UnsetHeader(nil, []string{"X-Routing-Key"})
+
+	td.CmpFalse(t, flags.CliConfig.Section("profile:work").HasKey("header.X-Routing-Key"))
 }

--- a/internal/services/config/config_test.go
+++ b/internal/services/config/config_test.go
@@ -1,0 +1,123 @@
+// SPDX-FileCopyrightText: 2025 OVH SAS <opensource@ovh.net>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/maxatome/go-testdeep/td"
+	baseconfig "github.com/ovh/ovhcloud-cli/internal/config"
+	"github.com/ovh/ovhcloud-cli/internal/display"
+	"github.com/ovh/ovhcloud-cli/internal/flags"
+	"gopkg.in/ini.v1"
+)
+
+// withTestConfig points flags.CliConfig/CliConfigPath at a throwaway ini
+// file for the duration of the test, and stubs display.ExitFunc so that
+// display.OutputError (called on validation failure) doesn't os.Exit the
+// test binary. Everything is restored afterwards.
+func withTestConfig(t *testing.T) {
+	t.Helper()
+
+	prevConfig, prevPath, prevExitFunc := flags.CliConfig, flags.CliConfigPath, display.ExitFunc
+	flags.CliConfig = ini.Empty()
+	flags.CliConfigPath = filepath.Join(t.TempDir(), "test.conf")
+	display.ExitFunc = func(int) {}
+
+	t.Cleanup(func() {
+		flags.CliConfig, flags.CliConfigPath, display.ExitFunc = prevConfig, prevPath, prevExitFunc
+	})
+}
+
+func TestSetEndpoint_CustomURL(t *testing.T) {
+	withTestConfig(t)
+
+	// Regression test: a fully qualified custom endpoint URL must be
+	// accepted, not rejected as having an "invalid scheme".
+	SetEndpoint(nil, []string{"https://api.eu.ovhcloud.com/1.0"})
+
+	val, err := flags.CliConfig.Section("default").GetKey("endpoint")
+	td.Require(t).CmpNoError(err)
+	td.Cmp(t, val.String(), "https://api.eu.ovhcloud.com/1.0")
+}
+
+func TestSetEndpoint_Region(t *testing.T) {
+	withTestConfig(t)
+
+	SetEndpoint(nil, []string{"EU"})
+
+	val, err := flags.CliConfig.Section("default").GetKey("endpoint")
+	td.Require(t).CmpNoError(err)
+	td.Cmp(t, val.String(), "ovh-eu")
+}
+
+func TestSetEndpoint_InvalidScheme(t *testing.T) {
+	withTestConfig(t)
+
+	// A value that isn't one of the known region names and isn't a
+	// valid http(s) URL (e.g. the menu label "Custom endpoint" that
+	// used to leak into this call from the login flow) must not be stored.
+	SetEndpoint(nil, []string{"Custom endpoint"})
+
+	_, err := flags.CliConfig.Section("default").GetKey("endpoint")
+	td.CmpError(t, err)
+}
+
+func TestSetHeader_LegacyMode(t *testing.T) {
+	withTestConfig(t)
+
+	SetEndpoint(nil, []string{"https://api.eu.ovhcloud.com/1.0"})
+	SetHeader(nil, []string{"X-Routing-Key", "internal-build-eu"})
+
+	val, err := flags.CliConfig.Section("https://api.eu.ovhcloud.com/1.0").GetKey("header.X-Routing-Key")
+	td.Require(t).CmpNoError(err)
+	td.Cmp(t, val.String(), "internal-build-eu")
+}
+
+func TestSetHeader_LegacyMode_NoEndpoint(t *testing.T) {
+	withTestConfig(t)
+
+	// No endpoint configured yet: setting a header should fail cleanly,
+	// not write anything.
+	SetHeader(nil, []string{"X-Routing-Key", "internal-build-eu"})
+
+	val, err := baseconfig.GetConfigValue(flags.CliConfig, "default", "endpoint")
+	td.Require(t).CmpNoError(err)
+	td.Cmp(t, val, "")
+}
+
+func TestUnsetHeader_LegacyMode(t *testing.T) {
+	withTestConfig(t)
+
+	SetEndpoint(nil, []string{"https://api.eu.ovhcloud.com/1.0"})
+	SetHeader(nil, []string{"X-Routing-Key", "internal-build-eu"})
+	UnsetHeader(nil, []string{"X-Routing-Key"})
+
+	td.CmpFalse(t, flags.CliConfig.Section("https://api.eu.ovhcloud.com/1.0").HasKey("header.X-Routing-Key"))
+}
+
+func TestSetHeader_ProfileMode(t *testing.T) {
+	withTestConfig(t)
+	flags.CliConfig.Section("default").Key("profile").SetValue("work")
+	flags.CliConfig.Section("profile:work").Key("endpoint").SetValue("ovh-eu")
+
+	SetHeader(nil, []string{"X-Routing-Key", "internal-build-eu"})
+
+	val, err := flags.CliConfig.Section("profile:work").GetKey("header.X-Routing-Key")
+	td.Require(t).CmpNoError(err)
+	td.Cmp(t, val.String(), "internal-build-eu")
+}
+
+func TestUnsetHeader_ProfileMode(t *testing.T) {
+	withTestConfig(t)
+	flags.CliConfig.Section("default").Key("profile").SetValue("work")
+	flags.CliConfig.Section("profile:work").Key("endpoint").SetValue("ovh-eu")
+
+	SetHeader(nil, []string{"X-Routing-Key", "internal-build-eu"})
+	UnsetHeader(nil, []string{"X-Routing-Key"})
+
+	td.CmpFalse(t, flags.CliConfig.Section("profile:work").HasKey("header.X-Routing-Key"))
+}

--- a/internal/services/login/login.go
+++ b/internal/services/login/login.go
@@ -28,11 +28,18 @@ func Login(_ *cobra.Command, _ []string) {
 	customEndpoint := selectedRegion == "Custom endpoint"
 
 	credentials := display.RunLoginInput(customEndpoint)
+	rawHeaders := credentials["headers"]
+	delete(credentials, "headers")
+
 	for k, v := range credentials {
 		if v == "" {
 			display.OutputWarning(&flags.OutputFormatConfig, "no value provided for %q", k)
 			return
 		}
+	}
+
+	for name, value := range parseHeadersInput(rawHeaders) {
+		credentials[config.HeaderKeyPrefix+name] = value
 	}
 
 	// If no configuration file could be loaded, choose the location to write a new one
@@ -123,4 +130,36 @@ func legacyEndpointArg(selectedRegion, endpoint string, customEndpoint bool) str
 		return endpoint
 	}
 	return strings.ToUpper(selectedRegion)
+}
+
+// parseHeadersInput parses a raw "Name: value, Name2: value2" string (as
+// typed in the custom-endpoint login prompt) into a map of header name to
+// value. Blank input, or pairs missing a "name: value"/"name=value"
+// separator, are skipped.
+func parseHeadersInput(raw string) map[string]string {
+	headers := map[string]string{}
+
+	for _, pair := range strings.Split(raw, ",") {
+		pair = strings.TrimSpace(pair)
+		if pair == "" {
+			continue
+		}
+
+		name, value, ok := strings.Cut(pair, ":")
+		if !ok {
+			name, value, ok = strings.Cut(pair, "=")
+		}
+		if !ok {
+			continue
+		}
+
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+
+		headers[name] = strings.TrimSpace(value)
+	}
+
+	return headers
 }

--- a/internal/services/login/login.go
+++ b/internal/services/login/login.go
@@ -28,11 +28,18 @@ func Login(_ *cobra.Command, _ []string) {
 	customEndpoint := selectedRegion == "Custom endpoint"
 
 	credentials := display.RunLoginInput(customEndpoint)
+	rawHeaders := credentials["headers"]
+	delete(credentials, "headers")
+
 	for k, v := range credentials {
 		if v == "" {
 			display.OutputWarning(&flags.OutputFormatConfig, "no value provided for %q", k)
 			return
 		}
+	}
+
+	for name, value := range parseHeadersInput(rawHeaders) {
+		credentials[config.HeaderKeyPrefix+name] = value
 	}
 
 	// If no configuration file could be loaded, choose the location to write a new one
@@ -105,10 +112,7 @@ func Login(_ *cobra.Command, _ []string) {
 
 	// Legacy mode: store credentials in endpoint section
 	configSection := endpoint
-	if !customEndpoint {
-		selectedRegion = strings.ToUpper(selectedRegion)
-	}
-	serviceconfig.SetEndpoint(nil, []string{selectedRegion})
+	serviceconfig.SetEndpoint(nil, []string{legacyEndpointArg(selectedRegion, endpoint, customEndpoint)})
 
 	for k, v := range credentials {
 		if err := config.SetConfigValue(flags.CliConfig, flags.CliConfigPath, configSection, k, v); err != nil {
@@ -118,3 +122,44 @@ func Login(_ *cobra.Command, _ []string) {
 	}
 }
 
+// legacyEndpointArg returns the value to pass to serviceconfig.SetEndpoint
+// when saving credentials in legacy (non-profile) mode: the raw URL for a
+// custom endpoint, or the uppercased region name (EU/CA/US) otherwise.
+func legacyEndpointArg(selectedRegion, endpoint string, customEndpoint bool) string {
+	if customEndpoint {
+		return endpoint
+	}
+	return strings.ToUpper(selectedRegion)
+}
+
+// parseHeadersInput parses a raw "Name: value, Name2: value2" string (as
+// typed in the custom-endpoint login prompt) into a map of header name to
+// value. Blank input, or pairs missing a "name: value"/"name=value"
+// separator, are skipped.
+func parseHeadersInput(raw string) map[string]string {
+	headers := map[string]string{}
+
+	for _, pair := range strings.Split(raw, ",") {
+		pair = strings.TrimSpace(pair)
+		if pair == "" {
+			continue
+		}
+
+		name, value, ok := strings.Cut(pair, ":")
+		if !ok {
+			name, value, ok = strings.Cut(pair, "=")
+		}
+		if !ok {
+			continue
+		}
+
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+
+		headers[name] = strings.TrimSpace(value)
+	}
+
+	return headers
+}

--- a/internal/services/login/login_test.go
+++ b/internal/services/login/login_test.go
@@ -23,3 +23,21 @@ func TestLegacyEndpointArg_Region(t *testing.T) {
 	got := legacyEndpointArg("eu", "ovh-eu", false)
 	td.Cmp(t, got, "EU")
 }
+
+func TestParseHeadersInput(t *testing.T) {
+	got := parseHeadersInput("X-Routing-Key: internal-build-eu, X-Debug-Bypass=true")
+	td.Cmp(t, got, map[string]string{
+		"X-Routing-Key":  "internal-build-eu",
+		"X-Debug-Bypass": "true",
+	})
+}
+
+func TestParseHeadersInput_Blank(t *testing.T) {
+	td.Cmp(t, parseHeadersInput(""), map[string]string{})
+	td.Cmp(t, parseHeadersInput("   "), map[string]string{})
+}
+
+func TestParseHeadersInput_SkipsMalformedPairs(t *testing.T) {
+	got := parseHeadersInput("no-separator-here, X-Valid: ok, : no-name")
+	td.Cmp(t, got, map[string]string{"X-Valid": "ok"})
+}

--- a/internal/services/login/login_test.go
+++ b/internal/services/login/login_test.go
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: 2025 OVH SAS <opensource@ovh.net>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package login
+
+import (
+	"testing"
+
+	"github.com/maxatome/go-testdeep/td"
+)
+
+// Regression test for a bug where logging in with a custom endpoint stored
+// the picker's menu label ("Custom endpoint") instead of the URL typed by
+// the user, which made serviceconfig.SetEndpoint reject it with
+// `given url has an invalid scheme, only "http" and "https" are allowed`.
+func TestLegacyEndpointArg_CustomEndpoint(t *testing.T) {
+	got := legacyEndpointArg("Custom endpoint", "https://api.eu.ovhcloud.com/1.0", true)
+	td.Cmp(t, got, "https://api.eu.ovhcloud.com/1.0")
+}
+
+func TestLegacyEndpointArg_Region(t *testing.T) {
+	got := legacyEndpointArg("eu", "ovh-eu", false)
+	td.Cmp(t, got, "EU")
+}
+
+func TestParseHeadersInput(t *testing.T) {
+	got := parseHeadersInput("X-Routing-Key: internal-build-eu, X-Debug-Bypass=true")
+	td.Cmp(t, got, map[string]string{
+		"X-Routing-Key":  "internal-build-eu",
+		"X-Debug-Bypass": "true",
+	})
+}
+
+func TestParseHeadersInput_Blank(t *testing.T) {
+	td.Cmp(t, parseHeadersInput(""), map[string]string{})
+	td.Cmp(t, parseHeadersInput("   "), map[string]string{})
+}
+
+func TestParseHeadersInput_SkipsMalformedPairs(t *testing.T) {
+	got := parseHeadersInput("no-separator-here, X-Valid: ok, : no-name")
+	td.Cmp(t, got, map[string]string{"X-Valid": "ok"})
+}


### PR DESCRIPTION
# Description

Ability to specify some HTTP headers when using a custom endpoint.

Fixes #224 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] Improvement (improvement of existing commands)
- [x] Documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have commented my code
- [x] I ran `go mod tidy`
- [x] I have added tests that prove my fix is effective or that my feature works
