### PR TITLE
feat(CLI): fixed issues #220

### DIFF
--- a/internal/services/cloud/cloud_project.go
+++ b/internal/services/cloud/cloud_project.go
@@ -95,14 +95,8 @@ func getCloudRegionsWithFeatureAvailable(projectID string, features ...string) (
 	if err != nil {
 		return nil, err
 	}
-
-	// Filter regions having given feature available
 	var regionIDs []any
 	for _, region := range regions {
-		if region["status"] != "UP" {
-			continue
-		}
-
 		services := region["services"].([]any)
 		for _, service := range services {
 			service := service.(map[string]any)


### PR DESCRIPTION
# Description

`getCloudRegionsWithFeatureAvailable` skipped any region whose top-level `status`
was not `"UP"`, hiding regions that are `DOWN` overall but still expose `UP`
services (e.g. `CA-EAST-TOR` with `storage-s3-*` up). The region-level status
check is removed; filtering now relies only on the per-service `status == "UP"`.

Fixes #220 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Improvement (improvement of existing commands)
- [ ] Breaking change (fix or feature that can break a current behavior)
- [ ] Documentation update

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have commented my code
- [X] I ran `go mod tidy`
- [ ] I have added tests that prove my fix is effective or that my feature works
