### PR TITLE
feat(cli): added cmd logout

### DIFF
--- a/internal/cmd/logout.go
+++ b/internal/cmd/logout.go
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: 2025 OVH SAS <opensource@ovh.net>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"github.com/ovh/ovhcloud-cli/internal/config"
+	"github.com/ovh/ovhcloud-cli/internal/flags"
+	httplib "github.com/ovh/ovhcloud-cli/internal/http"
+	"github.com/ovh/ovhcloud-cli/internal/services/login"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	logoutCmd := &cobra.Command{
+		Use:     "logout",
+		Short:   "Revoke your API credentials and remove them from the configuration",
+		Example: "ovhcloud logout\novhcloud logout --yes\novhcloud logout --profile work",
+		Run:     login.Logout,
+	}
+
+	logoutCmd.Flags().BoolVarP(&login.LogoutAssumeYes, "yes", "y", false, "Do not ask for confirmation")
+
+	// Initialize the API client if possible, but — unlike other commands — do
+	// not abort when it cannot be initialized: logout must still be able to
+	// clean up local credentials even when they are already invalid or missing.
+	logoutCmd.PersistentPreRun = func(cmd *cobra.Command, args []string) {
+		config.ActiveProfileOverride = flags.Profile
+		if httplib.Client == nil {
+			httplib.InitClientWithProfile(flags.CliConfig, flags.Profile)
+		}
+	}
+
+	rootCmd.AddCommand(logoutCmd)
+}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -46,6 +46,7 @@ var (
 
 	wasmHiddenCommands = []string{
 		"login",
+		"logout",
 		"config",
 		"upgrade",
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -171,6 +171,32 @@ var ActiveProfileOverride string
 
 const profileSectionPrefix = "profile:"
 
+// CredentialKeys are the INI keys holding OVHcloud API credentials.
+var CredentialKeys = []string{"application_key", "application_secret", "consumer_key"}
+
+func ProfileSectionName(profileName string) string {
+	return profileSectionPrefix + profileName
+}
+
+// DeleteCredentials removes the API credential keys (application_key,
+// application_secret, consumer_key) 
+func DeleteCredentials(cfg *ini.File, path, sectionName string) error {
+	if path == "" {
+		path = ConfigPaths[0]
+	}
+
+	section, err := cfg.GetSection(sectionName)
+	if err != nil {
+		return fmt.Errorf("section %q not found in configuration: %w", sectionName, err)
+	}
+
+	for _, key := range CredentialKeys {
+		section.DeleteKey(key)
+	}
+
+	return cfg.SaveTo(path)
+}
+
 // DefaultProfileName is the reserved name for the legacy/default configuration.
 // It does not map to a [profile:default] section — instead it represents the
 // standard go-ovh configuration from [default] + [ovh-<endpoint>] sections.

--- a/internal/services/login/logout.go
+++ b/internal/services/login/logout.go
@@ -1,0 +1,82 @@
+// SPDX-FileCopyrightText: 2025 OVH SAS <opensource@ovh.net>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package login
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/ovh/ovhcloud-cli/internal/config"
+	"github.com/ovh/ovhcloud-cli/internal/display"
+	"github.com/ovh/ovhcloud-cli/internal/flags"
+	httpLib "github.com/ovh/ovhcloud-cli/internal/http"
+	"github.com/spf13/cobra"
+)
+
+// LogoutAssumeYes skips the confirmation prompt when set (via -y/--yes).
+var LogoutAssumeYes bool
+
+// Logout revokes the current API credentials server-side and removes them from
+// the local configuration file.
+func Logout(_ *cobra.Command, _ []string) {
+	cfg := flags.CliConfig
+	path := flags.CliConfigPath
+
+	if cfg == nil || path == "" {
+		display.OutputError(&flags.OutputFormatConfig, "no configuration file found, nothing to log out from")
+		return
+	}
+	
+	var section string
+	if profileName := config.GetActiveProfileName(cfg, flags.Profile); profileName != "" && !config.IsDefaultProfile(profileName) {
+		section = config.ProfileSectionName(profileName)
+	} else {
+		endpoint, err := config.GetConfigValue(cfg, "default", "endpoint")
+		if err != nil || endpoint == "" {
+			display.OutputError(&flags.OutputFormatConfig, "no endpoint configured, nothing to log out from")
+			return
+		}
+		section = endpoint
+	}
+
+	if !LogoutAssumeYes && !confirmLogout(section) {
+		display.OutputInfo(&flags.OutputFormatConfig, nil, "Logout cancelled")
+		return
+	}
+
+	// 1. Revoke the current credentials server-side (best effort): the
+	// credentials may already be invalid, in which case we still want to clean
+	// up the local configuration.
+	if httpLib.Client != nil {
+		if err := httpLib.Client.Post("/auth/logout", nil, nil); err != nil {
+			display.OutputWarning(&flags.OutputFormatConfig, "could not revoke credentials via the API (they may already be invalid): %s", err)
+		} else {
+			display.OutputInfo(&flags.OutputFormatConfig, nil, "🔒 API credentials revoked")
+		}
+	} else {
+		display.OutputWarning(&flags.OutputFormatConfig, "API client not initialized, skipping remote revocation")
+	}
+
+	// 2. Remove the credentials from the local configuration.
+	if err := config.DeleteCredentials(cfg, path, section); err != nil {
+		display.OutputError(&flags.OutputFormatConfig, "failed to remove credentials from configuration: %s", err)
+		return
+	}
+
+	display.OutputInfo(&flags.OutputFormatConfig, nil, "✅ Logged out successfully (credentials removed from %s)", path)
+}
+
+// confirmLogout asks the user to confirm the logout. It returns true only if
+// the user explicitly answers yes.
+func confirmLogout(section string) bool {
+	fmt.Fprintf(os.Stderr, "⚠️  This will revoke the current API credentials and remove them from section %q of your configuration.\nContinue? [y/N]: ", section)
+
+	answer, _ := bufio.NewReader(os.Stdin).ReadString('\n')
+	answer = strings.TrimSpace(strings.ToLower(answer))
+
+	return answer == "y" || answer == "yes"
+}

--- a/internal/services/login/logout.go
+++ b/internal/services/login/logout.go
@@ -6,10 +6,13 @@ package login
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
+	"net/http"
 	"os"
 	"strings"
 
+	"github.com/ovh/go-ovh/ovh"
 	"github.com/ovh/ovhcloud-cli/internal/config"
 	"github.com/ovh/ovhcloud-cli/internal/display"
 	"github.com/ovh/ovhcloud-cli/internal/flags"
@@ -30,7 +33,7 @@ func Logout(_ *cobra.Command, _ []string) {
 		display.OutputError(&flags.OutputFormatConfig, "no configuration file found, nothing to log out from")
 		return
 	}
-	
+
 	var section string
 	if profileName := config.GetActiveProfileName(cfg, flags.Profile); profileName != "" && !config.IsDefaultProfile(profileName) {
 		section = config.ProfileSectionName(profileName)
@@ -52,10 +55,13 @@ func Logout(_ *cobra.Command, _ []string) {
 	// credentials may already be invalid, in which case we still want to clean
 	// up the local configuration.
 	if httpLib.Client != nil {
-		if err := httpLib.Client.Post("/auth/logout", nil, nil); err != nil {
-			display.OutputWarning(&flags.OutputFormatConfig, "could not revoke credentials via the API (they may already be invalid): %s", err)
-		} else {
+		switch err := httpLib.Client.Post("/auth/logout", nil, nil); {
+		case err == nil:
 			display.OutputInfo(&flags.OutputFormatConfig, nil, "🔒 API credentials revoked")
+		case isInvalidCredentialError(err):
+			display.OutputWarning(&flags.OutputFormatConfig, "credentials were already invalid or revoked, skipping remote revocation")
+		default:
+			display.OutputWarning(&flags.OutputFormatConfig, "could not revoke credentials via the API: %s", err)
 		}
 	} else {
 		display.OutputWarning(&flags.OutputFormatConfig, "API client not initialized, skipping remote revocation")
@@ -70,13 +76,26 @@ func Logout(_ *cobra.Command, _ []string) {
 	display.OutputInfo(&flags.OutputFormatConfig, nil, "✅ Logged out successfully (credentials removed from %s)", path)
 }
 
-// confirmLogout asks the user to confirm the logout. It returns true only if
-// the user explicitly answers yes.
+// confirmLogout asks the user to confirm the logout. The default (an empty
+// answer, i.e. just pressing Enter) is "no": it returns true only if the user
+// explicitly answers "y"/"yes". The prompt can be skipped entirely with the
+// -y/--yes flag.
 func confirmLogout(section string) bool {
-	fmt.Fprintf(os.Stderr, "⚠️  This will revoke the current API credentials and remove them from section %q of your configuration.\nContinue? [y/N]: ", section)
+	fmt.Fprintf(os.Stderr,
+		"⚠️  This will revoke the current API credentials and remove them from section %q of your configuration.\n"+
+			"Continue? [y/N] (press Enter to cancel; use -y/--yes to skip this prompt): ",
+		section)
 
 	answer, _ := bufio.NewReader(os.Stdin).ReadString('\n')
 	answer = strings.TrimSpace(strings.ToLower(answer))
 
 	return answer == "y" || answer == "yes"
+}
+
+// isInvalidCredentialError reports whether err is an OVHcloud API error caused
+// by credentials that are already invalid or revoked (HTTP 401/403).
+func isInvalidCredentialError(err error) bool {
+	var apiErr *ovh.APIError
+	return errors.As(err, &apiErr) &&
+		(apiErr.Code == http.StatusUnauthorized || apiErr.Code == http.StatusForbidden)
 }

--- a/internal/services/login/logout_test.go
+++ b/internal/services/login/logout_test.go
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: 2026 OVH SAS <opensource@ovh.net>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package login
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/maxatome/go-testdeep/td"
+	"github.com/ovh/go-ovh/ovh"
+)
+
+func TestIsInvalidCredentialError(t *testing.T) {
+	testCases := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{"nil error", nil, false},
+		{"forbidden (403)", &ovh.APIError{Code: http.StatusForbidden}, true},
+		{"unauthorized (401)", &ovh.APIError{Code: http.StatusUnauthorized}, true},
+		{"other API error (500)", &ovh.APIError{Code: http.StatusInternalServerError}, false},
+		{"not found (404)", &ovh.APIError{Code: http.StatusNotFound}, false},
+		{"wrapped forbidden", fmt.Errorf("revoke failed: %w", &ovh.APIError{Code: http.StatusForbidden}), true},
+		{"plain error", errors.New("network unreachable"), false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			td.Cmp(t, isInvalidCredentialError(tc.err), tc.expected)
+		})
+	}
+}


### PR DESCRIPTION
# Description

Adds a `logout` command, the counterpart of `login`. It revokes the current API
credentials server-side (`POST /auth/logout`) and removes them from the local
configuration file (profile section in profile mode, legacy `[<endpoint>]`
section otherwise). A confirmation prompt is shown (skippable with `-y/--yes`),
and remote revocation is best-effort: if the credentials are already invalid,
the command warns and still cleans up the local config.

Fixes #195 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Improvement (improvement of existing commands)
- [ ] Breaking change (fix or feature that can break a current behavior)
- [ ] Documentation update

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have commented my code
- [X] I ran `go mod tidy`
- [ ] I have added tests that prove my fix is effective or that my feature works
