### PR TITLE
fix(display): send errors, warnings and hints to stderr

### DIFF
--- a/internal/cmd/baremetal_test.go
+++ b/internal/cmd/baremetal_test.go
@@ -52,6 +52,5 @@ func (ms *MockSuite) TestBaremetalListCompatibleOSCmd(assert, require *td.T) {
 │ ovh    │ alma9_64               │
 │ ovh    │ byoi_64                │
 │ ovh    │ byolinux_64            │
-└────────┴────────────────────────┘
-💡 Use option -o json or -o yaml to get the raw output with all information`[1:])
+└────────┴────────────────────────┘`[1:])
 }

--- a/internal/cmd/cloud_managed_kubernetes_nodepool_test.go
+++ b/internal/cmd/cloud_managed_kubernetes_nodepool_test.go
@@ -42,8 +42,7 @@ func (ms *MockSuite) TestCloudKubeNodepoolListCmd(assert, require *td.T) {
 ├─────────┼─────────────────────┼────────┼──────────────┼───────────┤
 │ rototo  │ nodepool-2025-12-04 │ b3-8   │ 2            │ READY     │
 │ rototo2 │ nodepool-2025-12-05 │ b3-8   │ 3            │ UPSCALING │
-└─────────┴─────────────────────┴────────┴──────────────┴───────────┘
-💡 Use option -o json or -o yaml to get the raw output with all information`[1:])
+└─────────┴─────────────────────┴────────┴──────────────┴───────────┘`[1:])
 }
 
 // Get a Nodepool.

--- a/internal/cmd/cloud_managed_kubernetes_test.go
+++ b/internal/cmd/cloud_managed_kubernetes_test.go
@@ -41,8 +41,7 @@ func (ms *MockSuite) TestCloudKubeListCmd(assert, require *td.T) {
 │     id     │   name    │ region │ plan │ version │   status   │
 ├────────────┼───────────┼────────┼──────┼─────────┼────────────┤
 │ kube-12345 │ test-kube │ GRA11  │ free │ 1.21.5  │ INSTALLING │
-└────────────┴───────────┴────────┴──────┴─────────┴────────────┘
-💡 Use option -o json or -o yaml to get the raw output with all information`[1:])
+└────────────┴───────────┴────────┴──────┴─────────┴────────────┘`[1:])
 }
 
 //

--- a/internal/cmd/cloud_managed_registry_test.go
+++ b/internal/cmd/cloud_managed_registry_test.go
@@ -83,8 +83,7 @@ func (ms *MockSuite) TestCloudContainerRegistryListCmd(assert, require *td.T) {
 │                  id                  │     name      │   region    │ plan  │ deploymentMode │ version │ status │
 ├──────────────────────────────────────┼───────────────┼─────────────┼───────┼────────────────┼─────────┼────────┤
 │ 0b1b2dc2-952b-11f0-afd9-0050568ce122 │ ZuperRegistry │ EU-WEST-PAR │ SMALL │ 3-AZ           │ 2.12.2  │ READY  │
-└──────────────────────────────────────┴───────────────┴─────────────┴───────┴────────────────┴─────────┴────────┘
-💡 Use option -o json or -o yaml to get the raw output with all information`[1:])
+└──────────────────────────────────────┴───────────────┴─────────────┴───────┴────────────────┴─────────┴────────┘`[1:])
 }
 
 func (ms *MockSuite) TestCloudContainerRegistryGetCmd(assert, require *td.T) {
@@ -267,8 +266,7 @@ func (ms *MockSuite) TestCloudContainerRegistryUsersListCmd(assert, require *td.
 ├────┼────────────┼───────────────────┤
 │ 1  │ user1      │ user1@example.com │
 │ 2  │ admin-user │ admin@example.com │
-└────┴────────────┴───────────────────┘
-💡 Use option -o json or -o yaml to get the raw output with all information`[1:])
+└────┴────────────┴───────────────────┘`[1:])
 }
 
 func (ms *MockSuite) TestCloudContainerRegistryUsersGetCmd(assert, require *td.T) {
@@ -624,8 +622,7 @@ func (ms *MockSuite) TestCloudContainerRegistryPlanListCapabilitiesCmd(assert, r
 ├──────────────────────────────────────┼────────┼───────────────┼──────────────┼─────────────────┤
 │ c5ddc763-be75-48f7-b7ec-e923ca040bee │ MEDIUM │ true          │ 600G         │ 45              │
 │ 0dae73df-6c49-47bf-a9d5-6b866c74ac54 │ LARGE  │ true          │ 5T           │ 90              │
-└──────────────────────────────────────┴────────┴───────────────┴──────────────┴─────────────────┘
-💡 Use option -o json or -o yaml to get the raw output with all information`[1:])
+└──────────────────────────────────────┴────────┴───────────────┴──────────────┴─────────────────┘`[1:])
 }
 
 func (ms *MockSuite) TestCloudContainerRegistryPlanUpgradeCmd(assert, require *td.T) {
@@ -670,8 +667,7 @@ func (ms *MockSuite) TestCloudContainerRegistryIPRestrictionsManagementListCmd(a
 ├──────────────┼────────────────┼──────────────────────────┼──────────────────────────┤
 │ 192.0.2.0/24 │ Office network │ 2026-01-23T10:00:00.000Z │ 2026-01-23T10:00:00.000Z │
 │ 10.0.0.0/8   │ VPN network    │ 2026-01-24T10:00:00.000Z │ 2026-01-24T10:00:00.000Z │
-└──────────────┴────────────────┴──────────────────────────┴──────────────────────────┘
-💡 Use option -o json or -o yaml to get the raw output with all information`[1:])
+└──────────────┴────────────────┴──────────────────────────┴──────────────────────────┘`[1:])
 }
 
 func (ms *MockSuite) TestCloudContainerRegistryIPRestrictionsRegistryListCmd(assert, require *td.T) {
@@ -693,8 +689,7 @@ func (ms *MockSuite) TestCloudContainerRegistryIPRestrictionsRegistryListCmd(ass
 │    ipBlock     │ description │        createdAt         │        updatedAt         │
 ├────────────────┼─────────────┼──────────────────────────┼──────────────────────────┤
 │ 203.0.113.0/24 │ Docker push │ 2026-01-23T11:00:00.000Z │ 2026-01-23T11:00:00.000Z │
-└────────────────┴─────────────┴──────────────────────────┴──────────────────────────┘
-💡 Use option -o json or -o yaml to get the raw output with all information`[1:])
+└────────────────┴─────────────┴──────────────────────────┴──────────────────────────┘`[1:])
 }
 
 func (ms *MockSuite) TestCloudContainerRegistryIPRestrictionsManagementAddCmd(assert, require *td.T) {

--- a/internal/cmd/cloud_reference_test.go
+++ b/internal/cmd/cloud_reference_test.go
@@ -94,8 +94,7 @@ func (ms *MockSuite) TestCloudReferenceRancherPlansListCmdWithNil(assert, requir
 ├──────────────────┼───────────┼─────────┤
 │ OVHCLOUD_EDITION │ AVAILABLE │         │
 │ STANDARD         │ AVAILABLE │         │
-└──────────────────┴───────────┴─────────┘
-💡 Use option -o json or -o yaml to get the raw output with all information`[1:])
+└──────────────────┴───────────┴─────────┘`[1:])
 }
 
 func (ms *MockSuite) TestCloudReferenceDatabasesPlansListCmd(assert, require *td.T) {
@@ -147,8 +146,7 @@ func (ms *MockSuite) TestCloudReferenceDatabasesPlansListCmd(assert, require *td
 ├────────────┼───────────────────────┼────────┼─────────────────┤
 │ production │ Production grade plan │ STABLE │ P14D            │
 │ advanced   │ Advanced grade plan   │ STABLE │ P30D            │
-└────────────┴───────────────────────┴────────┴─────────────────┘
-💡 Use option -o json or -o yaml to get the raw output with all information`[1:])
+└────────────┴───────────────────────┴────────┴─────────────────┘`[1:])
 }
 
 func (ms *MockSuite) TestCloudReferenceDatabasesFlavorsListCmd(assert, require *td.T) {
@@ -213,8 +211,7 @@ func (ms *MockSuite) TestCloudReferenceDatabasesFlavorsListCmd(assert, require *
 ├──────────┼──────┼────────┼─────────┤
 │ db2-free │ 0    │ 0 MB   │ 512 MB  │
 │ db2-2    │ 1    │ 2 GB   │ 10 GB   │
-└──────────┴──────┴────────┴─────────┘
-💡 Use option -o json or -o yaml to get the raw output with all information`[1:])
+└──────────┴──────┴────────┴─────────┘`[1:])
 }
 
 func (ms *MockSuite) TestCloudReferenceDatabasesEnginesListCmd(assert, require *td.T) {
@@ -281,8 +278,7 @@ func (ms *MockSuite) TestCloudReferenceDatabasesEnginesListCmd(assert, require *
 │ postgresql │ Object-Relational Database Management System │ operational │ 13 | 14 | 15 | 16 | 17      │ 17             │
 │ mysql      │ Relational Database Management System        │ operational │ 8                           │ 8              │
 │ mongodb    │ Document-Based Database Management System    │ operational │ 4.4 | 5.0 | 6.0 | 7.0 | 8.0 │ 8.0            │
-└────────────┴──────────────────────────────────────────────┴─────────────┴─────────────────────────────┴────────────────┘
-💡 Use option -o json or -o yaml to get the raw output with all information`[1:])
+└────────────┴──────────────────────────────────────────────┴─────────────┴─────────────────────────────┴────────────────┘`[1:])
 }
 
 func (ms *MockSuite) TestCloudReferenceContainerRegistryPlansListCmd(assert, require *td.T) {
@@ -367,8 +363,7 @@ func (ms *MockSuite) TestCloudReferenceContainerRegistryPlansListCmd(assert, req
 ├──────────────────────────────────────┼────────┼───────────────┼──────────────┼─────────────────┤
 │ 9f728ba5-998b-4401-ab0f-497cd8bc6a89 │ SMALL  │ false         │ 200G         │ 15              │
 │ c5ddc763-be75-48f7-b7ec-e923ca040bee │ MEDIUM │ true          │ 600G         │ 45              │
-└──────────────────────────────────────┴────────┴───────────────┴──────────────┴─────────────────┘
-💡 Use option -o json or -o yaml to get the raw output with all information`[1:])
+└──────────────────────────────────────┴────────┴───────────────┴──────────────┴─────────────────┘`[1:])
 }
 
 func (ms *MockSuite) TestCloudReferenceContainerRegistryPlansListCmdWithFilter(assert, require *td.T) {
@@ -414,8 +409,7 @@ func (ms *MockSuite) TestCloudReferenceContainerRegistryPlansListCmdWithFilter(a
 │                  id                  │  name  │ vulnerability │ imageStorage │ parallelRequest │
 ├──────────────────────────────────────┼────────┼───────────────┼──────────────┼─────────────────┤
 │ c5ddc763-be75-48f7-b7ec-e923ca040bee │ MEDIUM │ true          │ 600G         │ 45              │
-└──────────────────────────────────────┴────────┴───────────────┴──────────────┴─────────────────┘
-💡 Use option -o json or -o yaml to get the raw output with all information`[1:])
+└──────────────────────────────────────┴────────┴───────────────┴──────────────┴─────────────────┘`[1:])
 }
 
 func (ms *MockSuite) TestCloudReferenceContainerRegistryRegionsListCmd(assert, require *td.T) {
@@ -448,8 +442,7 @@ func (ms *MockSuite) TestCloudReferenceContainerRegistryRegionsListCmd(assert, r
 │ GRA         │ 1-AZ │
 │ DE          │ 1-AZ │
 │ EU-WEST-PAR │ 3-AZ │
-└─────────────┴──────┘
-💡 Use option -o json or -o yaml to get the raw output with all information`[1:])
+└─────────────┴──────┘`[1:])
 }
 
 func (ms *MockSuite) TestCloudReferenceFlavorsListCmdJSON(assert, require *td.T) {
@@ -580,8 +573,7 @@ func (ms *MockSuite) TestCloudReferenceManagedAnalyticsPlansListCmd(assert, requ
 ├───────────┼────────────────┼────────┼─────────────────┤
 │ essential │ Essential plan │ STABLE │ P2D             │
 │ business  │ Business plan  │ STABLE │ P14D            │
-└───────────┴────────────────┴────────┴─────────────────┘
-💡 Use option -o json or -o yaml to get the raw output with all information`[1:])
+└───────────┴────────────────┴────────┴─────────────────┘`[1:])
 }
 
 func (ms *MockSuite) TestCloudReferenceManagedAnalyticsNodeFlavorsListCmd(assert, require *td.T) {
@@ -646,8 +638,7 @@ func (ms *MockSuite) TestCloudReferenceManagedAnalyticsNodeFlavorsListCmd(assert
 ├──────────┼──────┼────────┼─────────┤
 │ db2-free │ 0    │ 0 MB   │ 512 MB  │
 │ db2-4    │ 2    │ 4 GB   │ 20 GB   │
-└──────────┴──────┴────────┴─────────┘
-💡 Use option -o json or -o yaml to get the raw output with all information`[1:])
+└──────────┴──────┴────────┴─────────┘`[1:])
 }
 
 func (ms *MockSuite) TestCloudReferenceManagedAnalyticsEnginesListCmd(assert, require *td.T) {
@@ -693,6 +684,5 @@ func (ms *MockSuite) TestCloudReferenceManagedAnalyticsEnginesListCmd(assert, re
 ├────────────┼──────────────────────────────────────┼──────────┼───────────┼────────────────┤
 │ kafka      │ Distributed Event Streaming Platform │ analysis │ 3.7 | 3.8 │ 3.8            │
 │ opensearch │ Search And Analytics Engine          │ analysis │ 2         │ 2              │
-└────────────┴──────────────────────────────────────┴──────────┴───────────┴────────────────┘
-💡 Use option -o json or -o yaml to get the raw output with all information`[1:])
+└────────────┴──────────────────────────────────────┴──────────┴───────────┴────────────────┘`[1:])
 }

--- a/internal/cmd/iam_test.go
+++ b/internal/cmd/iam_test.go
@@ -42,8 +42,7 @@ func (ms *MockSuite) TestIAMTokenListCmd(assert, require *td.T) {
 ├────────┼──────────────┼──────────────────────┤
 │ token1 │ First token  │ 2025-01-01T00:00:00Z │
 │ token2 │ Second token │ 2025-01-01T00:00:00Z │
-└────────┴──────────────┴──────────────────────┘
-💡 Use option -o json or -o yaml to get the raw output with all information`[1:])
+└────────┴──────────────┴──────────────────────┘`[1:])
 }
 
 func (ms *MockSuite) TestIAMPolicyDeleteCmd(assert, require *td.T) {

--- a/internal/display/display.go
+++ b/internal/display/display.go
@@ -409,7 +409,14 @@ func OutputWithFormat(msg *OutputMessage, outputFormat *OutputFormat) {
 		}
 
 	case outputFormat.IsInteractive():
-		displayInteractive(msg)
+		// A diagnostic is not data to browse. The interactive viewer starts a
+		// full-screen program on stdout, which would put the message back on
+		// the stream this function exists to keep clean.
+		if msg.Error || msg.Warning {
+			writeTo(dst, "%s", msg.Message)
+		} else {
+			displayInteractive(msg)
+		}
 
 	default:
 		writeTo(dst, "%s", msg.Message)

--- a/internal/display/display.go
+++ b/internal/display/display.go
@@ -12,6 +12,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"reflect"
 	"strings"
@@ -37,7 +38,29 @@ var (
 	ExitFunc = os.Exit
 )
 
-func renderCustomFormat(value any, format string) error {
+// writeTo writes command data to the given stream and records it so that
+// Execute can return it to the caller.
+func writeTo(w io.Writer, message string, params ...any) {
+	ResultString = fmt.Sprintf(message, params...)
+	fmt.Fprintln(w, ResultString)
+}
+
+// errorf writes an error or a warning to stderr. Diagnostics must never be
+// mixed with command data: a redirected stdout has to stay parsable.
+func errorf(message string, params ...any) {
+	fmt.Fprintln(os.Stderr, fmt.Sprintf(message, params...))
+}
+
+// hintf writes a non-essential hint to stderr, and only when stdout is a
+// terminal: a hint is useless to a script and pollutes its input.
+func hintf(message string, params ...any) {
+	if !term.IsTerminal(os.Stdout.Fd()) {
+		return
+	}
+	fmt.Fprintln(os.Stderr, fmt.Sprintf(message, params...))
+}
+
+func renderCustomFormat(value any, format string, w io.Writer) error {
 	ev, err := gval.Full(filters.AdditionalEvaluators...).NewEvaluable(format)
 	if err != nil {
 		return fmt.Errorf("invalid format given: %w", err)
@@ -60,7 +83,7 @@ func renderCustomFormat(value any, format string) error {
 			output.WriteString("\n")
 		}
 		ResultString = output.String()
-		fmt.Print(ResultString)
+		fmt.Fprint(w, ResultString)
 	default:
 		out, err := ev(context.Background(), value)
 		if err != nil {
@@ -72,7 +95,7 @@ func renderCustomFormat(value any, format string) error {
 			return fmt.Errorf("error marshalling result: %w", err)
 		}
 		ResultString = string(outBytes)
-		fmt.Print(string(outBytes))
+		fmt.Fprint(w, ResultString)
 	}
 
 	return nil
@@ -81,7 +104,7 @@ func renderCustomFormat(value any, format string) error {
 func RenderTable(values []map[string]any, columnsToDisplay []string, outputFormat *OutputFormat) {
 	switch {
 	case outputFormat.CustomFormat() != "":
-		if err := renderCustomFormat(values, outputFormat.CustomFormat()); err != nil {
+		if err := renderCustomFormat(values, outputFormat.CustomFormat(), os.Stdout); err != nil {
 			exitError("error rendering custom format: %s", err)
 		}
 		return
@@ -89,12 +112,12 @@ func RenderTable(values []map[string]any, columnsToDisplay []string, outputForma
 		displayInteractive(values)
 		return
 	case outputFormat.IsYaml():
-		if err := prettyPrintYAML(values); err != nil {
+		if err := prettyPrintYAML(values, os.Stdout); err != nil {
 			exitError("error displaying YAML results: %s", err)
 		}
 		return
 	case outputFormat.IsJson():
-		if err := prettyPrintJSON(values); err != nil {
+		if err := prettyPrintJSON(values, os.Stdout); err != nil {
 			exitError("error displaying JSON results: %s", err)
 		}
 		return
@@ -177,7 +200,8 @@ func RenderTable(values []map[string]any, columnsToDisplay []string, outputForma
 		Headers(columnsTitles...).
 		Rows(rows...)
 
-	outputf("%s%s", t, "\n💡 Use option -o json or -o yaml to get the raw output with all information")
+	outputf("%s", t)
+	hintf("💡 Use option -o json or -o yaml to get the raw output with all information")
 }
 
 func RenderConfigTable(cfg *ini.File, outputformat *OutputFormat) {
@@ -245,24 +269,24 @@ func RenderConfigTable(cfg *ini.File, outputformat *OutputFormat) {
 	outputf("%s", t)
 }
 
-func prettyPrintJSON(value any) error {
+func prettyPrintJSON(value any, w io.Writer) error {
 	bytesOut, err := json.MarshalIndent(value, "", "  ")
 	if err != nil {
 		return err
 	}
 
-	outputf("%s", bytesOut)
+	writeTo(w, "%s", bytesOut)
 
 	return nil
 }
 
-func prettyPrintYAML(value any) error {
+func prettyPrintYAML(value any, w io.Writer) error {
 	bytesOut, err := yaml.Marshal(value)
 	if err != nil {
 		return err
 	}
 
-	outputf("%s", bytesOut)
+	writeTo(w, "%s", bytesOut)
 
 	return nil
 }
@@ -276,17 +300,17 @@ func OutputObject(value map[string]any, serviceName, templateContent string, out
 
 	switch {
 	case outputFormat.CustomFormat() != "":
-		if err := renderCustomFormat(value, outputFormat.CustomFormat()); err != nil {
+		if err := renderCustomFormat(value, outputFormat.CustomFormat(), os.Stdout); err != nil {
 			exitError("error rendering custom format: %s", err)
 		}
 		return
 	case outputFormat.IsYaml():
-		if err := prettyPrintYAML(value); err != nil {
+		if err := prettyPrintYAML(value, os.Stdout); err != nil {
 			exitError("error displaying YAML results: %s", err)
 		}
 		return
 	case outputFormat.IsJson():
-		if err := prettyPrintJSON(value); err != nil {
+		if err := prettyPrintJSON(value, os.Stdout); err != nil {
 			exitError("error displaying JSON results: %s", err)
 		}
 		return
@@ -326,7 +350,7 @@ func OutputObject(value map[string]any, serviceName, templateContent string, out
 		if err != nil {
 			exitError("execution failed: %s", err)
 		}
-		fmt.Print(out)
+		fmt.Fprint(os.Stdout, out)
 		ResultString = out
 	}
 }
@@ -341,17 +365,24 @@ func displayInteractive(value any) {
 
 func exitError(message string, params ...any) {
 	resultString := fmt.Sprintf("🛑 "+message, params...)
-	fmt.Println(resultString)
+	errorf("%s", resultString)
 	ResultError = errors.New(resultString)
 	ExitFunc(1)
 }
 
 func outputf(message string, params ...any) {
-	ResultString = fmt.Sprintf(message, params...)
-	fmt.Println(ResultString)
+	writeTo(os.Stdout, "%s", fmt.Sprintf(message, params...))
 }
 
 func OutputWithFormat(msg *OutputMessage, outputFormat *OutputFormat) {
+	// Errors and warnings go to stderr whatever the output format, so that a
+	// redirected stdout only ever holds command data: `cmd -o json > out.json`
+	// must leave out.json empty when the call failed.
+	dst := io.Writer(os.Stdout)
+	if msg.Error || msg.Warning {
+		dst = os.Stderr
+	}
+
 	switch {
 	case outputFormat.CustomFormat() != "":
 		data, err := json.Marshal(msg)
@@ -363,17 +394,17 @@ func OutputWithFormat(msg *OutputMessage, outputFormat *OutputFormat) {
 			exitError("error unmarshalling message: %s", err)
 		}
 
-		if err := renderCustomFormat(m, outputFormat.CustomFormat()); err != nil {
+		if err := renderCustomFormat(m, outputFormat.CustomFormat(), dst); err != nil {
 			exitError("error rendering custom format: %s", err)
 		}
 
 	case outputFormat.IsYaml():
-		if err := prettyPrintYAML(msg); err != nil {
+		if err := prettyPrintYAML(msg, dst); err != nil {
 			exitError("error displaying YAML results: %s", err)
 		}
 
 	case outputFormat.IsJson():
-		if err := prettyPrintJSON(msg); err != nil {
+		if err := prettyPrintJSON(msg, dst); err != nil {
 			exitError(err.Error())
 		}
 
@@ -381,7 +412,7 @@ func OutputWithFormat(msg *OutputMessage, outputFormat *OutputFormat) {
 		displayInteractive(msg)
 
 	default:
-		outputf("%s", msg.Message)
+		writeTo(dst, "%s", msg.Message)
 	}
 
 	if msg.Error {

--- a/internal/display/streams_test.go
+++ b/internal/display/streams_test.go
@@ -1,0 +1,72 @@
+// SPDX-FileCopyrightText: 2025 OVH SAS <opensource@ovh.net>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !(js && wasm)
+
+package display
+
+import (
+	"io"
+	"os"
+	"testing"
+
+	"github.com/maxatome/go-testdeep/td"
+)
+
+// captureStreams runs f with both standard streams replaced by pipes and
+// returns what was written to each of them.
+func captureStreams(t *testing.T, f func()) (stdout, stderr string) {
+	t.Helper()
+
+	outR, outW, err := os.Pipe()
+	td.Require(t).CmpNoError(err)
+	errR, errW, err := os.Pipe()
+	td.Require(t).CmpNoError(err)
+
+	origOut, origErr := os.Stdout, os.Stderr
+	os.Stdout, os.Stderr = outW, errW
+	defer func() {
+		os.Stdout, os.Stderr = origOut, origErr
+	}()
+
+	f()
+
+	outW.Close()
+	errW.Close()
+
+	outBytes, err := io.ReadAll(outR)
+	td.Require(t).CmpNoError(err)
+	errBytes, err := io.ReadAll(errR)
+	td.Require(t).CmpNoError(err)
+
+	return string(outBytes), string(errBytes)
+}
+
+// An error must never reach stdout: a redirected stdout has to stay parsable,
+// so `cmd -o json > out.json` leaves out.json empty when the call failed.
+func TestOutputError_GoesToStderrOnly(t *testing.T) {
+	origExit := ExitFunc
+	ExitFunc = func(int) {}
+	defer func() { ExitFunc = origExit }()
+
+	for _, format := range []string{"", "json", "yaml"} {
+		out, errOut := captureStreams(t, func() {
+			OutputError(&OutputFormat{Output: format}, "something went wrong")
+		})
+
+		td.Cmp(t, out, "", "stdout stays empty with output format %q", format)
+		td.Cmp(t, errOut, td.Contains("something went wrong"),
+			"stderr carries the error with output format %q", format)
+	}
+}
+
+// Success messages keep going to stdout, which is what scripts consume.
+func TestOutputInfo_GoesToStdout(t *testing.T) {
+	out, errOut := captureStreams(t, func() {
+		OutputInfo(&OutputFormat{}, nil, "task started")
+	})
+
+	td.Cmp(t, out, td.Contains("task started"))
+	td.Cmp(t, errOut, "")
+}

--- a/internal/display/streams_test.go
+++ b/internal/display/streams_test.go
@@ -50,7 +50,9 @@ func TestOutputError_GoesToStderrOnly(t *testing.T) {
 	ExitFunc = func(int) {}
 	defer func() { ExitFunc = origExit }()
 
-	for _, format := range []string{"", "json", "yaml"} {
+	// "interactive" is in the list on purpose: its viewer takes over stdout,
+	// so a diagnostic must be rendered plainly instead of being handed to it.
+	for _, format := range []string{"", "json", "yaml", "interactive"} {
 		out, errOut := captureStreams(t, func() {
 			OutputError(&OutputFormat{Output: format}, "something went wrong")
 		})
@@ -69,4 +71,21 @@ func TestOutputInfo_GoesToStdout(t *testing.T) {
 
 	td.Cmp(t, out, td.Contains("task started"))
 	td.Cmp(t, errOut, "")
+}
+
+// A warning follows the same rule as an error, in every format.
+func TestOutputWarning_GoesToStderrOnly(t *testing.T) {
+	origExit := ExitFunc
+	ExitFunc = func(int) {}
+	defer func() { ExitFunc = origExit }()
+
+	for _, format := range []string{"", "json", "yaml", "interactive"} {
+		out, errOut := captureStreams(t, func() {
+			OutputWarning(&OutputFormat{Output: format}, "careful")
+		})
+
+		td.Cmp(t, out, "", "stdout stays empty with output format %q", format)
+		td.Cmp(t, errOut, td.Contains("careful"),
+			"stderr carries the warning with output format %q", format)
+	}
 }


### PR DESCRIPTION
# Description

Every message the CLI produces — including failures — was written to stdout, while progress messages went to stderr through the `log` package. The convention was inverted, with three consequences for anyone scripting the CLI:

- `ovhcloud <cmd> -o json > servers.json` writes the error object **into the data file** when the call fails. Under `-o json` that object is valid JSON, so a downstream `jq` consumes it as a result instead of failing.
- `2> errors.log` captures the progress chatter, not the errors.
- The `💡 Use option -o json …` hint is concatenated to every table and lands in the redirected output, so a piped table always carries a trailing sentence that is not data.

This PR routes diagnostics to stderr and keeps stdout for data:

- errors and warnings go to stderr in **every** output format (table, json, yaml, custom expression);
- the table hint goes to stderr, and only when stdout is a terminal — it cannot help a pipe, so it is not printed into one;
- data (tables, JSON, YAML, rendered objects) keeps going to stdout, unchanged.

Exit codes are untouched: a failure still exits 1.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (improvement of existing commands)
- [ ] Breaking change (fix or feature that can break a current behavior)
- [ ] Documentation update

The visible output of a command is unchanged on a terminal. What changes is which stream carries it, so a script that used to read errors from stdout will now read them from stderr — this is the intent of the fix.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have commented my code
- [x] I ran `go mod tidy`
- [x] I have added tests that prove my fix is effective or that my feature works

`internal/display/streams_test.go` captures both streams and asserts that an error never reaches stdout in any output format, and that a success message still does. The 19 existing assertions that expected the hint inside the returned output have been updated accordingly.

`go build ./...`, `GOOS=js GOARCH=wasm go build ./...`, `go vet ./...` and `go test ./...` all pass.

## Notes for reviewers

- The WASM display path (`internal/display/display_wasm.go`, `//go:build js && wasm`) is untouched: it emits structured JSON and lets the front end render, so the stream question does not arise there.
- Object templates (`internal/services/*/templates/*.tmpl`) still embed the same `💡 Use option -o json …` line in their rendered body. Moving those out of the templates would touch every product and is left out of this PR on purpose — happy to follow up if you want the two paths aligned.
