### PR TITLE
feat(baremetal): add boot set-disk and surface the active boot entry

### DIFF
--- a/doc/ovhcloud_baremetal_boot_set-disk.md
+++ b/doc/ovhcloud_baremetal_boot_set-disk.md
@@ -1,11 +1,27 @@
-## ovhcloud baremetal boot
+## ovhcloud baremetal boot set-disk
 
-Manage boot options for the given baremetal
+Configure the given baremetal to boot on its hard disk
+
+### Synopsis
+
+Restore the hard disk boot entry of the given dedicated server.
+
+This is the counterpart of "baremetal reboot-rescue": a server left with the
+rescue boot entry will come back in rescue mode at its next reboot, whatever
+triggers it. The change applies at the next reboot:
+
+	ovhcloud baremetal boot set-disk ns1234.ip-11.22.33.net
+	ovhcloud baremetal reboot ns1234.ip-11.22.33.net
+
+
+```
+ovhcloud baremetal boot set-disk <service_name> [flags]
+```
 
 ### Options
 
 ```
-  -h, --help   help for boot
+  -h, --help   help for set-disk
 ```
 
 ### Options inherited from parent commands
@@ -29,9 +45,5 @@ Manage boot options for the given baremetal
 
 ### SEE ALSO
 
-* [ovhcloud baremetal](ovhcloud_baremetal.md)	 - Retrieve information and manage your Bare Metal services
-* [ovhcloud baremetal boot list](ovhcloud_baremetal_boot_list.md)	 - List boot options for the given baremetal
-* [ovhcloud baremetal boot set](ovhcloud_baremetal_boot_set.md)	 - Configure a boot ID on the given baremetal
-* [ovhcloud baremetal boot set-disk](ovhcloud_baremetal_boot_set-disk.md)	 - Configure the given baremetal to boot on its hard disk
-* [ovhcloud baremetal boot set-script](ovhcloud_baremetal_boot_set-script.md)	 - Configure a boot script on the given baremetal
+* [ovhcloud baremetal boot](ovhcloud_baremetal_boot.md)	 - Manage boot options for the given baremetal
 

--- a/internal/cmd/baremetal.go
+++ b/internal/cmd/baremetal.go
@@ -180,6 +180,23 @@ Please note that all parameters are not compatible with all OSes.
 		Run:               baremetal.SetBaremetalBootId,
 	})
 
+	baremetalBootCmd.AddCommand(&cobra.Command{
+		Use:   "set-disk <service_name>",
+		Short: "Configure the given baremetal to boot on its hard disk",
+		Long: `Restore the hard disk boot entry of the given dedicated server.
+
+This is the counterpart of "baremetal reboot-rescue": a server left with the
+rescue boot entry will come back in rescue mode at its next reboot, whatever
+triggers it. The change applies at the next reboot:
+
+	ovhcloud baremetal boot set-disk ns1234.ip-11.22.33.net
+	ovhcloud baremetal reboot ns1234.ip-11.22.33.net
+`,
+		Args:              cobra.ExactArgs(1),
+		ValidArgsFunction: completion.ServiceList("/v1/dedicated/server"),
+		Run:               baremetal.SetBaremetalBootDisk,
+	})
+
 	baremetalBootSetScriptCmd := &cobra.Command{
 		Use:               "set-script <service_name>",
 		Short:             "Configure a boot script on the given baremetal",

--- a/internal/cmd/baremetal_test.go
+++ b/internal/cmd/baremetal_test.go
@@ -5,6 +5,8 @@
 package cmd_test
 
 import (
+	"strings"
+
 	"github.com/jarcoal/httpmock"
 	"github.com/maxatome/go-testdeep/td"
 	"github.com/ovh/ovhcloud-cli/internal/cmd"
@@ -179,4 +181,69 @@ func (ms *MockSuite) TestBaremetalGetCmdWarnsAboutRescueBoot(assert, require *td
 	require.CmpNoError(err)
 	assert.Cmp(out, td.Contains("rescue"))
 	assert.Cmp(out, td.Contains("boot set-disk"))
+}
+
+// registerBootListResponders wires the calls made by `baremetal boot list`:
+// the list of boot identifiers, one object per entry, and the options of each.
+func registerBootListResponders() {
+	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/v1/dedicated/server/fakeBaremetal/boot",
+		httpmock.NewStringResponder(200, `[1, 1122]`),
+	)
+	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/v1/dedicated/server/fakeBaremetal/boot/1",
+		httpmock.NewStringResponder(200, `{"bootId": 1, "bootType": "harddisk", "description": "Boot on hard disk", "kernel": ""}`),
+	)
+	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/v1/dedicated/server/fakeBaremetal/boot/1122",
+		httpmock.NewStringResponder(200, `{"bootId": 1122, "bootType": "rescue", "description": "rescue64-pro", "kernel": "rescue"}`),
+	)
+	for _, id := range []string{"1", "1122"} {
+		httpmock.RegisterResponder("GET",
+			"https://eu.api.ovh.com/v1/dedicated/server/fakeBaremetal/boot/"+id+"/option",
+			httpmock.NewStringResponder(200, `[]`),
+		)
+	}
+}
+
+// The marker is the whole point of the column: without it, a server left in
+// rescue mode looks exactly like one booting on its disk.
+func (ms *MockSuite) TestBaremetalBootListCmdMarksTheActiveEntry(assert, require *td.T) {
+	registerBootListResponders()
+	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/v1/dedicated/server/fakeBaremetal",
+		httpmock.NewStringResponder(200, `{"name": "fakeBaremetal", "bootId": 1122}`),
+	)
+
+	out, err := cmd.Execute("baremetal", "boot", "list", "fakeBaremetal")
+
+	require.CmpNoError(err)
+	// The identifier comes first, as in every other service list.
+	assert.Cmp(out, td.Contains("bootId"))
+	// Only the rescue entry, which the server is set to boot on, is marked.
+	rescue := lineContaining(out, "rescue64-pro")
+	disk := lineContaining(out, "Boot on hard disk")
+	assert.Cmp(rescue, td.Contains("→"), "the active entry carries the marker")
+	assert.Cmp(disk, td.Not(td.Contains("→")), "the other entries do not")
+}
+
+// Reading the current boot is best effort: if the server cannot be fetched,
+// the listing must still answer, without claiming an entry is active.
+func (ms *MockSuite) TestBaremetalBootListCmdSurvivesServerLookupFailure(assert, require *td.T) {
+	registerBootListResponders()
+	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/v1/dedicated/server/fakeBaremetal",
+		httpmock.NewStringResponder(403, `{"message": "This call has not been granted"}`),
+	)
+
+	out, err := cmd.Execute("baremetal", "boot", "list", "fakeBaremetal")
+
+	require.CmpNoError(err)
+	assert.Cmp(out, td.Contains("rescue64-pro"), "the listing still answers")
+	assert.Cmp(out, td.Not(td.Contains("→")), "no entry is claimed active")
+}
+
+// lineContaining returns the first line of out holding needle, or "".
+func lineContaining(out, needle string) string {
+	for _, line := range strings.Split(out, "\n") {
+		if strings.Contains(line, needle) {
+			return line
+		}
+	}
+	return ""
 }

--- a/internal/cmd/baremetal_test.go
+++ b/internal/cmd/baremetal_test.go
@@ -116,3 +116,67 @@ func (ms *MockSuite) TestBaremetalReinstallSucceedsOnDoneTask(assert, require *t
 
 	require.CmpNoError(err)
 }
+
+func (ms *MockSuite) TestBaremetalBootSetDiskCmd(assert, require *td.T) {
+	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/v1/dedicated/server/fakeBaremetal/boot?bootType=harddisk",
+		httpmock.NewStringResponder(200, `[1]`),
+	)
+	httpmock.RegisterResponder("PUT", "https://eu.api.ovh.com/v1/dedicated/server/fakeBaremetal",
+		httpmock.NewStringResponder(200, `null`),
+	)
+
+	out, err := cmd.Execute("baremetal", "boot", "set-disk", "fakeBaremetal")
+
+	require.CmpNoError(err)
+	assert.Contains(out, "set to boot on its hard disk")
+}
+
+func (ms *MockSuite) TestBaremetalBootSetDiskCmdNoEntry(assert, require *td.T) {
+	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/v1/dedicated/server/fakeBaremetal/boot?bootType=harddisk",
+		httpmock.NewStringResponder(200, `[]`),
+	)
+
+	_, err := cmd.Execute("baremetal", "boot", "set-disk", "fakeBaremetal")
+
+	require.CmpError(err)
+	assert.Cmp(err.Error(), td.Contains("no hard disk boot entry found"))
+}
+
+// A server left with the rescue boot entry comes back in rescue at its next
+// reboot: the sheet must say so.
+func (ms *MockSuite) TestBaremetalGetCmdWarnsAboutRescueBoot(assert, require *td.T) {
+	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/v1/dedicated/server/fakeBaremetal",
+		httpmock.NewStringResponder(200, `{
+			"name": "fakeBaremetal",
+			"bootId": 1122,
+			"os": "debian12_64",
+			"state": "ok",
+			"powerState": "poweron",
+			"ip": "1.2.3.4",
+			"reverse": "fake.example.net",
+			"region": "eu-west",
+			"availabilityZone": "eu-west-gra-a",
+			"datacenter": "gra3",
+			"rack": "G123A01",
+			"iam": {"displayName": "fake", "urn": "urn:v1:eu:resource:dedicatedServer:fakeBaremetal"}
+		}`),
+	)
+	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/v1/dedicated/server/fakeBaremetal/task",
+		httpmock.NewStringResponder(200, `[]`),
+	)
+	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/v1/dedicated/server/fakeBaremetal/specifications/network",
+		httpmock.NewStringResponder(200, `{"routing": {"ipv6": null}}`),
+	)
+	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/v1/dedicated/server/fakeBaremetal/serviceInfos",
+		httpmock.NewStringResponder(200, `{"expiration": "2026-11-04", "renew": {"automatic": true}}`),
+	)
+	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/v1/dedicated/server/fakeBaremetal/boot/1122",
+		httpmock.NewStringResponder(200, `{"bootId": 1122, "bootType": "rescue", "description": "rescue64-pro", "kernel": "rescue"}`),
+	)
+
+	out, err := cmd.Execute("baremetal", "get", "fakeBaremetal")
+
+	require.CmpNoError(err)
+	assert.Cmp(out, td.Contains("rescue"))
+	assert.Cmp(out, td.Contains("boot set-disk"))
+}

--- a/internal/services/baremetal/baremetal.go
+++ b/internal/services/baremetal/baremetal.go
@@ -458,7 +458,7 @@ func ListBaremetalBoots(_ *cobra.Command, args []string) {
 		return
 	}
 
-	display.RenderTable(boots, []string{"active", "bootId", "bootType", "description", "kernel"}, &flags.OutputFormatConfig)
+	display.RenderTable(boots, []string{"bootId", "active", "bootType", "description", "kernel"}, &flags.OutputFormatConfig)
 }
 
 // SetBaremetalBootDisk restores the hard disk boot entry. Without it, leaving

--- a/internal/services/baremetal/baremetal.go
+++ b/internal/services/baremetal/baremetal.go
@@ -6,6 +6,7 @@ package baremetal
 
 import (
 	_ "embed"
+	"encoding/json"
 	"fmt"
 	"io"
 	"log"
@@ -121,6 +122,17 @@ func GetBaremetal(_ *cobra.Command, args []string) {
 		return
 	}
 	object["serviceInfo"] = serviceInfo
+
+	// Resolve the configured boot entry so that the sheet says whether the
+	// server starts on its disk or in rescue mode. Best-effort: a server whose
+	// boot entry cannot be read is still worth displaying.
+	if bootID, ok := jsonInt(object["bootId"]); ok {
+		path = fmt.Sprintf("/v1/dedicated/server/%s/boot/%d", url.PathEscape(args[0]), bootID)
+		var boot map[string]any
+		if err := httpLib.Client.Get(path, &boot); err == nil {
+			object["currentBoot"] = boot
+		}
+	}
 
 	display.OutputObject(object, args[0], baremetalTemplate, &flags.OutputFormatConfig)
 }
@@ -375,6 +387,40 @@ func ListBaremetalInterventions(_ *cobra.Command, args []string) {
 	display.RenderTable(plannedInterventions, []string{"type", "date", "status"}, &flags.OutputFormatConfig)
 }
 
+// jsonInt reads a numeric value coming from an API response. The API client
+// decodes with UseNumber, so a number stored in a map[string]any is a
+// json.Number, never a float64.
+func jsonInt(value any) (int64, bool) {
+	switch n := value.(type) {
+	case json.Number:
+		i, err := n.Int64()
+		return i, err == nil
+	case float64:
+		return int64(n), true
+	case int64:
+		return n, true
+	case int:
+		return int64(n), true
+	}
+
+	return 0, false
+}
+
+// fetchCurrentBootID returns the boot entry the server is currently
+// configured to start on. It is best-effort: a failure here must not prevent
+// the caller from displaying what it already fetched.
+func fetchCurrentBootID(serviceName string) (int64, bool) {
+	var server struct {
+		BootID int64 `json:"bootId"`
+	}
+	path := fmt.Sprintf("/v1/dedicated/server/%s", url.PathEscape(serviceName))
+	if err := httpLib.Client.Get(path, &server); err != nil {
+		return 0, false
+	}
+
+	return server.BootID, true
+}
+
 func ListBaremetalBoots(_ *cobra.Command, args []string) {
 	path := fmt.Sprintf("/v1/dedicated/server/%s/boot", url.PathEscape(args[0]))
 
@@ -383,6 +429,8 @@ func ListBaremetalBoots(_ *cobra.Command, args []string) {
 		display.OutputError(&flags.OutputFormatConfig, "error fetching boot options for server %q: %s", args[0], err)
 		return
 	}
+
+	currentBootID, hasCurrent := fetchCurrentBootID(args[0])
 
 	for _, boot := range boots {
 		path = fmt.Sprintf("/v1/dedicated/server/%s/boot/%s/option", url.PathEscape(args[0]), boot["bootId"])
@@ -394,6 +442,14 @@ func ListBaremetalBoots(_ *cobra.Command, args []string) {
 		}
 
 		boot["options"] = options
+
+		// Without this column, nothing in the CLI tells which entry the
+		// server will actually start on: a server left in rescue mode looks
+		// exactly like one booting on its disk.
+		boot["active"] = ""
+		if bootID, ok := jsonInt(boot["bootId"]); ok && hasCurrent && bootID == currentBootID {
+			boot["active"] = "→"
+		}
 	}
 
 	boots, err = filtersLib.FilterLines(boots, flags.GenericFilters)
@@ -402,7 +458,38 @@ func ListBaremetalBoots(_ *cobra.Command, args []string) {
 		return
 	}
 
-	display.RenderTable(boots, []string{"bootId", "bootType", "description", "kernel"}, &flags.OutputFormatConfig)
+	display.RenderTable(boots, []string{"active", "bootId", "bootType", "description", "kernel"}, &flags.OutputFormatConfig)
+}
+
+// SetBaremetalBootDisk restores the hard disk boot entry. Without it, leaving
+// rescue mode means listing boot entries, recognising the harddisk one and
+// setting its identifier by hand — and a server forgotten in rescue mode
+// silently comes back in rescue at the next reboot.
+func SetBaremetalBootDisk(_ *cobra.Command, args []string) {
+	endpoint := fmt.Sprintf("/v1/dedicated/server/%s/boot?bootType=harddisk", url.PathEscape(args[0]))
+
+	var boots []int
+	if err := httpLib.Client.Get(endpoint, &boots); err != nil {
+		display.OutputError(&flags.OutputFormatConfig, "failed to fetch boot options: %s", err)
+		return
+	}
+
+	if len(boots) == 0 {
+		display.OutputError(&flags.OutputFormatConfig, "no hard disk boot entry found for server %s", args[0])
+		return
+	}
+
+	endpoint = fmt.Sprintf("/v1/dedicated/server/%s", url.PathEscape(args[0]))
+	if err := httpLib.Client.Put(endpoint, map[string]any{
+		"bootId": boots[0],
+	}, nil); err != nil {
+		display.OutputError(&flags.OutputFormatConfig, "failed to set hard disk boot for server %s: %s", args[0], err)
+		return
+	}
+
+	display.OutputInfo(&flags.OutputFormatConfig, nil,
+		"✅ Server %s is set to boot on its hard disk. Reboot to apply: ovhcloud baremetal reboot %s",
+		args[0], args[0])
 }
 
 func SetBaremetalBootId(_ *cobra.Command, args []string) {

--- a/internal/services/baremetal/templates/baremetal.tmpl
+++ b/internal/services/baremetal/templates/baremetal.tmpl
@@ -20,6 +20,12 @@ _{{index .Result "iam" "displayName"}}_
 {{if index .Result "network" "routing" "ipv6"}}| IPv6 | {{index .Result "network" "routing" "ipv6" "ip"}} |{{end}}
 | Reverse | {{index .Result "reverse"}} |
 | Power state | {{index .Result "powerState"}} |
+{{with index .Result "currentBoot"}}| Boot | {{.bootType}} — {{.description}} |{{end}}
+
+{{with index .Result "currentBoot"}}{{if eq .bootType "rescue"}}
+> ⚠️ This server is configured to boot in **rescue** mode: any reboot will come back in rescue, not in production.
+> Restore the disk boot with `ovhcloud baremetal boot set-disk {{index $.Result "name"}}`.
+{{end}}{{end}}
 
 
 {{if index .Result "tasks"}}


### PR DESCRIPTION
# Description

`baremetal reboot-rescue` writes the rescue boot entry into the server configuration and reboots. Nothing ever restores it, and no command does the opposite: leaving rescue mode today means running `boot list`, recognising the `harddisk` entry among the results, and passing its identifier to `boot set` by hand.

Until that is done, the server is *configured* to boot in rescue. Any later reboot — a kernel panic, a hardware intervention, a scheduled restart — silently brings it back into rescue instead of production, possibly weeks after the intervention that put it there.

Nothing in the CLI surfaced that state either: neither `get` nor `boot list` told which entry the server would start on.

This PR adds the missing counterpart and makes the state visible:

- **`baremetal boot set-disk <server>`** restores the hard disk boot entry;
- **`boot list`** marks the entry the server is currently configured to start on;
- **`get`** displays the configured boot, and warns explicitly when it is a rescue one, with the command to undo it.

```
$ ovhcloud baremetal boot list ns1234.ip-11.22.33.net
   ACTIVE  BOOT ID  BOOTTYPE  DESCRIPTION          KERNEL
           1        harddisk  Boot sur disque dur
   →       1122     rescue    rescue64-pro         rescue

$ ovhcloud baremetal boot set-disk ns1234.ip-11.22.33.net
✅ Server ns1234.ip-11.22.33.net is set to boot on its hard disk. Reboot to apply: ovhcloud baremetal reboot ns1234.ip-11.22.33.net
```

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Improvement (improvement of existing commands)
- [ ] Breaking change (fix or feature that can break a current behavior)
- [ ] Documentation update

`boot list` gains an `ACTIVE` column, and `get` gains a `Boot` row plus a warning block. No existing command changes its behaviour.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have commented my code
- [x] I ran `go mod tidy`
- [x] I have added tests that prove my fix is effective or that my feature works

Three tests in `internal/cmd/baremetal_test.go`: `boot set-disk` on a server that has a hard disk entry, the same on a server that has none (must fail with a clear message), and a `get` on a server configured in rescue, which must warn and name the command that fixes it.

`go build ./...`, `GOOS=js GOARCH=wasm go build ./...`, `go vet ./...` and `go test ./...` all pass.

## Notes for reviewers

- Resolving the current boot entry in `get` costs one extra API call and is **best-effort**: if `/boot/{bootId}` cannot be read, the sheet is still displayed without the boot row, rather than failing entirely.
- `boot list` resolves the current boot identifier through `GET /dedicated/server/{serviceName}`; when that call fails, entries are listed without the `ACTIVE` marker instead of erroring out.
- Numeric values coming from API responses are `json.Number`, not `float64`, because the client decodes with `UseNumber()` — the identifier comparison goes through a small helper that handles both, otherwise the marker never matches.
