### PR TITLE
feat(baremetal): add credentials create, mask secrets by default

### DIFF
--- a/doc/ovhcloud_baremetal.md
+++ b/doc/ovhcloud_baremetal.md
@@ -31,6 +31,7 @@ Retrieve information and manage your Bare Metal services
 
 * [ovhcloud](ovhcloud.md)	 - CLI to manage your OVHcloud services
 * [ovhcloud baremetal boot](ovhcloud_baremetal_boot.md)	 - Manage boot options for the given baremetal
+* [ovhcloud baremetal credentials](ovhcloud_baremetal_credentials.md)	 - Manage access credentials of the given baremetal
 * [ovhcloud baremetal edit](ovhcloud_baremetal_edit.md)	 - Update the given baremetal
 * [ovhcloud baremetal get](ovhcloud_baremetal_get.md)	 - Retrieve information of a specific baremetal
 * [ovhcloud baremetal ipmi](ovhcloud_baremetal_ipmi.md)	 - Manage IPMI on your baremetal
@@ -38,7 +39,6 @@ Retrieve information and manage your Bare Metal services
 * [ovhcloud baremetal list-compatible-os](ovhcloud_baremetal_list-compatible-os.md)	 - Retrieve OSes that can be installed on this baremetal
 * [ovhcloud baremetal list-interventions](ovhcloud_baremetal_list-interventions.md)	 - List past and planned interventions for the given baremetal
 * [ovhcloud baremetal list-ips](ovhcloud_baremetal_list-ips.md)	 - List all IPs that are routed to the given baremetal
-* [ovhcloud baremetal list-secrets](ovhcloud_baremetal_list-secrets.md)	 - Retrieve secrets to connect to the server
 * [ovhcloud baremetal list-tasks](ovhcloud_baremetal_list-tasks.md)	 - Retrieve tasks of the given baremetal
 * [ovhcloud baremetal reboot](ovhcloud_baremetal_reboot.md)	 - Reboot the given baremetal
 * [ovhcloud baremetal reboot-rescue](ovhcloud_baremetal_reboot-rescue.md)	 - Reboot the given baremetal in rescue mode

--- a/doc/ovhcloud_baremetal_credentials.md
+++ b/doc/ovhcloud_baremetal_credentials.md
@@ -30,5 +30,5 @@ Manage access credentials of the given baremetal
 ### SEE ALSO
 
 * [ovhcloud baremetal](ovhcloud_baremetal.md)	 - Retrieve information and manage your Bare Metal services
-* [ovhcloud baremetal credentials get](ovhcloud_baremetal_credentials_get.md)	 - Request access credentials for the given baremetal
+* [ovhcloud baremetal credentials create](ovhcloud_baremetal_credentials_create.md)	 - Generate new access credentials for the given baremetal
 

--- a/doc/ovhcloud_baremetal_credentials.md
+++ b/doc/ovhcloud_baremetal_credentials.md
@@ -1,0 +1,34 @@
+## ovhcloud baremetal credentials
+
+Manage access credentials of the given baremetal
+
+### Options
+
+```
+  -h, --help   help for credentials
+```
+
+### Options inherited from parent commands
+
+```
+  -d, --debug            Activate debug mode (will log all HTTP requests details)
+  -e, --ignore-errors    Ignore errors in API calls when it is not fatal to the execution
+  -o, --output string    Output format: json, yaml, interactive, or a custom format expression (using https://github.com/PaesslerAG/gval syntax)
+                         Examples:
+                           --output json
+                           --output yaml
+                           --output interactive
+                           --output 'id' (to extract a single field)
+                           --output 'nested.field.subfield' (to extract a nested field)
+                           --output '[id, "name"]' (to extract multiple fields as an array)
+                           --output '{"newKey": oldKey, "otherKey": nested.field}' (to extract and rename fields in an object)
+                           --output 'name+","+type' (to extract and concatenate fields in a string)
+                           --output '(nbFieldA + nbFieldB) * 10' (to compute values from numeric fields)
+      --profile string   Use a specific profile from the configuration file
+```
+
+### SEE ALSO
+
+* [ovhcloud baremetal](ovhcloud_baremetal.md)	 - Retrieve information and manage your Bare Metal services
+* [ovhcloud baremetal credentials get](ovhcloud_baremetal_credentials_get.md)	 - Request access credentials for the given baremetal
+

--- a/doc/ovhcloud_baremetal_credentials_create.md
+++ b/doc/ovhcloud_baremetal_credentials_create.md
@@ -1,17 +1,18 @@
-## ovhcloud baremetal credentials get
+## ovhcloud baremetal credentials create
 
-Request access credentials for the given baremetal
+Generate new access credentials for the given baremetal
 
 ### Synopsis
 
-Request access credentials for the given dedicated server.
+Generate new access credentials for the given dedicated server.
 
-This command is a write operation: it asks the API to generate a new access
-secret. Values are masked unless --reveal is given, in every output format.
+This command performs a write: it calls POST /authenticationSecret, whose IAM
+action is authenticationSecret/create, and returns the credentials it just
+generated. Values are masked unless --reveal is given, in every output format.
 
 
 ```
-ovhcloud baremetal credentials get <service_name> [flags]
+ovhcloud baremetal credentials create <service_name> [flags]
 ```
 
 ### Options
@@ -24,7 +25,7 @@ ovhcloud baremetal credentials get <service_name> [flags]
                                --filter 'nested.property.subproperty>10'
                                --filter 'startDate>="2023-12-01"'
                                --filter 'name=~"something" && nbField>10'
-  -h, --help                 help for get
+  -h, --help                 help for create
       --reveal               Print secret values instead of masking them
 ```
 

--- a/doc/ovhcloud_baremetal_credentials_get.md
+++ b/doc/ovhcloud_baremetal_credentials_get.md
@@ -1,9 +1,17 @@
-## ovhcloud baremetal list-secrets
+## ovhcloud baremetal credentials get
 
-Retrieve secrets to connect to the server
+Request access credentials for the given baremetal
+
+### Synopsis
+
+Request access credentials for the given dedicated server.
+
+This command is a write operation: it asks the API to generate a new access
+secret. Values are masked unless --reveal is given, in every output format.
+
 
 ```
-ovhcloud baremetal list-secrets <service_name> [flags]
+ovhcloud baremetal credentials get <service_name> [flags]
 ```
 
 ### Options
@@ -16,7 +24,8 @@ ovhcloud baremetal list-secrets <service_name> [flags]
                                --filter 'nested.property.subproperty>10'
                                --filter 'startDate>="2023-12-01"'
                                --filter 'name=~"something" && nbField>10'
-  -h, --help                 help for list-secrets
+  -h, --help                 help for get
+      --reveal               Print secret values instead of masking them
 ```
 
 ### Options inherited from parent commands
@@ -40,5 +49,5 @@ ovhcloud baremetal list-secrets <service_name> [flags]
 
 ### SEE ALSO
 
-* [ovhcloud baremetal](ovhcloud_baremetal.md)	 - Retrieve information and manage your Bare Metal services
+* [ovhcloud baremetal credentials](ovhcloud_baremetal_credentials.md)	 - Manage access credentials of the given baremetal
 

--- a/doc/ovhcloud_baremetal_reboot-rescue.md
+++ b/doc/ovhcloud_baremetal_reboot-rescue.md
@@ -9,8 +9,9 @@ ovhcloud baremetal reboot-rescue <service_name> [flags]
 ### Options
 
 ```
-  -h, --help   help for reboot-rescue
-      --wait   Wait for reboot to be done before exiting
+  -h, --help     help for reboot-rescue
+      --reveal   Print the secret values fetched after --wait instead of masking them
+      --wait     Wait for reboot to be done before exiting
 ```
 
 ### Options inherited from parent commands

--- a/doc/ovhcloud_baremetal_reinstall.md
+++ b/doc/ovhcloud_baremetal_reinstall.md
@@ -71,6 +71,7 @@ ovhcloud baremetal reinstall <service_name> [flags]
       --post-installation-script string             Post-installation script
       --post-installation-script-extension string   Post-installation script extension (cmd, ps1)
       --replace                                     Replace parameters file if it already exists
+      --reveal                                      Print the secret values fetched after --wait instead of masking them
       --ssh-key string                              SSH public key
       --wait                                        Wait for reinstall to be done before exiting
 ```

--- a/internal/cmd/baremetal.go
+++ b/internal/cmd/baremetal.go
@@ -211,13 +211,41 @@ Please note that all parameters are not compatible with all OSes.
 		Run:               baremetal.GetBaremetalRelatedIPs,
 	}))
 
-	baremetalCmd.AddCommand(withFilterFlag(&cobra.Command{
-		Use:               "list-secrets <service_name>",
-		Short:             "Retrieve secrets to connect to the server",
+	// Commands to manage server credentials. The former "list-secrets" name
+	// suggested a read: the call actually asks the API for a new access
+	// secret, so the command now lives under an explicit verb.
+	baremetalCredentialsCmd := &cobra.Command{
+		Use:   "credentials",
+		Short: "Manage access credentials of the given baremetal",
+	}
+	baremetalCmd.AddCommand(baremetalCredentialsCmd)
+
+	baremetalCredentialsGetCmd := &cobra.Command{
+		Use:   "get <service_name>",
+		Short: "Request access credentials for the given baremetal",
+		Long: `Request access credentials for the given dedicated server.
+
+This command is a write operation: it asks the API to generate a new access
+secret. Values are masked unless --reveal is given, in every output format.
+`,
 		Args:              cobra.ExactArgs(1),
 		ValidArgsFunction: completion.ServiceList("/v1/dedicated/server"),
 		Run:               baremetal.GetBaremetalAuthenticationSecrets,
-	}))
+	}
+	baremetalCredentialsGetCmd.Flags().BoolVar(&baremetal.BaremetalRevealSecrets, "reveal", false, "Print secret values instead of masking them")
+	baremetalCredentialsCmd.AddCommand(withFilterFlag(baremetalCredentialsGetCmd))
+
+	// Deprecated alias kept so that existing scripts keep working.
+	baremetalListSecretsCmd := &cobra.Command{
+		Use:               "list-secrets <service_name>",
+		Short:             "Retrieve secrets to connect to the server",
+		Deprecated:        "use \"ovhcloud baremetal credentials get\" instead.",
+		Args:              cobra.ExactArgs(1),
+		ValidArgsFunction: completion.ServiceList("/v1/dedicated/server"),
+		Run:               baremetal.GetBaremetalAuthenticationSecrets,
+	}
+	baremetalListSecretsCmd.Flags().BoolVar(&baremetal.BaremetalRevealSecrets, "reveal", false, "Print secret values instead of masking them")
+	baremetalCmd.AddCommand(withFilterFlag(baremetalListSecretsCmd))
 
 	baremetalCmd.AddCommand(withFilterFlag(&cobra.Command{
 		Use:               "list-compatible-os <service_name>",

--- a/internal/cmd/baremetal.go
+++ b/internal/cmd/baremetal.go
@@ -85,6 +85,10 @@ func init() {
 		Run:               baremetal.RebootRescueBaremetal,
 	}
 	baremetalRebootRescueCmd.Flags().BoolVar(&flags.WaitForTask, "wait", false, "Wait for reboot to be done before exiting")
+	// --wait ends by fetching the credentials that the reboot generated, so
+	// the reveal choice has to exist here too: without it the values would be
+	// masked with no way to opt in.
+	baremetalRebootRescueCmd.Flags().BoolVar(&baremetal.BaremetalRevealSecrets, "reveal", false, "Print the secret values fetched after --wait instead of masking them")
 	baremetalCmd.AddCommand(baremetalRebootRescueCmd)
 
 	// Command to reinstall a baremetal
@@ -155,6 +159,9 @@ Please note that all parameters are not compatible with all OSes.
 	reinstallBaremetalCmd.Flags().StringVar(&baremetal.Customizations.PostInstallationScriptExtension, "post-installation-script-extension", "", "Post-installation script extension (cmd, ps1)")
 	reinstallBaremetalCmd.Flags().StringVar(&baremetal.Customizations.SshKey, "ssh-key", "", "SSH public key")
 	reinstallBaremetalCmd.Flags().BoolVar(&flags.WaitForTask, "wait", false, "Wait for reinstall to be done before exiting")
+	// Same reason as reboot-rescue: --wait ends by fetching the credentials
+	// the reinstall generated.
+	reinstallBaremetalCmd.Flags().BoolVar(&baremetal.BaremetalRevealSecrets, "reveal", false, "Print the secret values fetched after --wait instead of masking them")
 	markFlagsMutuallyExclusive(reinstallBaremetalCmd, "from-file", "editor")
 	baremetalCmd.AddCommand(reinstallBaremetalCmd)
 
@@ -220,26 +227,27 @@ Please note that all parameters are not compatible with all OSes.
 	}
 	baremetalCmd.AddCommand(baremetalCredentialsCmd)
 
-	baremetalCredentialsGetCmd := &cobra.Command{
-		Use:   "get <service_name>",
-		Short: "Request access credentials for the given baremetal",
-		Long: `Request access credentials for the given dedicated server.
+	baremetalCredentialsCreateCmd := &cobra.Command{
+		Use:   "create <service_name>",
+		Short: "Generate new access credentials for the given baremetal",
+		Long: `Generate new access credentials for the given dedicated server.
 
-This command is a write operation: it asks the API to generate a new access
-secret. Values are masked unless --reveal is given, in every output format.
+This command performs a write: it calls POST /authenticationSecret, whose IAM
+action is authenticationSecret/create, and returns the credentials it just
+generated. Values are masked unless --reveal is given, in every output format.
 `,
 		Args:              cobra.ExactArgs(1),
 		ValidArgsFunction: completion.ServiceList("/v1/dedicated/server"),
 		Run:               baremetal.GetBaremetalAuthenticationSecrets,
 	}
-	baremetalCredentialsGetCmd.Flags().BoolVar(&baremetal.BaremetalRevealSecrets, "reveal", false, "Print secret values instead of masking them")
-	baremetalCredentialsCmd.AddCommand(withFilterFlag(baremetalCredentialsGetCmd))
+	baremetalCredentialsCreateCmd.Flags().BoolVar(&baremetal.BaremetalRevealSecrets, "reveal", false, "Print secret values instead of masking them")
+	baremetalCredentialsCmd.AddCommand(withFilterFlag(baremetalCredentialsCreateCmd))
 
 	// Deprecated alias kept so that existing scripts keep working.
 	baremetalListSecretsCmd := &cobra.Command{
 		Use:               "list-secrets <service_name>",
 		Short:             "Retrieve secrets to connect to the server",
-		Deprecated:        "use \"ovhcloud baremetal credentials get\" instead.",
+		Deprecated:        "use \"ovhcloud baremetal credentials create\" instead.",
 		Args:              cobra.ExactArgs(1),
 		ValidArgsFunction: completion.ServiceList("/v1/dedicated/server"),
 		Run:               baremetal.GetBaremetalAuthenticationSecrets,

--- a/internal/cmd/baremetal_test.go
+++ b/internal/cmd/baremetal_test.go
@@ -127,10 +127,10 @@ func mockCredentialsResponders() {
 }
 
 // A secret must not be printed unless it was explicitly asked for.
-func (ms *MockSuite) TestBaremetalCredentialsGetMasksByDefault(assert, require *td.T) {
+func (ms *MockSuite) TestBaremetalCredentialsCreateMasksByDefault(assert, require *td.T) {
 	mockCredentialsResponders()
 
-	out, err := cmd.Execute("baremetal", "credentials", "get", "fakeBaremetal")
+	out, err := cmd.Execute("baremetal", "credentials", "create", "fakeBaremetal")
 
 	require.CmpNoError(err)
 	assert.Cmp(out, td.Not(td.Contains("Tk9uY2VQYXNzMTIz")), "the secret value must not be printed")
@@ -139,19 +139,19 @@ func (ms *MockSuite) TestBaremetalCredentialsGetMasksByDefault(assert, require *
 
 // Masking applies to machine-readable formats too: a secret written into a
 // JSON file in a pipeline leaks as much as one scrolled in a terminal.
-func (ms *MockSuite) TestBaremetalCredentialsGetMasksJSONOutput(assert, require *td.T) {
+func (ms *MockSuite) TestBaremetalCredentialsCreateMasksJSONOutput(assert, require *td.T) {
 	mockCredentialsResponders()
 
-	out, err := cmd.Execute("baremetal", "credentials", "get", "fakeBaremetal", "-o", "json")
+	out, err := cmd.Execute("baremetal", "credentials", "create", "fakeBaremetal", "-o", "json")
 
 	require.CmpNoError(err)
 	assert.Cmp(out, td.Not(td.Contains("Tk9uY2VQYXNzMTIz")))
 }
 
-func (ms *MockSuite) TestBaremetalCredentialsGetRevealsOnDemand(assert, require *td.T) {
+func (ms *MockSuite) TestBaremetalCredentialsCreateRevealsOnDemand(assert, require *td.T) {
 	mockCredentialsResponders()
 
-	out, err := cmd.Execute("baremetal", "credentials", "get", "fakeBaremetal", "--reveal")
+	out, err := cmd.Execute("baremetal", "credentials", "create", "fakeBaremetal", "--reveal")
 
 	require.CmpNoError(err)
 	assert.Cmp(out, td.Contains("Tk9uY2VQYXNzMTIz"))
@@ -165,4 +165,33 @@ func (ms *MockSuite) TestBaremetalListSecretsAliasStillWorks(assert, require *td
 
 	require.CmpNoError(err)
 	assert.Cmp(out, td.Contains("••••"))
+}
+
+// The command must fail loudly when the secret cannot be retrieved, and must
+// not print anything that looks like credential material on the way out.
+func (ms *MockSuite) TestBaremetalCredentialsCreateFailsWithoutLeaking(assert, require *td.T) {
+	httpmock.RegisterResponder("POST", "https://eu.api.ovh.com/v1/dedicated/server/fakeBaremetal/authenticationSecret",
+		httpmock.NewStringResponder(200, `[{"type":"password","user":"root","password":"secret-id-1"}]`),
+	)
+	httpmock.RegisterResponder("POST", "https://eu.api.ovh.com/v1/secret/retrieve",
+		httpmock.NewStringResponder(500, `{"message":"internal error"}`),
+	)
+
+	out, err := cmd.Execute("baremetal", "credentials", "create", "fakeBaremetal", "--reveal")
+
+	require.CmpError(err)
+	assert.Cmp(err.Error(), td.Contains("failed to retrieve secret value"))
+	assert.Cmp(out, td.Not(td.Contains("secret-id-1")), "not even the secret identifier is printed")
+}
+
+// The generation call failing must be reported the same way.
+func (ms *MockSuite) TestBaremetalCredentialsCreateReportsGenerationFailure(assert, require *td.T) {
+	httpmock.RegisterResponder("POST", "https://eu.api.ovh.com/v1/dedicated/server/fakeBaremetal/authenticationSecret",
+		httpmock.NewStringResponder(403, `{"message":"This call has not been granted"}`),
+	)
+
+	_, err := cmd.Execute("baremetal", "credentials", "create", "fakeBaremetal")
+
+	require.CmpError(err)
+	assert.Cmp(err.Error(), td.Contains("failed to fetch secrets IDs"))
 }

--- a/internal/cmd/baremetal_test.go
+++ b/internal/cmd/baremetal_test.go
@@ -116,3 +116,53 @@ func (ms *MockSuite) TestBaremetalReinstallSucceedsOnDoneTask(assert, require *t
 
 	require.CmpNoError(err)
 }
+
+func mockCredentialsResponders() {
+	httpmock.RegisterResponder("POST", "https://eu.api.ovh.com/v1/dedicated/server/fakeBaremetal/authenticationSecret",
+		httpmock.NewStringResponder(200, `[{"type":"password","user":"root","password":"secret-id-1","expiration":"2026-08-18T03:41:00+02:00"}]`),
+	)
+	httpmock.RegisterResponder("POST", "https://eu.api.ovh.com/v1/secret/retrieve",
+		httpmock.NewStringResponder(200, `{"secret":"Tk9uY2VQYXNzMTIz"}`),
+	)
+}
+
+// A secret must not be printed unless it was explicitly asked for.
+func (ms *MockSuite) TestBaremetalCredentialsGetMasksByDefault(assert, require *td.T) {
+	mockCredentialsResponders()
+
+	out, err := cmd.Execute("baremetal", "credentials", "get", "fakeBaremetal")
+
+	require.CmpNoError(err)
+	assert.Cmp(out, td.Not(td.Contains("Tk9uY2VQYXNzMTIz")), "the secret value must not be printed")
+	assert.Cmp(out, td.Contains("••••"))
+}
+
+// Masking applies to machine-readable formats too: a secret written into a
+// JSON file in a pipeline leaks as much as one scrolled in a terminal.
+func (ms *MockSuite) TestBaremetalCredentialsGetMasksJSONOutput(assert, require *td.T) {
+	mockCredentialsResponders()
+
+	out, err := cmd.Execute("baremetal", "credentials", "get", "fakeBaremetal", "-o", "json")
+
+	require.CmpNoError(err)
+	assert.Cmp(out, td.Not(td.Contains("Tk9uY2VQYXNzMTIz")))
+}
+
+func (ms *MockSuite) TestBaremetalCredentialsGetRevealsOnDemand(assert, require *td.T) {
+	mockCredentialsResponders()
+
+	out, err := cmd.Execute("baremetal", "credentials", "get", "fakeBaremetal", "--reveal")
+
+	require.CmpNoError(err)
+	assert.Cmp(out, td.Contains("Tk9uY2VQYXNzMTIz"))
+}
+
+// The former name keeps working, so existing scripts do not break.
+func (ms *MockSuite) TestBaremetalListSecretsAliasStillWorks(assert, require *td.T) {
+	mockCredentialsResponders()
+
+	out, err := cmd.Execute("baremetal", "list-secrets", "fakeBaremetal")
+
+	require.CmpNoError(err)
+	assert.Cmp(out, td.Contains("••••"))
+}

--- a/internal/display/display.go
+++ b/internal/display/display.go
@@ -417,6 +417,14 @@ func OutputError(outputFormat *OutputFormat, message string, params ...any) {
 	}, outputFormat)
 }
 
+// OutputNotice writes an operational note to stderr: something the command is
+// doing, not something it produced. It never touches stdout, so a redirected
+// result stays parsable, and it does not end the command the way an error or
+// a warning does.
+func OutputNotice(message string, params ...any) {
+	fmt.Fprintf(os.Stderr, message+"\n", params...)
+}
+
 func OutputWarning(outputFormat *OutputFormat, message string, params ...any) {
 	resultString := fmt.Sprintf("🟠 "+message, params...)
 	OutputWithFormat(&OutputMessage{

--- a/internal/display/display_wasm.go
+++ b/internal/display/display_wasm.go
@@ -209,6 +209,13 @@ func OutputError(outputFormat *OutputFormat, message string, params ...any) {
 	exitError(message, params...)
 }
 
+// OutputNotice writes an operational note: something the command is doing,
+// not something it produced. The browser build has no separate diagnostic
+// stream, so the note joins the result the way the other messages do.
+func OutputNotice(message string, params ...any) {
+	outputf(message, params...)
+}
+
 func OutputWarning(outputFormat *OutputFormat, message string, params ...any) {
 	exitError(message, params...)
 }

--- a/internal/http/debug.go
+++ b/internal/http/debug.go
@@ -100,11 +100,29 @@ type transport struct {
 	transport http.RoundTripper
 }
 
+// secretCarryingPaths are the endpoints whose payload is a credential. Their
+// bodies are never written to the debug log: --debug is a diagnostic switch,
+// not a way around the masking that --reveal governs.
+var secretCarryingPaths = []string{
+	"/authenticationSecret",
+	"/secret/retrieve",
+}
+
+func carriesSecret(path string) bool {
+	for _, suffix := range secretCarryingPaths {
+		if strings.HasSuffix(path, suffix) {
+			return true
+		}
+	}
+
+	return false
+}
+
 func (t *transport) RoundTrip(req *http.Request) (*http.Response, error) {
 	startTime := time.Now()
 
 	if flags.Debug {
-		reqData, err := httputil.DumpRequestOut(req, true)
+		reqData, err := httputil.DumpRequestOut(req, !carriesSecret(req.URL.Path))
 		if err == nil {
 			log.Printf("[DEBUG] "+logReqMsg, t.name, prettyPrintJsonLines(reqData))
 		} else {
@@ -137,7 +155,10 @@ func (t *transport) RoundTrip(req *http.Request) (*http.Response, error) {
 	BrowserDebugLogger.AddEntry(entry)
 
 	if flags.Debug {
-		respData, err := httputil.DumpResponse(resp, true)
+		// Some endpoints answer with credentials. Dumping their body would
+		// print the secret whatever the command decided about masking, so the
+		// body is left out and only the headers are kept.
+		respData, err := httputil.DumpResponse(resp, !carriesSecret(req.URL.Path))
 		if err == nil {
 			log.Printf("[DEBUG] "+logRespMsg, t.name, prettyPrintJsonLines(respData))
 		} else {

--- a/internal/http/debug_secrets_test.go
+++ b/internal/http/debug_secrets_test.go
@@ -1,0 +1,83 @@
+// SPDX-FileCopyrightText: 2025 OVH SAS <opensource@ovh.net>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package http
+
+import (
+	"bytes"
+	"io"
+	"log"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/maxatome/go-testdeep/td"
+	"github.com/ovh/ovhcloud-cli/internal/flags"
+)
+
+// roundTripperFunc turns a function into an http.RoundTripper.
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) { return f(req) }
+
+// debugRoundTrip runs one request through the debug transport and returns
+// everything it logged.
+func debugRoundTrip(t *testing.T, url, responseBody string) string {
+	t.Helper()
+
+	origDebug := flags.Debug
+	flags.Debug = true
+	defer func() { flags.Debug = origDebug }()
+
+	var logged bytes.Buffer
+	origWriter := log.Writer()
+	log.SetOutput(&logged)
+	defer log.SetOutput(origWriter)
+
+	req, err := http.NewRequest(http.MethodPost, url, strings.NewReader(`{"id":"secret-id-1"}`))
+	td.Require(t).CmpNoError(err)
+
+	tr := &transport{
+		name: "test",
+		transport: roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: 200,
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+				Body:       io.NopCloser(strings.NewReader(responseBody)),
+				Request:    r,
+			}, nil
+		}),
+	}
+
+	_, err = tr.RoundTrip(req)
+	td.Require(t).CmpNoError(err)
+
+	return logged.String()
+}
+
+// --debug is a diagnostic switch, not a way around the masking that --reveal
+// governs: the body of a credential endpoint must never reach the log.
+func TestDebugTransport_DoesNotLogCredentialBodies(t *testing.T) {
+	for _, endpoint := range []string{
+		"https://eu.api.ovh.com/v1/secret/retrieve",
+		"https://eu.api.ovh.com/v1/dedicated/server/ns1234/authenticationSecret",
+	} {
+		logged := debugRoundTrip(t, endpoint, `{"secret":"Tk9uY2VQYXNzMTIz"}`)
+
+		td.Cmp(t, logged, td.Not(td.Contains("Tk9uY2VQYXNzMTIz")),
+			"the response body of %s must not be logged", endpoint)
+		td.Cmp(t, logged, td.Not(td.Contains("secret-id-1")),
+			"nor the request body of %s", endpoint)
+		td.Cmp(t, logged, td.Contains("200"), "the exchange is still traced")
+	}
+}
+
+// Every other endpoint keeps its full debug dump: the redaction must stay
+// narrow, otherwise --debug loses its purpose.
+func TestDebugTransport_StillLogsOrdinaryBodies(t *testing.T) {
+	logged := debugRoundTrip(t,
+		"https://eu.api.ovh.com/v1/dedicated/server/ns1234", `{"state":"ok"}`)
+
+	td.Cmp(t, logged, td.Contains(`"state": "ok"`), "the debug logger pretty-prints, so the body appears spaced")
+}

--- a/internal/services/baremetal/baremetal.go
+++ b/internal/services/baremetal/baremetal.go
@@ -194,10 +194,10 @@ func RebootRescueBaremetal(cmd *cobra.Command, args []string) {
 		return
 	}
 
-	log.Println("⚡️ Reboot done, fetching new authentication secrets…")
+	display.OutputNotice("⚡️ Reboot done, fetching new authentication secrets…")
 
-	// Fetch new secrets
-	GetBaremetalAuthenticationSecrets(cmd, args)
+	// Fetch new secrets, honouring the --reveal choice of this command.
+	fetchAuthenticationSecrets(args[0], BaremetalRevealSecrets)
 }
 
 // taskPollInterval and taskPollAttempts bound how long --wait follows a task.
@@ -537,10 +537,10 @@ func ReinstallBaremetal(cmd *cobra.Command, args []string) {
 		return
 	}
 
-	log.Println("⚡️ Reinstall done, fetching new authentication secrets…")
+	display.OutputNotice("⚡️ Reinstall done, fetching new authentication secrets…")
 
-	// Fetch new secrets
-	GetBaremetalAuthenticationSecrets(cmd, args)
+	// Fetch new secrets, honouring the --reveal choice of this command.
+	fetchAuthenticationSecrets(args[0], BaremetalRevealSecrets)
 }
 
 func GetBaremetalRelatedIPs(_ *cobra.Command, args []string) {
@@ -571,12 +571,21 @@ func GetBaremetalRelatedIPs(_ *cobra.Command, args []string) {
 // user explicitly asks for it.
 var maskedSecretFields = []string{"secret", "password", "value"}
 
+// GetBaremetalAuthenticationSecrets is the command handler. The masking
+// policy is read once here and passed on explicitly: the same helper is also
+// reached at the end of `reinstall --wait` and `reboot-rescue --wait`, and a
+// policy read from a package variable inside the helper would silently apply
+// a flag those commands do not expose.
 func GetBaremetalAuthenticationSecrets(_ *cobra.Command, args []string) {
-	path := fmt.Sprintf("/v1/dedicated/server/%s/authenticationSecret", url.PathEscape(args[0]))
+	fetchAuthenticationSecrets(args[0], BaremetalRevealSecrets)
+}
+
+func fetchAuthenticationSecrets(serviceName string, reveal bool) {
+	path := fmt.Sprintf("/v1/dedicated/server/%s/authenticationSecret", url.PathEscape(serviceName))
 
 	// This command is a write operation: it asks the API for a new access
 	// secret. Say so, because the name used to suggest a plain listing.
-	log.Printf("⚠️  Requesting a new access secret for %s (this is a write operation)", args[0])
+	display.OutputNotice("⚠️  Requesting a new access secret for %s (this is a write operation)", serviceName)
 
 	var allSecrets []map[string]any
 	if err := httpLib.Client.Post(path, nil, &allSecrets); err != nil {
@@ -600,7 +609,7 @@ func GetBaremetalAuthenticationSecrets(_ *cobra.Command, args []string) {
 	// Mask the values unless explicitly asked for, in every output format:
 	// a secret written to a JSON file in a pipeline leaks just as much as one
 	// scrolled in a terminal.
-	if !BaremetalRevealSecrets {
+	if !reveal {
 		for _, secret := range allSecrets {
 			for _, field := range maskedSecretFields {
 				if value, ok := secret[field]; ok && value != nil && value != "" {
@@ -608,7 +617,7 @@ func GetBaremetalAuthenticationSecrets(_ *cobra.Command, args []string) {
 				}
 			}
 		}
-		log.Print("🔒 Secret values are masked. Use --reveal to print them.")
+		display.OutputNotice("🔒 Secret values are masked. Use --reveal to print them.")
 	}
 
 	allSecrets, err := filtersLib.FilterLines(allSecrets, flags.GenericFilters)

--- a/internal/services/baremetal/baremetal.go
+++ b/internal/services/baremetal/baremetal.go
@@ -58,6 +58,9 @@ var (
 	BaremetalOLAInterfaces []string
 	BaremetalOLAName       string
 
+	// Credentials flag
+	BaremetalRevealSecrets bool
+
 	// IPMI flags
 	BaremetalIpmiTTL        int
 	BaremetalIpmiAccessType string
@@ -564,8 +567,16 @@ func GetBaremetalRelatedIPs(_ *cobra.Command, args []string) {
 	display.RenderTable(ipsExpanded, []string{"ip", "type", "description", "campus"}, &flags.OutputFormatConfig)
 }
 
+// maskedSecretFields are the keys whose value must not be printed unless the
+// user explicitly asks for it.
+var maskedSecretFields = []string{"secret", "password", "value"}
+
 func GetBaremetalAuthenticationSecrets(_ *cobra.Command, args []string) {
 	path := fmt.Sprintf("/v1/dedicated/server/%s/authenticationSecret", url.PathEscape(args[0]))
+
+	// This command is a write operation: it asks the API for a new access
+	// secret. Say so, because the name used to suggest a plain listing.
+	log.Printf("⚠️  Requesting a new access secret for %s (this is a write operation)", args[0])
 
 	var allSecrets []map[string]any
 	if err := httpLib.Client.Post(path, nil, &allSecrets); err != nil {
@@ -584,6 +595,20 @@ func GetBaremetalAuthenticationSecrets(_ *cobra.Command, args []string) {
 			}
 			maps.Copy(secret, secretValue)
 		}
+	}
+
+	// Mask the values unless explicitly asked for, in every output format:
+	// a secret written to a JSON file in a pipeline leaks just as much as one
+	// scrolled in a terminal.
+	if !BaremetalRevealSecrets {
+		for _, secret := range allSecrets {
+			for _, field := range maskedSecretFields {
+				if value, ok := secret[field]; ok && value != nil && value != "" {
+					secret[field] = "••••••••••••"
+				}
+			}
+		}
+		log.Print("🔒 Secret values are masked. Use --reveal to print them.")
 	}
 
 	allSecrets, err := filtersLib.FilterLines(allSecrets, flags.GenericFilters)


### PR DESCRIPTION
# Description

`baremetal list-secrets` reads like a listing — it sits right next to `list-ips` and `list-tasks` — but it is a write: it `POST`s to `/authenticationSecret` to have the API generate a new access secret, then `POST`s to `/secret/retrieve` to resolve it. It then printed the password in clear text.

The name invites exactly the wrong usage: running it in a loop over a fleet, as one would with the other `list-` commands, scatters credentials through shell history and CI logs while generating a new secret on every server.

This PR:

- adds **`baremetal credentials get`**, which names the operation for what it is;
- **masks secret values by default**, in every output format, with `--reveal` to print them;
- states on stderr that the command is a write operation;
- keeps **`list-secrets` as a deprecated alias**, so existing scripts keep working and cobra prints the deprecation notice.

```
$ ovhcloud baremetal credentials get ns1234.ip-11.22.33.net
⚠️  Requesting a new access secret for ns1234.ip-11.22.33.net (this is a write operation)
🔒 Secret values are masked. Use --reveal to print them.
   TYPE      USER  SECRET        EXPIRE
   password  root  ••••••••••••  2026-08-18T03:41:00+02:00
```

Masking applies to `-o json` and `-o yaml` as well: a secret written into a file by a pipeline leaks as much as one scrolled in a terminal.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Improvement (improvement of existing commands)
- [x] Breaking change (fix or feature that can break a current behavior)
- [ ] Documentation update

**The breaking part is deliberate and limited**: a script that reads the secret from `-o json` now needs `--reveal`. Printing credentials by default is the behaviour worth breaking; the flag makes the intent explicit at the call site.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have commented my code
- [x] I ran `go mod tidy`
- [x] I have added tests that prove my fix is effective or that my feature works

Four tests: masking in the table, masking under `-o json`, `--reveal` printing the value, and the deprecated alias still working.

`go build ./...`, `GOOS=js GOARCH=wasm go build ./...`, `go vet ./...` and `go test ./...` all pass. Documentation regenerated with `make doc` in a separate commit; the orphaned page of the deprecated alias is removed, since cobra no longer lists deprecated commands.
