### PR TITLE
feat(baremetal): confirm before reinstall, add --yes and --dry-run

### DIFF
--- a/doc/ovhcloud_baremetal_reinstall.md
+++ b/doc/ovhcloud_baremetal_reinstall.md
@@ -46,6 +46,11 @@ to see all the available parameters and real life examples.
 
 Please note that all parameters are not compatible with all OSes.
 
+Reinstalling wipes every disk of the server, so the command asks for a
+confirmation: type the server name when prompted. Unattended runs (pipelines,
+piped input) must pass --yes, and --dry-run prints the parameters that would
+be sent without sending them.
+
 
 ```
 ovhcloud baremetal reinstall <service_name> [flags]
@@ -55,6 +60,7 @@ ovhcloud baremetal reinstall <service_name> [flags]
 
 ```
       --config-drive-user-data string               Config Drive UserData
+      --dry-run                                     Print the installation parameters without sending anything
       --editor                                      Use a text editor to define parameters
       --efi-bootloader-path string                  Path of the EFI bootloader from the OS installed on the server
       --from-file string                            File containing parameters
@@ -73,6 +79,7 @@ ovhcloud baremetal reinstall <service_name> [flags]
       --replace                                     Replace parameters file if it already exists
       --ssh-key string                              SSH public key
       --wait                                        Wait for reinstall to be done before exiting
+  -y, --yes                                         Skip the confirmation prompt (required for unattended runs)
 ```
 
 ### Options inherited from parent commands

--- a/doc/ovhcloud_baremetal_reinstall.md
+++ b/doc/ovhcloud_baremetal_reinstall.md
@@ -24,7 +24,10 @@ There are three ways to define the installation parameters:
 
   Note that you can also pipe the content of the file to reinstall, like the following:
 
-	cat ./install.json | ovhcloud baremetal reinstall ns1234.ip-11.22.33.net
+	cat ./install.json | ovhcloud baremetal reinstall ns1234.ip-11.22.33.net --yes
+
+  Piped input is not a terminal, so there is nobody to answer the confirmation:
+  such a run refuses to start unless --yes is given.
 
   In both cases, you can override the parameters in the given file using command line flags, for example:
 

--- a/internal/cmd/baremetal.go
+++ b/internal/cmd/baremetal.go
@@ -132,6 +132,11 @@ You can visit https://eu.api.ovh.com/console/?section=%2Fdedicated%2Fserver&bran
 to see all the available parameters and real life examples.
 
 Please note that all parameters are not compatible with all OSes.
+
+Reinstalling wipes every disk of the server, so the command asks for a
+confirmation: type the server name when prompted. Unattended runs (pipelines,
+piped input) must pass --yes, and --dry-run prints the parameters that would
+be sent without sending them.
 `,
 		Args:              cobra.MaximumNArgs(1),
 		ArgAliases:        []string{"service_name"},
@@ -155,6 +160,9 @@ Please note that all parameters are not compatible with all OSes.
 	reinstallBaremetalCmd.Flags().StringVar(&baremetal.Customizations.PostInstallationScriptExtension, "post-installation-script-extension", "", "Post-installation script extension (cmd, ps1)")
 	reinstallBaremetalCmd.Flags().StringVar(&baremetal.Customizations.SshKey, "ssh-key", "", "SSH public key")
 	reinstallBaremetalCmd.Flags().BoolVar(&flags.WaitForTask, "wait", false, "Wait for reinstall to be done before exiting")
+	reinstallBaremetalCmd.Flags().BoolVarP(&flags.AssumeYes, "yes", "y", false, "Skip the confirmation prompt (required for unattended runs)")
+	reinstallBaremetalCmd.Flags().BoolVar(&flags.DryRun, "dry-run", false, "Print the installation parameters without sending anything")
+	markFlagsMutuallyExclusive(reinstallBaremetalCmd, "yes", "dry-run")
 	markFlagsMutuallyExclusive(reinstallBaremetalCmd, "from-file", "editor")
 	baremetalCmd.AddCommand(reinstallBaremetalCmd)
 

--- a/internal/cmd/baremetal.go
+++ b/internal/cmd/baremetal.go
@@ -111,7 +111,10 @@ There are three ways to define the installation parameters:
 
   Note that you can also pipe the content of the file to reinstall, like the following:
 
-	cat ./install.json | ovhcloud baremetal reinstall ns1234.ip-11.22.33.net
+	cat ./install.json | ovhcloud baremetal reinstall ns1234.ip-11.22.33.net --yes
+
+  Piped input is not a terminal, so there is nobody to answer the confirmation:
+  such a run refuses to start unless --yes is given.
 
   In both cases, you can override the parameters in the given file using command line flags, for example:
 

--- a/internal/cmd/baremetal_test.go
+++ b/internal/cmd/baremetal_test.go
@@ -57,6 +57,9 @@ func (ms *MockSuite) TestBaremetalListCompatibleOSCmd(assert, require *td.T) {
 }
 
 // registerReinstallTask wires a reinstall whose task ends in the given state.
+//
+// These tests pass --yes: they are about what the CLI says when a task fails,
+// not about the confirmation, and without it the reinstall never starts.
 func registerReinstallTask(task string) {
 	httpmock.RegisterResponder("POST", "https://eu.api.ovh.com/v1/dedicated/server/fakeBaremetal/reinstall",
 		httpmock.NewStringResponder(200, `{"taskId": 156839472}`),
@@ -72,7 +75,7 @@ func (ms *MockSuite) TestBaremetalReinstallReportsTheFailureReason(assert, requi
 	registerReinstallTask(`{"taskId": 156839472, "function": "reinstallServer",
 		"status": "customerError", "comment": "partitioning scheme incompatible with this hardware"}`)
 
-	_, err := cmd.Execute("baremetal", "reinstall", "fakeBaremetal", "--os", "debian12_64", "--wait")
+	_, err := cmd.Execute("baremetal", "reinstall", "fakeBaremetal", "--os", "debian12_64", "--wait", "--yes")
 
 	require.CmpError(err)
 	assert.Cmp(err.Error(), td.Contains("customerError"), "the real status is named")
@@ -86,7 +89,7 @@ func (ms *MockSuite) TestBaremetalReinstallReportsTheFailureReason(assert, requi
 func (ms *MockSuite) TestBaremetalReinstallPrintsAReadableTaskID(assert, require *td.T) {
 	registerReinstallTask(`{"taskId": 156839472, "function": "reinstallServer", "status": "ovhError"}`)
 
-	_, err := cmd.Execute("baremetal", "reinstall", "fakeBaremetal", "--os", "debian12_64", "--wait")
+	_, err := cmd.Execute("baremetal", "reinstall", "fakeBaremetal", "--os", "debian12_64", "--wait", "--yes")
 
 	require.CmpError(err)
 	assert.Cmp(err.Error(), td.Contains("156839472"))
@@ -99,7 +102,7 @@ func (ms *MockSuite) TestBaremetalReinstallPrintsAReadableTaskID(assert, require
 func (ms *MockSuite) TestBaremetalReinstallReportsAnUnknownStatus(assert, require *td.T) {
 	registerReinstallTask(`{"taskId": 156839472, "function": "reinstallServer", "status": "quarantined"}`)
 
-	_, err := cmd.Execute("baremetal", "reinstall", "fakeBaremetal", "--os", "debian12_64", "--wait")
+	_, err := cmd.Execute("baremetal", "reinstall", "fakeBaremetal", "--os", "debian12_64", "--wait", "--yes")
 
 	require.CmpError(err)
 	assert.Cmp(err.Error(), td.Contains("unexpected status quarantined"))
@@ -112,9 +115,10 @@ func (ms *MockSuite) TestBaremetalReinstallSucceedsOnDoneTask(assert, require *t
 		httpmock.NewStringResponder(200, `[]`),
 	)
 
-	_, err := cmd.Execute("baremetal", "reinstall", "fakeBaremetal", "--os", "debian12_64", "--wait")
+	_, err := cmd.Execute("baremetal", "reinstall", "fakeBaremetal", "--os", "debian12_64", "--wait", "--yes")
 
 	require.CmpNoError(err)
+}
 
 // Reinstalling wipes the disks: an unattended run must not do it silently.
 func (ms *MockSuite) TestBaremetalReinstallRefusesWithoutConfirmation(assert, require *td.T) {
@@ -152,6 +156,13 @@ func (ms *MockSuite) TestBaremetalReinstallDryRun(assert, require *td.T) {
 
 	require.CmpNoError(err)
 	assert.Cmp(out, td.Contains("Dry run"))
+	// The parameters must be in the message itself: the default output prints
+	// the message alone, so a payload living only in the structured details
+	// would leave stdout with a promise and no request.
+	assert.Cmp(out, td.Contains(`"operatingSystem": "debian12_64"`),
+		"the request that would be sent is printed")
+	assert.Cmp(out, td.Contains("/v1/dedicated/server/fakeBaremetal/reinstall"),
+		"and the endpoint it would go to")
 	assert.Cmp(httpmock.GetCallCountInfo()["POST https://eu.api.ovh.com/v1/dedicated/server/fakeBaremetal/reinstall"], 0,
 		"no reinstall call must reach the API")
 }

--- a/internal/cmd/baremetal_test.go
+++ b/internal/cmd/baremetal_test.go
@@ -115,4 +115,43 @@ func (ms *MockSuite) TestBaremetalReinstallSucceedsOnDoneTask(assert, require *t
 	_, err := cmd.Execute("baremetal", "reinstall", "fakeBaremetal", "--os", "debian12_64", "--wait")
 
 	require.CmpNoError(err)
+
+// Reinstalling wipes the disks: an unattended run must not do it silently.
+func (ms *MockSuite) TestBaremetalReinstallRefusesWithoutConfirmation(assert, require *td.T) {
+	httpmock.RegisterResponder("POST", "https://eu.api.ovh.com/v1/dedicated/server/fakeBaremetal/reinstall",
+		httpmock.NewStringResponder(200, `{"taskId": 123}`),
+	)
+
+	_, err := cmd.Execute("baremetal", "reinstall", "fakeBaremetal", "--os", "debian12_64")
+
+	require.CmpError(err)
+	assert.Cmp(err.Error(), td.Contains("cancelled"))
+	assert.Cmp(httpmock.GetCallCountInfo()["POST https://eu.api.ovh.com/v1/dedicated/server/fakeBaremetal/reinstall"], 0,
+		"no reinstall call must reach the API")
+}
+
+func (ms *MockSuite) TestBaremetalReinstallProceedsWithYes(assert, require *td.T) {
+	httpmock.RegisterResponder("POST", "https://eu.api.ovh.com/v1/dedicated/server/fakeBaremetal/reinstall",
+		httpmock.NewStringResponder(200, `{"taskId": 123}`),
+	)
+
+	out, err := cmd.Execute("baremetal", "reinstall", "fakeBaremetal", "--os", "debian12_64", "--yes")
+
+	require.CmpNoError(err)
+	assert.Cmp(out, td.Contains("Reinstallation is started"))
+	assert.Cmp(httpmock.GetCallCountInfo()["POST https://eu.api.ovh.com/v1/dedicated/server/fakeBaremetal/reinstall"], 1)
+}
+
+// --dry-run shows what would be sent and sends nothing.
+func (ms *MockSuite) TestBaremetalReinstallDryRun(assert, require *td.T) {
+	httpmock.RegisterResponder("POST", "https://eu.api.ovh.com/v1/dedicated/server/fakeBaremetal/reinstall",
+		httpmock.NewStringResponder(200, `{"taskId": 123}`),
+	)
+
+	out, err := cmd.Execute("baremetal", "reinstall", "fakeBaremetal", "--os", "debian12_64", "--dry-run")
+
+	require.CmpNoError(err)
+	assert.Cmp(out, td.Contains("Dry run"))
+	assert.Cmp(httpmock.GetCallCountInfo()["POST https://eu.api.ovh.com/v1/dedicated/server/fakeBaremetal/reinstall"], 0,
+		"no reinstall call must reach the API")
 }

--- a/internal/cmd/baremetal_test.go
+++ b/internal/cmd/baremetal_test.go
@@ -5,9 +5,6 @@
 package cmd_test
 
 import (
-	"bytes"
-	"log"
-
 	"github.com/jarcoal/httpmock"
 	"github.com/maxatome/go-testdeep/td"
 	"github.com/ovh/ovhcloud-cli/internal/cmd"
@@ -168,51 +165,4 @@ func (ms *MockSuite) TestBaremetalReinstallDryRun(assert, require *td.T) {
 		"and the endpoint it would go to")
 	assert.Cmp(httpmock.GetCallCountInfo()["POST https://eu.api.ovh.com/v1/dedicated/server/fakeBaremetal/reinstall"], 0,
 		"no reinstall call must reach the API")
-}
-
-// A dry run prints the payload once. It used to print it twice: the message
-// carries it, and a log.Println just above the --dry-run branch repeated the
-// same JSON behind a Go timestamp no other command in this CLI emits.
-//
-//	🔍 Dry run: nothing was sent. This would have been posted to …
-//	{ "operatingSystem": "debian12_64" }
-//	2026/08/23 23:47:22 Final parameters:
-//	{ "operatingSystem": "debian12_64" }
-//
-// The log line goes to stderr, so no assertion on stdout could ever have seen
-// it — which is why it survived every green run. This one redirects the logger.
-func (ms *MockSuite) TestBaremetalReinstallDryRunDoesNotLogTheParametersTwice(assert, require *td.T) {
-	httpmock.RegisterResponder("POST", "https://eu.api.ovh.com/v1/dedicated/server/fakeBaremetal/reinstall",
-		httpmock.NewStringResponder(200, `{"taskId": 123}`),
-	)
-	var logged bytes.Buffer
-	previous := log.Writer()
-	log.SetOutput(&logged)
-	defer log.SetOutput(previous)
-
-	out, err := cmd.Execute("baremetal", "reinstall", "fakeBaremetal", "--os", "debian12_64", "--dry-run")
-
-	require.CmpNoError(err)
-	assert.Cmp(out, td.Contains(`"operatingSystem": "debian12_64"`),
-		"the payload is still printed, once, as the message")
-	assert.Cmp(logged.String(), td.Not(td.Contains("Final parameters")),
-		"a dry run logs nothing: it sends nothing")
-}
-
-// The positive control of the test above: a REAL run still logs what it is
-// about to send. Without it, deleting the log line altogether would pass.
-func (ms *MockSuite) TestBaremetalReinstallStillLogsTheParametersItSends(assert, require *td.T) {
-	httpmock.RegisterResponder("POST", "https://eu.api.ovh.com/v1/dedicated/server/fakeBaremetal/reinstall",
-		httpmock.NewStringResponder(200, `{"taskId": 123}`),
-	)
-	var logged bytes.Buffer
-	previous := log.Writer()
-	log.SetOutput(&logged)
-	defer log.SetOutput(previous)
-
-	_, err := cmd.Execute("baremetal", "reinstall", "fakeBaremetal", "--os", "debian12_64", "--yes")
-
-	require.CmpNoError(err)
-	assert.Cmp(logged.String(), td.Contains("Final parameters"))
-	assert.Cmp(logged.String(), td.Contains(`"operatingSystem": "debian12_64"`))
 }

--- a/internal/cmd/baremetal_test.go
+++ b/internal/cmd/baremetal_test.go
@@ -5,6 +5,9 @@
 package cmd_test
 
 import (
+	"bytes"
+	"log"
+
 	"github.com/jarcoal/httpmock"
 	"github.com/maxatome/go-testdeep/td"
 	"github.com/ovh/ovhcloud-cli/internal/cmd"
@@ -165,4 +168,51 @@ func (ms *MockSuite) TestBaremetalReinstallDryRun(assert, require *td.T) {
 		"and the endpoint it would go to")
 	assert.Cmp(httpmock.GetCallCountInfo()["POST https://eu.api.ovh.com/v1/dedicated/server/fakeBaremetal/reinstall"], 0,
 		"no reinstall call must reach the API")
+}
+
+// A dry run prints the payload once. It used to print it twice: the message
+// carries it, and a log.Println just above the --dry-run branch repeated the
+// same JSON behind a Go timestamp no other command in this CLI emits.
+//
+//	🔍 Dry run: nothing was sent. This would have been posted to …
+//	{ "operatingSystem": "debian12_64" }
+//	2026/08/23 23:47:22 Final parameters:
+//	{ "operatingSystem": "debian12_64" }
+//
+// The log line goes to stderr, so no assertion on stdout could ever have seen
+// it — which is why it survived every green run. This one redirects the logger.
+func (ms *MockSuite) TestBaremetalReinstallDryRunDoesNotLogTheParametersTwice(assert, require *td.T) {
+	httpmock.RegisterResponder("POST", "https://eu.api.ovh.com/v1/dedicated/server/fakeBaremetal/reinstall",
+		httpmock.NewStringResponder(200, `{"taskId": 123}`),
+	)
+	var logged bytes.Buffer
+	previous := log.Writer()
+	log.SetOutput(&logged)
+	defer log.SetOutput(previous)
+
+	out, err := cmd.Execute("baremetal", "reinstall", "fakeBaremetal", "--os", "debian12_64", "--dry-run")
+
+	require.CmpNoError(err)
+	assert.Cmp(out, td.Contains(`"operatingSystem": "debian12_64"`),
+		"the payload is still printed, once, as the message")
+	assert.Cmp(logged.String(), td.Not(td.Contains("Final parameters")),
+		"a dry run logs nothing: it sends nothing")
+}
+
+// The positive control of the test above: a REAL run still logs what it is
+// about to send. Without it, deleting the log line altogether would pass.
+func (ms *MockSuite) TestBaremetalReinstallStillLogsTheParametersItSends(assert, require *td.T) {
+	httpmock.RegisterResponder("POST", "https://eu.api.ovh.com/v1/dedicated/server/fakeBaremetal/reinstall",
+		httpmock.NewStringResponder(200, `{"taskId": 123}`),
+	)
+	var logged bytes.Buffer
+	previous := log.Writer()
+	log.SetOutput(&logged)
+	defer log.SetOutput(previous)
+
+	_, err := cmd.Execute("baremetal", "reinstall", "fakeBaremetal", "--os", "debian12_64", "--yes")
+
+	require.CmpNoError(err)
+	assert.Cmp(logged.String(), td.Contains("Final parameters"))
+	assert.Cmp(logged.String(), td.Contains(`"operatingSystem": "debian12_64"`))
 }

--- a/internal/cmd/dry_run_log_test.go
+++ b/internal/cmd/dry_run_log_test.go
@@ -1,0 +1,68 @@
+// SPDX-FileCopyrightText: 2025 OVH SAS <opensource@ovh.net>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Ces deux tests vivent dans leur propre fichier, et non dans
+// baremetal_test.go, pour une raison mecanique : 23 branches en aval ajoutent
+// elles aussi des tests juste apres TestBaremetalReinstallDryRun et dans le
+// meme bloc d'imports. Les y placer a fait echouer les 23 merges d'un coup, sur
+// une adjacence et non sur un desaccord. Un fichier neuf ne peut entrer en
+// collision qu'avec un fichier de meme nom.
+
+package cmd_test
+
+import (
+	"bytes"
+	"log"
+
+	"github.com/jarcoal/httpmock"
+	"github.com/maxatome/go-testdeep/td"
+	"github.com/ovh/ovhcloud-cli/internal/cmd"
+)
+
+// A dry run prints the payload once. It used to print it twice: the message
+// carries it, and a log.Println just above the --dry-run branch repeated the
+// same JSON behind a Go timestamp no other command in this CLI emits.
+//
+//	🔍 Dry run: nothing was sent. This would have been posted to …
+//	{ "operatingSystem": "debian12_64" }
+//	2026/08/23 23:47:22 Final parameters:
+//	{ "operatingSystem": "debian12_64" }
+//
+// The log line goes to stderr, so no assertion on stdout could ever have seen
+// it — which is why it survived every green run. This one redirects the logger.
+func (ms *MockSuite) TestBaremetalReinstallDryRunDoesNotLogTheParametersTwice(assert, require *td.T) {
+	httpmock.RegisterResponder("POST", "https://eu.api.ovh.com/v1/dedicated/server/fakeBaremetal/reinstall",
+		httpmock.NewStringResponder(200, `{"taskId": 123}`),
+	)
+	var logged bytes.Buffer
+	previous := log.Writer()
+	log.SetOutput(&logged)
+	defer log.SetOutput(previous)
+
+	out, err := cmd.Execute("baremetal", "reinstall", "fakeBaremetal", "--os", "debian12_64", "--dry-run")
+
+	require.CmpNoError(err)
+	assert.Cmp(out, td.Contains(`"operatingSystem": "debian12_64"`),
+		"the payload is still printed, once, as the message")
+	assert.Cmp(logged.String(), td.Not(td.Contains("Final parameters")),
+		"a dry run logs nothing: it sends nothing")
+}
+
+// The positive control of the test above: a REAL run still logs what it is
+// about to send. Without it, deleting the log line altogether would pass.
+func (ms *MockSuite) TestBaremetalReinstallStillLogsTheParametersItSends(assert, require *td.T) {
+	httpmock.RegisterResponder("POST", "https://eu.api.ovh.com/v1/dedicated/server/fakeBaremetal/reinstall",
+		httpmock.NewStringResponder(200, `{"taskId": 123}`),
+	)
+	var logged bytes.Buffer
+	previous := log.Writer()
+	log.SetOutput(&logged)
+	defer log.SetOutput(previous)
+
+	_, err := cmd.Execute("baremetal", "reinstall", "fakeBaremetal", "--os", "debian12_64", "--yes")
+
+	require.CmpNoError(err)
+	assert.Cmp(logged.String(), td.Contains("Final parameters"))
+	assert.Cmp(logged.String(), td.Contains(`"operatingSystem": "debian12_64"`))
+}

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -39,4 +39,10 @@ var (
 
 	// Flag to indicate whether the command should use a file for input parameters
 	ParametersFile string
+
+	// Flag used by destructive commands to skip the interactive confirmation
+	AssumeYes bool
+
+	// Flag used to display what would be sent to the API without sending it
+	DryRun bool
 )

--- a/internal/services/baremetal/baremetal.go
+++ b/internal/services/baremetal/baremetal.go
@@ -23,6 +23,7 @@ import (
 	"github.com/ovh/ovhcloud-cli/internal/flags"
 	httpLib "github.com/ovh/ovhcloud-cli/internal/http"
 	"github.com/ovh/ovhcloud-cli/internal/services/common"
+	"github.com/ovh/ovhcloud-cli/internal/utils"
 	"github.com/spf13/cobra"
 )
 
@@ -502,6 +503,20 @@ func ReinstallBaremetal(cmd *cobra.Command, args []string) {
 		return
 	}
 
+	// Reinstalling wipes every disk of the server. Nothing else in this CLI
+	// destroys customer data, so this is the one place that asks before acting.
+	if !flags.AssumeYes && !flags.DryRun {
+		warning := fmt.Sprintf("Reinstalling %s wipes every disk of the server. This cannot be undone.", args[0])
+		if OperatingSystem != "" {
+			warning += fmt.Sprintf("\n   Operating system to install: %s", OperatingSystem)
+		}
+
+		if !utils.ConfirmByName(args[0], warning) {
+			display.OutputError(&flags.OutputFormatConfig, "reinstallation of %s cancelled", args[0])
+			return
+		}
+	}
+
 	endpoint := fmt.Sprintf("/v1/dedicated/server/%s/reinstall", url.PathEscape(args[0]))
 	task, err := common.CreateResource(
 		cmd,
@@ -519,6 +534,11 @@ func ReinstallBaremetal(cmd *cobra.Command, args []string) {
 		[]string{"operatingSystem"})
 	if err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "error reinstalling server: %s", err)
+		return
+	}
+
+	// Nothing was sent in dry-run mode, so there is no task to follow.
+	if flags.DryRun {
 		return
 	}
 

--- a/internal/services/common/common.go
+++ b/internal/services/common/common.go
@@ -183,10 +183,18 @@ func CreateResource(cmd *cobra.Command, path, endpoint, defaultExample string,
 	// --dry-run stops here: the caller sees exactly what would have been sent,
 	// and nothing reaches the API.
 	if flags.DryRun {
+		// The payload goes in the message, not only in the details: the
+		// default output prints the message alone, so a --dry-run whose body
+		// lived in the details printed a promise and no request.
+		payload, err := json.MarshalIndent(parameters, "", "  ")
+		if err != nil {
+			return nil, fmt.Errorf("failed to render the parameters: %w", err)
+		}
+
 		display.OutputInfo(&flags.OutputFormatConfig, map[string]any{
 			"endpoint":   endpoint,
 			"parameters": parameters,
-		}, "🔍 Dry run: nothing was sent. The request above would have been posted to %s", endpoint)
+		}, "🔍 Dry run: nothing was sent. This would have been posted to %s:\n%s", endpoint, payload)
 		return nil, nil
 	}
 

--- a/internal/services/common/common.go
+++ b/internal/services/common/common.go
@@ -180,6 +180,16 @@ func CreateResource(cmd *cobra.Command, path, endpoint, defaultExample string,
 
 	log.Println("Final parameters: \n" + string(out))
 
+	// --dry-run stops here: the caller sees exactly what would have been sent,
+	// and nothing reaches the API.
+	if flags.DryRun {
+		display.OutputInfo(&flags.OutputFormatConfig, map[string]any{
+			"endpoint":   endpoint,
+			"parameters": parameters,
+		}, "🔍 Dry run: nothing was sent. The request above would have been posted to %s", endpoint)
+		return nil, nil
+	}
+
 	var createdResource map[string]any
 	if err := httpLib.Client.Post(endpoint, parameters, &createdResource); err != nil {
 		return nil, fmt.Errorf("error creating resource: %w", err)

--- a/internal/services/common/common.go
+++ b/internal/services/common/common.go
@@ -178,8 +178,6 @@ func CreateResource(cmd *cobra.Command, path, endpoint, defaultExample string,
 		return nil, fmt.Errorf("parameters cannot be marshalled: %w", err)
 	}
 
-	log.Println("Final parameters: \n" + string(out))
-
 	// --dry-run stops here: the caller sees exactly what would have been sent,
 	// and nothing reaches the API.
 	if flags.DryRun {
@@ -197,6 +195,19 @@ func CreateResource(cmd *cobra.Command, path, endpoint, defaultExample string,
 		}, "🔍 Dry run: nothing was sent. This would have been posted to %s:\n%s", endpoint, payload)
 		return nil, nil
 	}
+
+	// Logged only once the dry run is ruled out. A --dry-run already prints the
+	// payload as its message, so logging it here printed the same JSON twice,
+	// the second time behind a Go timestamp no other command in this CLI emits:
+	//
+	//	🔍 Dry run: nothing was sent. This would have been posted to …
+	//	{ "operatingSystem": "debian12_64" }
+	//	2026/08/23 23:47:22 Final parameters:
+	//	{ "operatingSystem": "debian12_64" }
+	//
+	// A real run still logs what it is about to send, which is what this line
+	// was for.
+	log.Println("Final parameters: \n" + string(out))
 
 	var createdResource map[string]any
 	if err := httpLib.Client.Post(endpoint, parameters, &createdResource); err != nil {

--- a/internal/utils/confirm_test.go
+++ b/internal/utils/confirm_test.go
@@ -1,0 +1,77 @@
+// SPDX-FileCopyrightText: 2025 OVH SAS <opensource@ovh.net>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !(js && wasm)
+
+package utils
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/maxatome/go-testdeep/td"
+)
+
+// withInteractiveInput runs f as if the operator were typing answer at an
+// interactive terminal.
+func withInteractiveInput(t *testing.T, answer string, f func()) {
+	t.Helper()
+
+	origInput, origInteractive := confirmInput, confirmInteractive
+	confirmInput = strings.NewReader(answer)
+	confirmInteractive = func() bool { return true }
+	defer func() { confirmInput, confirmInteractive = origInput, origInteractive }()
+
+	f()
+}
+
+// The exact name is the guard between a typo and an erased disk, so the
+// accepting path has to be exercised, not only the refusals around it.
+func TestConfirmByName_AcceptsTheExactName(t *testing.T) {
+	var confirmed bool
+	withInteractiveInput(t, "ns3168421.ip-51-77-12.eu\n", func() {
+		confirmed = ConfirmByName("ns3168421.ip-51-77-12.eu", "this wipes both disks")
+	})
+
+	td.Cmp(t, confirmed, true)
+}
+
+// Surrounding whitespace is the operator's, not the server's.
+func TestConfirmByName_AcceptsTheNameWithSurroundingSpaces(t *testing.T) {
+	var confirmed bool
+	withInteractiveInput(t, "  ns3168421.ip-51-77-12.eu  \n", func() {
+		confirmed = ConfirmByName("ns3168421.ip-51-77-12.eu", "this wipes both disks")
+	})
+
+	td.Cmp(t, confirmed, true)
+}
+
+// Anything else is a refusal: a near miss must not pass.
+func TestConfirmByName_RejectsAnythingElse(t *testing.T) {
+	for _, answer := range []string{
+		"ns3168421.ip-51-77-12.e\n",  // one character short
+		"ns3168422.ip-51-77-12.eu\n", // the neighbouring server
+		"yes\n",
+		"\n",
+		"", // stream closed before any answer
+	} {
+		var confirmed bool
+		withInteractiveInput(t, answer, func() {
+			confirmed = ConfirmByName("ns3168421.ip-51-77-12.eu", "this wipes both disks")
+		})
+
+		td.Cmp(t, confirmed, false, "answer %q must not confirm", answer)
+	}
+}
+
+// Without a terminal there is no prompt at all: an unattended run has to opt
+// in with --yes rather than be asked a question nobody will read.
+func TestConfirmByName_RefusesWhenNotInteractive(t *testing.T) {
+	origInput, origInteractive := confirmInput, confirmInteractive
+	confirmInput = strings.NewReader("ns3168421.ip-51-77-12.eu\n")
+	confirmInteractive = func() bool { return false }
+	defer func() { confirmInput, confirmInteractive = origInput, origInteractive }()
+
+	td.Cmp(t, ConfirmByName("ns3168421.ip-51-77-12.eu", "this wipes both disks"), false)
+}

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -7,6 +7,7 @@ package utils
 import (
 	"bufio"
 	"fmt"
+	"io"
 	"os"
 	"runtime"
 	"strings"
@@ -39,8 +40,18 @@ func IsInputFromPipe() bool {
 //
 // The prompt is written to stderr so that a redirected stdout keeps holding
 // data only.
+// Both indirections exist so that the confirmation path itself can be
+// exercised by a test: it is the guard standing between a typo and an erased
+// disk, and a guard nobody executes is a guard nobody has checked.
+var (
+	confirmInput       io.Reader = os.Stdin
+	confirmInteractive           = func() bool {
+		return !IsInputFromPipe() && term.IsTerminal(os.Stdin.Fd())
+	}
+)
+
 func ConfirmByName(expected, warning string) bool {
-	if IsInputFromPipe() || !term.IsTerminal(os.Stdin.Fd()) {
+	if !confirmInteractive() {
 		fmt.Fprintf(os.Stderr,
 			"🛑 %s\n   Refusing to continue without a confirmation. Re-run with --yes to confirm, or --dry-run to preview.\n",
 			warning)
@@ -49,7 +60,7 @@ func ConfirmByName(expected, warning string) bool {
 
 	fmt.Fprintf(os.Stderr, "⚠️  %s\n   Type %q to confirm › ", warning, expected)
 
-	reader := bufio.NewReader(os.Stdin)
+	reader := bufio.NewReader(confirmInput)
 	answer, err := reader.ReadString('\n')
 	if err != nil {
 		return false

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -5,11 +5,14 @@
 package utils
 
 import (
+	"bufio"
 	"fmt"
 	"os"
 	"runtime"
+	"strings"
 
 	"dario.cat/mergo"
+	"github.com/charmbracelet/x/term"
 )
 
 func MergeMaps(left, right map[string]any) error {
@@ -27,4 +30,30 @@ func IsInputFromPipe() bool {
 
 	fileInfo, _ := os.Stdin.Stat()
 	return fileInfo.Mode()&os.ModeCharDevice == 0
+}
+
+// ConfirmByName asks the operator to type the given name before a destructive
+// action is carried out. It returns false — without prompting — when the input
+// is not an interactive terminal, so an unattended run never destroys anything
+// by default: such runs must opt in explicitly.
+//
+// The prompt is written to stderr so that a redirected stdout keeps holding
+// data only.
+func ConfirmByName(expected, warning string) bool {
+	if IsInputFromPipe() || !term.IsTerminal(os.Stdin.Fd()) {
+		fmt.Fprintf(os.Stderr,
+			"🛑 %s\n   Refusing to continue without a confirmation. Re-run with --yes to confirm, or --dry-run to preview.\n",
+			warning)
+		return false
+	}
+
+	fmt.Fprintf(os.Stderr, "⚠️  %s\n   Type %q to confirm › ", warning, expected)
+
+	reader := bufio.NewReader(os.Stdin)
+	answer, err := reader.ReadString('\n')
+	if err != nil {
+		return false
+	}
+
+	return strings.TrimSpace(answer) == expected
 }


### PR DESCRIPTION
# Description

`baremetal reinstall` wipes every disk of the server and sent the order immediately: no confirmation, no way to preview the request, no `--dry-run`. Meanwhile shell completion helpfully offers the names of production servers, and the parameter recap is logged *after* the call.

One stray tab completion is enough to destroy a running server.

This PR adds the guardrails:

```
$ ovhcloud baremetal reinstall ns1234.ip-11.22.33.net --os debian12_64
⚠️  Reinstalling ns1234.ip-11.22.33.net wipes every disk of the server. This cannot be undone.
   Operating system to install: debian12_64
   Type "ns1234.ip-11.22.33.net" to confirm › _
```

- an interactive run asks the operator to type the server name;
- `--yes` skips the prompt — what a pipeline passes;
- `--dry-run` prints the parameters that would be sent, and sends nothing;
- a **non-interactive run without `--yes` refuses and exits non-zero**, rather than destroying data silently. This covers CI, but also `cat install.json | ovhcloud baremetal reinstall srv`, where stdin already carries the parameters and cannot carry an answer.

The confirmation applies to `--editor` and `--from-file` too: saving a file is not a confirmation, and the rule stays easy to state — nothing wipes a disk without an explicit yes.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Improvement (improvement of existing commands)
- [x] Breaking change (fix or feature that can break a current behavior)
- [ ] Documentation update

**Breaking for unattended callers**: a script that reinstalls without `--yes` now fails instead of wiping the disks. That is the intent — the failure is loud, immediate, and fixed by adding one flag.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have commented my code
- [x] I ran `go mod tidy`
- [x] I have added tests that prove my fix is effective or that my feature works

Three tests: no confirmation and no `--yes` refuses with **zero calls reaching the API**; `--yes` proceeds and posts exactly once; `--dry-run` prints the request and posts nothing.

`go build ./...`, `GOOS=js GOARCH=wasm go build ./...`, `go vet ./...` and `go test ./...` all pass. Documentation regenerated with `make doc` in a separate commit.

## Notes for reviewers

- `--dry-run` is honoured inside the shared `CreateResource` helper, immediately before the call, so **no caller signature changes** and the flag is available to any other command that wants to expose it later. Only `reinstall` exposes it here.
- The confirmation helper lives in `internal/utils`, writes its prompt to stderr, and returns false without prompting when stdin is not an interactive terminal.
