### PR TITLE
fix(edit): keep flags explicitly set to their zero value

### DIFF
--- a/internal/cmd/baremetal_test.go
+++ b/internal/cmd/baremetal_test.go
@@ -7,6 +7,7 @@ package cmd_test
 import (
 	"github.com/jarcoal/httpmock"
 	"github.com/maxatome/go-testdeep/td"
+	"github.com/maxatome/tdhttpmock"
 	"github.com/ovh/ovhcloud-cli/internal/cmd"
 )
 
@@ -115,4 +116,21 @@ func (ms *MockSuite) TestBaremetalReinstallSucceedsOnDoneTask(assert, require *t
 	_, err := cmd.Execute("baremetal", "reinstall", "fakeBaremetal", "--os", "debian12_64", "--wait")
 
 	require.CmpNoError(err)
+}
+
+// End to end: --monitoring=false must reach the API as monitoring:false,
+// instead of being dropped and silently restored from the fetched resource.
+func (ms *MockSuite) TestBaremetalEditDisablesMonitoring(assert, require *td.T) {
+	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/v1/dedicated/server/fakeBaremetal",
+		httpmock.NewStringResponder(200, `{"name":"fakeBaremetal","monitoring":true,"rootDevice":"/dev/sda"}`),
+	)
+	httpmock.RegisterMatcherResponder("PUT", "https://eu.api.ovh.com/v1/dedicated/server/fakeBaremetal",
+		tdhttpmock.JSONBody(td.JSONPointer("/monitoring", false)),
+		httpmock.NewStringResponder(200, `null`),
+	)
+
+	out, err := cmd.Execute("baremetal", "edit", "fakeBaremetal", "--monitoring=false")
+
+	require.CmpNoError(err)
+	assert.Cmp(out, td.Contains("updated successfully"))
 }

--- a/internal/services/account/account.go
+++ b/internal/services/account/account.go
@@ -91,7 +91,7 @@ func EditOauth2Client(cmd *cobra.Command, args []string) {
 		cmd,
 		"/me/api/oauth2/client/{clientId}",
 		fmt.Sprintf("/v1/me/api/oauth2/client/%s", url.PathEscape(args[0])),
-		Oauth2ClientSpec,
+		&Oauth2ClientSpec,
 		assets.MeOpenapiSchema,
 	); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "%s", err)

--- a/internal/services/cloud/cloud_loadbalancer.go
+++ b/internal/services/cloud/cloud_loadbalancer.go
@@ -426,7 +426,7 @@ func EditCloudLoadbalancer(cmd *cobra.Command, args []string) {
 		cmd,
 		"/cloud/project/{serviceName}/region/{regionName}/loadbalancing/loadbalancer/{loadBalancerId}",
 		fmt.Sprintf("/v1/cloud/project/%s/region/%s/loadbalancing/loadbalancer/%s", projectID, url.PathEscape(region), url.PathEscape(args[0])),
-		CloudLoadbalancerUpdateSpec,
+		&CloudLoadbalancerUpdateSpec,
 		assets.CloudOpenapiSchema,
 	); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "%s", err)
@@ -666,7 +666,7 @@ func EditCloudLoadbalancerListener(cmd *cobra.Command, args []string) {
 		"/cloud/project/{serviceName}/region/{regionName}/loadbalancing/listener/{listenerId}",
 		fmt.Sprintf("/v1/cloud/project/%s/region/%s/loadbalancing/listener/%s",
 			projectID, url.PathEscape(region), url.PathEscape(args[0])),
-		CloudLoadbalancerListenerUpdateSpec,
+		&CloudLoadbalancerListenerUpdateSpec,
 		assets.CloudOpenapiSchema,
 	); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "%s", err)
@@ -768,7 +768,7 @@ func EditCloudLoadbalancerPool(cmd *cobra.Command, args []string) {
 		"/cloud/project/{serviceName}/region/{regionName}/loadbalancing/pool/{poolId}",
 		fmt.Sprintf("/v1/cloud/project/%s/region/%s/loadbalancing/pool/%s",
 			projectID, url.PathEscape(region), url.PathEscape(args[0])),
-		CloudLoadbalancerPoolUpdateSpec,
+		&CloudLoadbalancerPoolUpdateSpec,
 		assets.CloudOpenapiSchema,
 	); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "%s", err)
@@ -920,7 +920,7 @@ func EditCloudLoadbalancerPoolMember(cmd *cobra.Command, args []string) {
 		"/cloud/project/{serviceName}/region/{regionName}/loadbalancing/pool/{poolId}/member/{memberId}",
 		fmt.Sprintf("/v1/cloud/project/%s/region/%s/loadbalancing/pool/%s/member/%s",
 			projectID, url.PathEscape(region), url.PathEscape(args[0]), url.PathEscape(args[1])),
-		CloudLoadbalancerPoolMemberUpdateSpec,
+		&CloudLoadbalancerPoolMemberUpdateSpec,
 		assets.CloudOpenapiSchema,
 	); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "%s", err)
@@ -1022,7 +1022,7 @@ func EditCloudLoadbalancerHealthMonitor(cmd *cobra.Command, args []string) {
 		"/cloud/project/{serviceName}/region/{regionName}/loadbalancing/healthMonitor/{healthMonitorId}",
 		fmt.Sprintf("/v1/cloud/project/%s/region/%s/loadbalancing/healthMonitor/%s",
 			projectID, url.PathEscape(region), url.PathEscape(args[0])),
-		CloudLoadbalancerHealthMonitorUpdateSpec,
+		&CloudLoadbalancerHealthMonitorUpdateSpec,
 		assets.CloudOpenapiSchema,
 	); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "%s", err)
@@ -1124,7 +1124,7 @@ func EditCloudLoadbalancerL7Policy(cmd *cobra.Command, args []string) {
 		"/cloud/project/{serviceName}/region/{regionName}/loadbalancing/l7Policy/{l7PolicyId}",
 		fmt.Sprintf("/v1/cloud/project/%s/region/%s/loadbalancing/l7Policy/%s",
 			projectID, url.PathEscape(region), url.PathEscape(args[0])),
-		CloudLoadbalancerL7PolicyUpdateSpec,
+		&CloudLoadbalancerL7PolicyUpdateSpec,
 		assets.CloudOpenapiSchema,
 	); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "%s", err)
@@ -1255,7 +1255,7 @@ func EditCloudLoadbalancerL7Rule(cmd *cobra.Command, args []string) {
 		"/cloud/project/{serviceName}/region/{regionName}/loadbalancing/l7Policy/{l7PolicyId}/l7Rule/{l7RuleId}",
 		fmt.Sprintf("/v1/cloud/project/%s/region/%s/loadbalancing/l7Policy/%s/l7Rule/%s",
 			projectID, url.PathEscape(region), url.PathEscape(args[0]), url.PathEscape(args[1])),
-		CloudLoadbalancerL7RuleUpdateSpec,
+		&CloudLoadbalancerL7RuleUpdateSpec,
 		assets.CloudOpenapiSchema,
 	); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "%s", err)

--- a/internal/services/cloud/cloud_managed_analytics.go
+++ b/internal/services/cloud/cloud_managed_analytics.go
@@ -277,7 +277,7 @@ func EditManagedAnalytics(cmd *cobra.Command, args []string) {
 		cmd,
 		fmt.Sprintf("/cloud/project/{serviceName}/database/%s/{clusterId}", url.PathEscape(analyticsService["engine"].(string))),
 		fmt.Sprintf("/v1/cloud/project/%s/database/%s/%s", projectID, url.PathEscape(analyticsService["engine"].(string)), url.PathEscape(args[0])),
-		ManagedAnalyticsSpec,
+		&ManagedAnalyticsSpec,
 		assets.CloudOpenapiSchema,
 	); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "%s", err)
@@ -1113,7 +1113,7 @@ func EditManagedAnalyticsTopic(cmd *cobra.Command, args []string) {
 		cmd,
 		fmt.Sprintf("/cloud/project/{serviceName}/database/%s/{clusterId}/topic/{topicId}", url.PathEscape(analyticsService["engine"].(string))),
 		fmt.Sprintf("/v1/cloud/project/%s/database/%s/%s/topic/%s", projectID, url.PathEscape(analyticsService["engine"].(string)), url.PathEscape(args[0]), url.PathEscape(args[1])),
-		ManagedAnalyticsTopicSpec,
+		&ManagedAnalyticsTopicSpec,
 		assets.CloudOpenapiSchema,
 	); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "%s", err)

--- a/internal/services/cloud/cloud_managed_database.go
+++ b/internal/services/cloud/cloud_managed_database.go
@@ -241,7 +241,7 @@ func EditManagedDatabase(cmd *cobra.Command, args []string) {
 		cmd,
 		fmt.Sprintf("/cloud/project/{serviceName}/database/%s/{clusterId}", url.PathEscape(databaseService["engine"].(string))),
 		fmt.Sprintf("/v1/cloud/project/%s/database/%s/%s", projectID, url.PathEscape(databaseService["engine"].(string)), url.PathEscape(args[0])),
-		ManagedDatabaseSpec,
+		&ManagedDatabaseSpec,
 		assets.CloudOpenapiSchema,
 	); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "%s", err)

--- a/internal/services/cloud/cloud_managed_kubernetes.go
+++ b/internal/services/cloud/cloud_managed_kubernetes.go
@@ -292,7 +292,7 @@ func EditKube(cmd *cobra.Command, args []string) {
 		cmd,
 		"/cloud/project/{serviceName}/kube/{kubeId}",
 		fmt.Sprintf("/v1/cloud/project/%s/kube/%s", projectID, url.PathEscape(args[0])),
-		KubeSpec,
+		&KubeSpec,
 		assets.CloudOpenapiSchema,
 	); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "%s", err)
@@ -344,7 +344,7 @@ func EditKubeCustomization(cmd *cobra.Command, args []string) {
 		cmd,
 		"/cloud/project/{serviceName}/kube/{kubeId}/customization",
 		fmt.Sprintf("/v1/cloud/project/%s/kube/%s/customization", projectID, url.PathEscape(args[0])),
-		KubeSpec.Customization,
+		&KubeSpec.Customization,
 		assets.CloudOpenapiSchema,
 	); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "%s", err)
@@ -551,7 +551,7 @@ func EditKubeNodepool(cmd *cobra.Command, args []string) {
 		cmd,
 		"/cloud/project/{serviceName}/kube/{kubeId}/nodepool/{nodepoolId}",
 		fmt.Sprintf("/v1/cloud/project/%s/kube/%s/nodepool/%s", projectID, url.PathEscape(args[0]), url.PathEscape(args[1])),
-		KubeNodepoolSpec,
+		&KubeNodepoolSpec,
 		assets.CloudOpenapiSchema,
 	); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "%s", err)
@@ -703,7 +703,7 @@ func EditKubeOIDCIntegration(cmd *cobra.Command, args []string) {
 		cmd,
 		"/cloud/project/{serviceName}/kube/{kubeId}/openIdConnect",
 		fmt.Sprintf("/v1/cloud/project/%s/kube/%s/openIdConnect", projectID, url.PathEscape(args[0])),
-		KubeOIDCConfig,
+		&KubeOIDCConfig,
 		assets.CloudOpenapiSchema,
 	); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "%s", err)
@@ -780,7 +780,7 @@ func EditKubePrivateNetworkConfiguration(cmd *cobra.Command, args []string) {
 		cmd,
 		"/cloud/project/{serviceName}/kube/{kubeId}/privateNetworkConfiguration",
 		fmt.Sprintf("/v1/cloud/project/%s/kube/%s/privateNetworkConfiguration", projectID, url.PathEscape(args[0])),
-		KubeSpec.PrivateNetworkConfiguration,
+		&KubeSpec.PrivateNetworkConfiguration,
 		assets.CloudOpenapiSchema,
 	); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "%s", err)

--- a/internal/services/cloud/cloud_managed_rancher.go
+++ b/internal/services/cloud/cloud_managed_rancher.go
@@ -93,7 +93,7 @@ func EditRancher(cmd *cobra.Command, args []string) {
 		cmd,
 		"/publicCloud/project/{projectId}/rancher/{rancherId}",
 		fmt.Sprintf("/v2/publicCloud/project/%s/rancher/%s", projectID, url.PathEscape(args[0])),
-		RancherSpec,
+		&RancherSpec,
 		assets.CloudV2OpenapiSchema,
 	); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "%s", err)

--- a/internal/services/cloud/cloud_network.go
+++ b/internal/services/cloud/cloud_network.go
@@ -528,7 +528,7 @@ func EditGateway(cmd *cobra.Command, args []string) {
 		cmd,
 		"/cloud/project/{serviceName}/region/{regionName}/gateway/{id}",
 		foundURL,
-		CloudGatewaySpec,
+		&CloudGatewaySpec,
 		assets.CloudOpenapiSchema,
 	); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "%s", err)

--- a/internal/services/cloud/cloud_project.go
+++ b/internal/services/cloud/cloud_project.go
@@ -56,7 +56,7 @@ func EditCloudProject(cmd *cobra.Command, args []string) {
 		cmd,
 		"/cloud/project/{serviceName}",
 		fmt.Sprintf("/v1/cloud/project/%s", url.PathEscape(args[0])),
-		CloudProjectSpec,
+		&CloudProjectSpec,
 		assets.CloudOpenapiSchema,
 	); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "%s", err)

--- a/internal/services/cloud/cloud_quota.go
+++ b/internal/services/cloud/cloud_quota.go
@@ -59,7 +59,7 @@ func EditCloudQuota(cmd *cobra.Command, _ []string) {
 		cmd,
 		"/publicCloud/project/{projectId}/quota",
 		fmt.Sprintf("/v2/publicCloud/project/%s/quota", projectID),
-		QuotaEditSpec,
+		&QuotaEditSpec,
 		assets.CloudV2OpenapiSchema,
 	); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "%s", err)

--- a/internal/services/cloud/cloud_storage_block.go
+++ b/internal/services/cloud/cloud_storage_block.go
@@ -143,7 +143,7 @@ func EditVolume(cmd *cobra.Command, args []string) {
 		cmd,
 		"/publicCloud/project/{projectId}/storage/block/volume/{id}",
 		endpoint,
-		VolumeEditSpec,
+		&VolumeEditSpec,
 		assets.CloudV2OpenapiSchema,
 	); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "%s", err)

--- a/internal/services/cloud/cloud_storage_file.go
+++ b/internal/services/cloud/cloud_storage_file.go
@@ -177,7 +177,7 @@ func EditShare(cmd *cobra.Command, args []string) {
 		cmd,
 		"/cloud/project/{serviceName}/region/{regionName}/share/{shareId}",
 		endpoint,
-		ShareEditSpec,
+		&ShareEditSpec,
 		assets.CloudOpenapiSchema,
 	); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "%s", err)

--- a/internal/services/cloud/cloud_storage_object.go
+++ b/internal/services/cloud/cloud_storage_object.go
@@ -244,7 +244,7 @@ func EditStorageS3(cmd *cobra.Command, args []string) {
 		cmd,
 		"/cloud/project/{serviceName}/region/{regionName}/storage/{name}",
 		foundURL,
-		StorageS3Spec,
+		&StorageS3Spec,
 		assets.CloudOpenapiSchema,
 	); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "%s", err)
@@ -468,7 +468,7 @@ func EditStorageS3Object(cmd *cobra.Command, args []string) {
 		cmd,
 		"/cloud/project/{serviceName}/region/{regionName}/storage/{name}/object/{key}",
 		foundURL+"/object/"+url.PathEscape(args[1]),
-		StorageS3ObjectSpec,
+		&StorageS3ObjectSpec,
 		assets.CloudOpenapiSchema,
 	); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "%s", err)
@@ -558,7 +558,7 @@ func EditStorageS3ObjectVersion(cmd *cobra.Command, args []string) {
 		cmd,
 		"/cloud/project/{serviceName}/region/{regionName}/storage/{name}/object/{key}/version/{versionId}",
 		foundURL+"/object/"+url.PathEscape(args[1])+"/version/"+url.PathEscape(args[2]),
-		StorageS3ObjectSpec,
+		&StorageS3ObjectSpec,
 		assets.CloudOpenapiSchema,
 	); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "%s", err)
@@ -762,7 +762,7 @@ func EditStorageS3Lifecycle(cmd *cobra.Command, args []string) {
 		cmd,
 		"/cloud/project/{serviceName}/region/{regionName}/storage/{name}/lifecycle",
 		foundURL+"/lifecycle",
-		StorageS3LifecycleSpec,
+		&StorageS3LifecycleSpec,
 		assets.CloudOpenapiSchema,
 	); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "%s", err)

--- a/internal/services/common/common.go
+++ b/internal/services/common/common.go
@@ -204,6 +204,10 @@ func EditResource(cmd *cobra.Command, path, url string, cliParams any, openapiSp
 		return fmt.Errorf("failed to parse arguments from command line: %w", err)
 	}
 
+	// Put back the values `omitempty` dropped although the user set them
+	// explicitly, such as a boolean turned to false.
+	addExplicitlySetFlags(cmd, cliParams, cliParameters)
+
 	// Handle data from file if --from-file flag is used
 	if flags.ParametersFile != "" {
 		log.Print("Flag --from-file used, all other flags will override the file values")

--- a/internal/services/common/explicit_flags.go
+++ b/internal/services/common/explicit_flags.go
@@ -1,0 +1,119 @@
+// SPDX-FileCopyrightText: 2025 OVH SAS <opensource@ovh.net>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package common
+
+import (
+	"reflect"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+// addExplicitlySetFlags puts back into the request body the fields the user
+// explicitly set on the command line but whose value was dropped by
+// `omitempty` during marshalling — a boolean set to false, an integer set to
+// zero, a string set to the empty value.
+//
+// Without this, `--monitoring=false` produced an empty body, the merge with
+// the fetched resource restored the remote value, and the CLI reported a
+// success for an update that never happened.
+//
+// Flags are matched to struct fields by address, not by name: pflag stores the
+// pointer it was given (`type boolValue bool` + `newBoolValue(val, p)` returns
+// `(*boolValue)(p)`), so the address of a flag value is the address of the
+// field it writes to. Matching by name would be wrong — several commands
+// expose a field under an unrelated flag name, for instance
+// PrivateNetworkRoutingAsDefault as `--routing-as-default`.
+func addExplicitlySetFlags(cmd *cobra.Command, cliParams any, body map[string]any) {
+	if cmd == nil || cliParams == nil || body == nil {
+		return
+	}
+
+	value := reflect.ValueOf(cliParams)
+	if value.Kind() != reflect.Ptr || value.IsNil() {
+		return
+	}
+	value = value.Elem()
+	if value.Kind() != reflect.Struct {
+		return
+	}
+
+	// Address of every addressable scalar field, with the path of JSON keys
+	// leading to it and the field itself.
+	fields := map[uintptr]targetField{}
+	collectFieldAddresses(value, nil, fields)
+
+	cmd.Flags().Visit(func(flag *pflag.Flag) {
+		flagValue := reflect.ValueOf(flag.Value)
+		if flagValue.Kind() != reflect.Ptr || flagValue.IsNil() {
+			return
+		}
+
+		target, ok := fields[flagValue.Pointer()]
+		if !ok {
+			return
+		}
+
+		// Read the value from the struct field, not from the flag: pflag
+		// stores it under its own type (pflag.boolValue), which would end up
+		// in the request body instead of a plain bool.
+		setAtPath(body, target.path, target.value.Interface())
+	})
+}
+
+// targetField is a scalar field of the parameters struct: where it belongs in
+// the request body, and the field itself.
+type targetField struct {
+	path  []string
+	value reflect.Value
+}
+
+// collectFieldAddresses walks the struct and records, for each scalar field,
+// its address and the chain of JSON keys leading to it.
+func collectFieldAddresses(value reflect.Value, prefix []string, out map[uintptr]targetField) {
+	structType := value.Type()
+
+	for i := 0; i < structType.NumField(); i++ {
+		field := structType.Field(i)
+		if !field.IsExported() {
+			continue
+		}
+
+		name, _, _ := strings.Cut(field.Tag.Get("json"), ",")
+		if name == "-" {
+			continue
+		}
+		if name == "" {
+			name = field.Name
+		}
+
+		fieldValue := value.Field(i)
+		path := append(append([]string{}, prefix...), name)
+
+		if fieldValue.Kind() == reflect.Struct {
+			collectFieldAddresses(fieldValue, path, out)
+			continue
+		}
+
+		if fieldValue.CanAddr() {
+			out[fieldValue.Addr().Pointer()] = targetField{path: path, value: fieldValue}
+		}
+	}
+}
+
+// setAtPath writes value in body, creating intermediate maps as needed.
+func setAtPath(body map[string]any, path []string, value any) {
+	for _, key := range path[:len(path)-1] {
+		next, ok := body[key].(map[string]any)
+		if !ok {
+			next = map[string]any{}
+			body[key] = next
+		}
+		body = next
+	}
+
+	body[path[len(path)-1]] = value
+}

--- a/internal/services/common/explicit_flags_callsites_test.go
+++ b/internal/services/common/explicit_flags_callsites_test.go
@@ -19,9 +19,10 @@ import (
 // Call sites that legitimately hand over something other than a pointer to a
 // package-level parameters struct. Each one is safe for a different reason.
 var editResourceValueArgAllowed = map[string]string{
-	"nil":      "vrackServices exposes no editable parameter",
-	"payload":  "container registry OIDC already builds its body from cmd.Flags().Changed",
-	"userSpec": "managed database and analytics rebuild a struct per engine, no flag points into it",
+	"nil":          "vrackServices exposes no editable parameter",
+	"payload":      "container registry OIDC already builds its body from cmd.Flags().Changed",
+	"renewPayload": "service-info already builds its body from cmd.Flags().Changed",
+	"userSpec":     "managed database and analytics rebuild a struct per engine, no flag points into it",
 }
 
 // addExplicitlySetFlags matches flags to struct fields by address, because a

--- a/internal/services/common/explicit_flags_callsites_test.go
+++ b/internal/services/common/explicit_flags_callsites_test.go
@@ -50,11 +50,16 @@ func TestEditResourceCallSitesPassAPointer(t *testing.T) {
 
 		ast.Inspect(file, func(node ast.Node) bool {
 			call, ok := node.(*ast.CallExpr)
-			if !ok || !isEditResourceCall(call.Fun) || len(call.Args) < 4 {
+			if !ok || !isEditResourceCall(call.Fun) {
 				return true
 			}
 
 			checked++
+			if len(call.Args) < 4 {
+				t.Errorf("%s: EditResource called with %d arguments, cannot locate the parameters struct",
+					fileSet.Position(call.Pos()), len(call.Args))
+				return true
+			}
 			position := fileSet.Position(call.Args[3].Pos())
 
 			switch argument := call.Args[3].(type) {
@@ -63,7 +68,13 @@ func TestEditResourceCallSitesPassAPointer(t *testing.T) {
 					t.Errorf("%s: parameters passed by value, addExplicitlySetFlags will do nothing", position)
 				}
 			case *ast.CompositeLit:
-				// A body built by hand: every key is present, nothing to restore.
+				// A body built by hand as a map: every key is present, so
+				// omitempty cannot drop anything. A struct literal is another
+				// matter — no flag points into a value built on the spot, so
+				// the mechanism would silently do nothing.
+				if _, isMap := argument.Type.(*ast.MapType); !isMap {
+					t.Errorf("%s: a struct literal cannot be matched to any flag, pass a pointer to the parameters struct", position)
+				}
 			case *ast.Ident:
 				if _, allowed := editResourceValueArgAllowed[argument.Name]; !allowed {
 					t.Errorf("%s: %s is passed by value, pass &%s so flags set to their zero value survive",
@@ -84,11 +95,13 @@ func TestEditResourceCallSitesPassAPointer(t *testing.T) {
 	td.Cmp(t, checked > 50, true, "expected the services tree to expose many edit commands, found %d", checked)
 }
 
+// isEditResourceCall matches on the function name alone, whatever package
+// qualifier carries it: pinning it to "common" would miss an aliased import,
+// and a false positive here fails loudly rather than passing in silence.
 func isEditResourceCall(fun ast.Expr) bool {
 	switch callee := fun.(type) {
 	case *ast.SelectorExpr:
-		pkg, ok := callee.X.(*ast.Ident)
-		return ok && pkg.Name == "common" && callee.Sel.Name == "EditResource"
+		return callee.Sel.Name == "EditResource"
 	case *ast.Ident:
 		return callee.Name == "EditResource"
 	}

--- a/internal/services/common/explicit_flags_callsites_test.go
+++ b/internal/services/common/explicit_flags_callsites_test.go
@@ -1,0 +1,96 @@
+// SPDX-FileCopyrightText: 2025 OVH SAS <opensource@ovh.net>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package common
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/maxatome/go-testdeep/td"
+)
+
+// Call sites that legitimately hand over something other than a pointer to a
+// package-level parameters struct. Each one is safe for a different reason.
+var editResourceValueArgAllowed = map[string]string{
+	"nil":      "vrackServices exposes no editable parameter",
+	"payload":  "container registry OIDC already builds its body from cmd.Flags().Changed",
+	"userSpec": "managed database and analytics rebuild a struct per engine, no flag points into it",
+}
+
+// addExplicitlySetFlags matches flags to struct fields by address, because a
+// flag stores the pointer it was given. A copy of the parameters struct holds
+// none of those addresses, so passing one by value turns the whole mechanism
+// into a silent no-op for that command — the exact defect this package exists
+// to fix. Every call site must therefore hand over a pointer.
+func TestEditResourceCallSitesPassAPointer(t *testing.T) {
+	servicesDir, err := filepath.Abs("..")
+	if err != nil {
+		t.Skipf("cannot locate the services directory: %s", err)
+	}
+
+	fileSet := token.NewFileSet()
+	var checked int
+
+	err = filepath.WalkDir(servicesDir, func(path string, entry fs.DirEntry, err error) error {
+		if err != nil || entry.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return err
+		}
+
+		file, err := parser.ParseFile(fileSet, path, nil, 0)
+		if err != nil {
+			return err
+		}
+
+		ast.Inspect(file, func(node ast.Node) bool {
+			call, ok := node.(*ast.CallExpr)
+			if !ok || !isEditResourceCall(call.Fun) || len(call.Args) < 4 {
+				return true
+			}
+
+			checked++
+			position := fileSet.Position(call.Args[3].Pos())
+
+			switch argument := call.Args[3].(type) {
+			case *ast.UnaryExpr:
+				if argument.Op != token.AND {
+					t.Errorf("%s: parameters passed by value, addExplicitlySetFlags will do nothing", position)
+				}
+			case *ast.CompositeLit:
+				// A body built by hand: every key is present, nothing to restore.
+			case *ast.Ident:
+				if _, allowed := editResourceValueArgAllowed[argument.Name]; !allowed {
+					t.Errorf("%s: %s is passed by value, pass &%s so flags set to their zero value survive",
+						position, argument.Name, argument.Name)
+				}
+			default:
+				t.Errorf("%s: unexpected parameters argument, expected a pointer", position)
+			}
+
+			return true
+		})
+
+		return nil
+	})
+
+	td.Require(t).CmpNoError(err)
+	// Guard against a walk that silently found nothing and passed by default.
+	td.Cmp(t, checked > 50, true, "expected the services tree to expose many edit commands, found %d", checked)
+}
+
+func isEditResourceCall(fun ast.Expr) bool {
+	switch callee := fun.(type) {
+	case *ast.SelectorExpr:
+		pkg, ok := callee.X.(*ast.Ident)
+		return ok && pkg.Name == "common" && callee.Sel.Name == "EditResource"
+	case *ast.Ident:
+		return callee.Name == "EditResource"
+	}
+	return false
+}

--- a/internal/services/common/explicit_flags_test.go
+++ b/internal/services/common/explicit_flags_test.go
@@ -1,0 +1,114 @@
+// SPDX-FileCopyrightText: 2025 OVH SAS <opensource@ovh.net>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package common
+
+import (
+	"testing"
+
+	"github.com/maxatome/go-testdeep/td"
+	"github.com/spf13/cobra"
+)
+
+type nestedSpec struct {
+	RoutingAsDefault bool `json:"routingAsDefault,omitempty"`
+}
+
+type editSpec struct {
+	Monitoring     bool       `json:"monitoring,omitempty"`
+	NoIntervention bool       `json:"noIntervention,omitempty"`
+	Retries        int        `json:"retries,omitempty"`
+	Comment        string     `json:"comment,omitempty"`
+	Network        nestedSpec `json:"network,omitempty"`
+}
+
+func newCommand(spec *editSpec) *cobra.Command {
+	cmd := &cobra.Command{Use: "edit"}
+	cmd.Flags().BoolVar(&spec.Monitoring, "monitoring", false, "")
+	cmd.Flags().BoolVar(&spec.NoIntervention, "no-intervention", false, "")
+	cmd.Flags().IntVar(&spec.Retries, "retries", 0, "")
+	cmd.Flags().StringVar(&spec.Comment, "comment", "", "")
+	// Deliberately unrelated flag name: matching by name would miss this one.
+	cmd.Flags().BoolVar(&spec.Network.RoutingAsDefault, "default-route", false, "")
+
+	return cmd
+}
+
+// A boolean explicitly set to false must reach the request body, otherwise the
+// merge with the fetched resource silently restores the remote value.
+func TestAddExplicitlySetFlags_FalseBooleanIsKept(t *testing.T) {
+	var spec editSpec
+	cmd := newCommand(&spec)
+	td.Require(t).CmpNoError(cmd.Flags().Parse([]string{"--monitoring=false"}))
+
+	body := map[string]any{}
+	addExplicitlySetFlags(cmd, &spec, body)
+
+	td.Cmp(t, body, map[string]any{"monitoring": false})
+}
+
+// Fields the user did not mention must stay out of the body: an edit is a
+// partial update.
+func TestAddExplicitlySetFlags_UntouchedFieldsAreLeftOut(t *testing.T) {
+	var spec editSpec
+	cmd := newCommand(&spec)
+	td.Require(t).CmpNoError(cmd.Flags().Parse([]string{"--monitoring=false"}))
+
+	body := map[string]any{}
+	addExplicitlySetFlags(cmd, &spec, body)
+
+	td.Cmp(t, body["noIntervention"], nil)
+	td.Cmp(t, body["comment"], nil)
+	td.Cmp(t, body["retries"], nil)
+}
+
+// Zero values of other kinds are dropped by omitempty just the same.
+func TestAddExplicitlySetFlags_ZeroValuesOfEveryKind(t *testing.T) {
+	var spec editSpec
+	cmd := newCommand(&spec)
+	td.Require(t).CmpNoError(cmd.Flags().Parse([]string{"--retries=0", "--comment="}))
+
+	body := map[string]any{}
+	addExplicitlySetFlags(cmd, &spec, body)
+
+	td.Cmp(t, body["retries"], 0)
+	td.Cmp(t, body["comment"], "")
+}
+
+// Flags are matched by address, so a flag whose name has nothing to do with
+// the field it writes to is still restored — and lands at the right depth.
+func TestAddExplicitlySetFlags_NestedFieldUnderUnrelatedFlagName(t *testing.T) {
+	var spec editSpec
+	cmd := newCommand(&spec)
+	td.Require(t).CmpNoError(cmd.Flags().Parse([]string{"--default-route=false"}))
+
+	body := map[string]any{}
+	addExplicitlySetFlags(cmd, &spec, body)
+
+	td.Cmp(t, body, map[string]any{"network": map[string]any{"routingAsDefault": false}})
+}
+
+// An existing value at the same path must not be clobbered by a sibling.
+func TestAddExplicitlySetFlags_KeepsSiblingsOfNestedPath(t *testing.T) {
+	var spec editSpec
+	cmd := newCommand(&spec)
+	td.Require(t).CmpNoError(cmd.Flags().Parse([]string{"--default-route=false"}))
+
+	body := map[string]any{"network": map[string]any{"vlanId": float64(42)}}
+	addExplicitlySetFlags(cmd, &spec, body)
+
+	td.Cmp(t, body, map[string]any{
+		"network": map[string]any{"vlanId": float64(42), "routingAsDefault": false},
+	})
+}
+
+func TestAddExplicitlySetFlags_ToleratesNilInputs(t *testing.T) {
+	var spec editSpec
+	cmd := newCommand(&spec)
+
+	addExplicitlySetFlags(nil, &spec, map[string]any{})
+	addExplicitlySetFlags(cmd, nil, map[string]any{})
+	addExplicitlySetFlags(cmd, &spec, nil)
+	addExplicitlySetFlags(cmd, editSpec{}, map[string]any{}) // not a pointer
+}

--- a/internal/services/dedicatedceph/dedicatedceph.go
+++ b/internal/services/dedicatedceph/dedicatedceph.go
@@ -41,7 +41,7 @@ func EditDedicatedCeph(cmd *cobra.Command, args []string) {
 		cmd,
 		"/dedicated/ceph/{serviceName}",
 		fmt.Sprintf("/v1/dedicated/ceph/%s", url.PathEscape(args[0])),
-		DedicatedCephSpec,
+		&DedicatedCephSpec,
 		assets.DedicatedcephOpenapiSchema,
 	); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "%s", err)

--- a/internal/services/dedicatednasha/dedicatednasha.go
+++ b/internal/services/dedicatednasha/dedicatednasha.go
@@ -41,7 +41,7 @@ func EditDedicatedNasHA(cmd *cobra.Command, args []string) {
 		cmd,
 		"/dedicated/nasha/{serviceName}",
 		fmt.Sprintf("/v1/dedicated/nasha/%s", url.PathEscape(args[0])),
-		DedicatedNasHASpec,
+		&DedicatedNasHASpec,
 		assets.DedicatednashaOpenapiSchema,
 	); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "%s", err)

--- a/internal/services/domainname/domainname.go
+++ b/internal/services/domainname/domainname.go
@@ -41,7 +41,7 @@ func EditDomainName(cmd *cobra.Command, args []string) {
 		cmd,
 		"/domain/{serviceName}",
 		fmt.Sprintf("/v1/domain/%s", url.PathEscape(args[0])),
-		DomainSpec,
+		&DomainSpec,
 		assets.DomainOpenapiSchema,
 	); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "%s", err)

--- a/internal/services/domainzone/domainzone.go
+++ b/internal/services/domainzone/domainzone.go
@@ -133,7 +133,7 @@ func UpdateRecord(cmd *cobra.Command, args []string) {
 		cmd,
 		"/domain/zone/{zoneName}/record/{id}",
 		fmt.Sprintf("/v1/domain/zone/%s/record/%s", url.PathEscape(args[0]), url.PathEscape(args[1])),
-		UpdateRecordSpec,
+		&UpdateRecordSpec,
 		assets.DomainOpenapiSchema,
 	); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "%s", err)

--- a/internal/services/emailmxplan/emailmxplan.go
+++ b/internal/services/emailmxplan/emailmxplan.go
@@ -58,7 +58,7 @@ func EditEmailMXPlan(cmd *cobra.Command, args []string) {
 		cmd,
 		"/email/mxplan/{service}",
 		fmt.Sprintf("/v1/email/mxplan/%s", url.PathEscape(args[0])),
-		EmailMXPlanSpec,
+		&EmailMXPlanSpec,
 		assets.EmailmxplanOpenapiSchema,
 	); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "%s", err)

--- a/internal/services/emailpro/emailpro.go
+++ b/internal/services/emailpro/emailpro.go
@@ -58,7 +58,7 @@ func EditEmailPro(cmd *cobra.Command, args []string) {
 		cmd,
 		"/email/pro/{service}",
 		fmt.Sprintf("/v1/email/pro/%s", url.PathEscape(args[0])),
-		EmailProSpec,
+		&EmailProSpec,
 		assets.EmailproOpenapiSchema,
 	); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "%s", err)

--- a/internal/services/iam/iam.go
+++ b/internal/services/iam/iam.go
@@ -119,7 +119,7 @@ func EditIAMPolicy(cmd *cobra.Command, args []string) {
 		cmd,
 		"/iam/policy/{policyId}",
 		fmt.Sprintf("/v2/iam/policy/%s", url.PathEscape(args[0])),
-		IAMPolicySpec,
+		&IAMPolicySpec,
 		assets.IamOpenapiSchema,
 	); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "%s", err)
@@ -170,7 +170,7 @@ func EditIAMPermissionsGroup(cmd *cobra.Command, args []string) {
 		cmd,
 		"/iam/permissionsGroup/{permissionsGroupURN}",
 		fmt.Sprintf("/v2/iam/permissionsGroup/%s", url.PathEscape(args[0])),
-		IAMPolicySpec,
+		&IAMPolicySpec,
 		assets.IamOpenapiSchema,
 	); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "%s", err)
@@ -191,7 +191,7 @@ func EditIAMResource(cmd *cobra.Command, args []string) {
 		cmd,
 		"/iam/resource/{resourceURN}",
 		fmt.Sprintf("/v2/iam/resource/%s", url.PathEscape(args[0])),
-		IAMResourceSpec,
+		&IAMResourceSpec,
 		assets.IamOpenapiSchema,
 	); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "%s", err)
@@ -221,7 +221,7 @@ func EditIAMResourceGroup(cmd *cobra.Command, args []string) {
 		cmd,
 		"/iam/resourceGroup/{groupId}",
 		fmt.Sprintf("/v2/iam/resourceGroup/%s", url.PathEscape(args[0])),
-		IAMPolicySpec,
+		&IAMPolicySpec,
 		assets.IamOpenapiSchema,
 	); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "%s", err)
@@ -278,7 +278,7 @@ func EditUser(cmd *cobra.Command, args []string) {
 		cmd,
 		"/me/identity/user/{user}",
 		fmt.Sprintf("/v1/me/identity/user/%s", url.PathEscape(args[0])),
-		UserSpec,
+		&UserSpec,
 		assets.MeOpenapiSchema,
 	); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "%s", err)

--- a/internal/services/ip/ip.go
+++ b/internal/services/ip/ip.go
@@ -41,7 +41,7 @@ func EditIp(cmd *cobra.Command, args []string) {
 		cmd,
 		"/ip/{ip}",
 		fmt.Sprintf("/v1/ip/%s", url.PathEscape(args[0])),
-		IPSpec,
+		&IPSpec,
 		assets.IpOpenapiSchema,
 	); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "%s", err)

--- a/internal/services/iploadbalancing/iploadbalancing.go
+++ b/internal/services/iploadbalancing/iploadbalancing.go
@@ -41,7 +41,7 @@ func EditIpLoadbalancing(cmd *cobra.Command, args []string) {
 		cmd,
 		"/ipLoadbalancing/{serviceName}",
 		fmt.Sprintf("/v1/ipLoadbalancing/%s", url.PathEscape(args[0])),
-		IPLoadbalancingSpec,
+		&IPLoadbalancingSpec,
 		assets.IploadbalancingOpenapiSchema,
 	); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "%s", err)

--- a/internal/services/ldp/ldp.go
+++ b/internal/services/ldp/ldp.go
@@ -41,7 +41,7 @@ func EditLdp(cmd *cobra.Command, args []string) {
 		cmd,
 		"/dbaas/logs/{serviceName}",
 		fmt.Sprintf("/v1/dbaas/logs/%s", url.PathEscape(args[0])),
-		LdpSpec,
+		&LdpSpec,
 		assets.LdpOpenapiSchema,
 	); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "%s", err)

--- a/internal/services/overthebox/overthebox.go
+++ b/internal/services/overthebox/overthebox.go
@@ -42,7 +42,7 @@ func EditOverTheBox(cmd *cobra.Command, args []string) {
 		cmd,
 		"/overTheBox/{serviceName}",
 		fmt.Sprintf("/v1/overTheBox/%s", url.PathEscape(args[0])),
-		OverTheBoxSpec,
+		&OverTheBoxSpec,
 		assets.OvertheboxOpenapiSchema,
 	); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "%s", err)

--- a/internal/services/ovhcloudconnect/ovhcloudconnect.go
+++ b/internal/services/ovhcloudconnect/ovhcloudconnect.go
@@ -40,7 +40,7 @@ func EditOvhCloudConnect(cmd *cobra.Command, args []string) {
 		cmd,
 		"/ovhCloudConnect/{serviceName}",
 		fmt.Sprintf("/v1/ovhCloudConnect/%s", url.PathEscape(args[0])),
-		OvhCloudConnectSpec,
+		&OvhCloudConnectSpec,
 		assets.OvhcloudconnectOpenapiSchema,
 	); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "%s", err)

--- a/internal/services/packxdsl/packxdsl.go
+++ b/internal/services/packxdsl/packxdsl.go
@@ -40,7 +40,7 @@ func EditPackXDSL(cmd *cobra.Command, args []string) {
 		cmd,
 		"/pack/xdsl/{packName}",
 		fmt.Sprintf("/v1/pack/xdsl/%s", url.PathEscape(args[0])),
-		PackXDSLSpec,
+		&PackXDSLSpec,
 		assets.PackxdslOpenapiSchema,
 	); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "%s", err)

--- a/internal/services/sms/sms.go
+++ b/internal/services/sms/sms.go
@@ -58,7 +58,7 @@ func EditSms(cmd *cobra.Command, args []string) {
 		cmd,
 		"/sms/{serviceName}",
 		fmt.Sprintf("/v1/sms/%s", url.PathEscape(args[0])),
-		SmsSpec,
+		&SmsSpec,
 		assets.SmsOpenapiSchema,
 	); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "%s", err)

--- a/internal/services/sslgateway/sslgateway.go
+++ b/internal/services/sslgateway/sslgateway.go
@@ -46,7 +46,7 @@ func EditSslGateway(cmd *cobra.Command, args []string) {
 		cmd,
 		"/sslGateway/{serviceName}",
 		fmt.Sprintf("/v1/sslGateway/%s", url.PathEscape(args[0])),
-		SSLGatewaySpec,
+		&SSLGatewaySpec,
 		assets.SslgatewayOpenapiSchema,
 	); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "%s", err)

--- a/internal/services/storagenetapp/storagenetapp.go
+++ b/internal/services/storagenetapp/storagenetapp.go
@@ -40,7 +40,7 @@ func EditStorageNetApp(cmd *cobra.Command, args []string) {
 		cmd,
 		"/storage/netapp/{serviceName}",
 		fmt.Sprintf("/v1/storage/netapp/%s", url.PathEscape(args[0])),
-		StorageNetAppSpec,
+		&StorageNetAppSpec,
 		assets.SmsOpenapiSchema,
 	); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "%s", err)

--- a/internal/services/telephony/telephony.go
+++ b/internal/services/telephony/telephony.go
@@ -47,7 +47,7 @@ func EditTelephony(cmd *cobra.Command, args []string) {
 		cmd,
 		"/telephony/{billingAccount}",
 		fmt.Sprintf("/v1/telephony/%s", url.PathEscape(args[0])),
-		TelephonySpec,
+		&TelephonySpec,
 		assets.TelephonyOpenapiSchema,
 	); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "%s", err)

--- a/internal/services/vmwareclouddirectorbackup/vmwareclouddirectorbackup.go
+++ b/internal/services/vmwareclouddirectorbackup/vmwareclouddirectorbackup.go
@@ -71,7 +71,7 @@ func EditVmwareCloudDirectorBackup(cmd *cobra.Command, args []string) {
 		cmd,
 		"/vmwareCloudDirector/backup/{backupId}",
 		fmt.Sprintf("/v2/vmwareCloudDirector/backup/%s", url.PathEscape(args[0])),
-		VmwareCloudDirectorBackupSpec,
+		&VmwareCloudDirectorBackupSpec,
 		assets.VmwareclouddirectorbackupOpenapiSchema,
 	); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "%s", err)

--- a/internal/services/vmwareclouddirectororganization/vmwareclouddirectororganization.go
+++ b/internal/services/vmwareclouddirectororganization/vmwareclouddirectororganization.go
@@ -43,7 +43,7 @@ func EditVmwareCloudDirectorOrganization(cmd *cobra.Command, args []string) {
 		cmd,
 		"/vmwareCloudDirector/organization/{organizationId}",
 		fmt.Sprintf("/v2/vmwareCloudDirector/organization/%s", url.PathEscape(args[0])),
-		VmwareCloudDirectorOrganizationSpec,
+		&VmwareCloudDirectorOrganizationSpec,
 		assets.VmwareclouddirectororganizationOpenapiSchema,
 	); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "%s", err)

--- a/internal/services/vps/vps.go
+++ b/internal/services/vps/vps.go
@@ -110,7 +110,7 @@ func EditVps(cmd *cobra.Command, args []string) {
 		cmd,
 		"/vps/{serviceName}",
 		fmt.Sprintf("/v1/vps/%s", url.PathEscape(args[0])),
-		VpsSpec,
+		&VpsSpec,
 		assets.VpsOpenapiSchema,
 	); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "%s", err)
@@ -139,7 +139,7 @@ func EditVpsSnapshot(cmd *cobra.Command, args []string) {
 		cmd,
 		"/vps/{serviceName}/snapshot",
 		fmt.Sprintf("/v1/vps/%s/snapshot", url.PathEscape(args[0])),
-		VpsSnapshotSpec,
+		&VpsSnapshotSpec,
 		assets.VpsOpenapiSchema,
 	); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "%s", err)
@@ -314,7 +314,7 @@ func EditVpsServiceInfo(cmd *cobra.Command, args []string) {
 		cmd,
 		"/vps/{serviceName}/serviceInfos",
 		fmt.Sprintf("/v1/vps/%s/serviceInfos", url.PathEscape(args[0])),
-		common.ServiceInfoSpec,
+		&common.ServiceInfoSpec,
 		assets.VpsOpenapiSchema,
 	); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "%s", err)
@@ -363,7 +363,7 @@ func EditVpsDisk(cmd *cobra.Command, args []string) {
 		cmd,
 		"/vps/{serviceName}/disks/{id}",
 		fmt.Sprintf("/v1/vps/%s/disks/%s", url.PathEscape(args[0]), url.PathEscape(args[1])),
-		VpsDiskSpec,
+		&VpsDiskSpec,
 		assets.VpsOpenapiSchema,
 	); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "%s", err)

--- a/internal/services/vrack/vrack.go
+++ b/internal/services/vrack/vrack.go
@@ -41,7 +41,7 @@ func EditVrack(cmd *cobra.Command, args []string) {
 		cmd,
 		"/vrack/{serviceName}",
 		fmt.Sprintf("/v1/vrack/%s", url.PathEscape(args[0])),
-		VrackSpec,
+		&VrackSpec,
 		assets.VrackOpenapiSchema,
 	); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "%s", err)

--- a/internal/services/webhosting/webhosting.go
+++ b/internal/services/webhosting/webhosting.go
@@ -357,7 +357,7 @@ func EditWebHosting(cmd *cobra.Command, args []string) {
 		cmd,
 		"/hosting/web/{serviceName}",
 		fmt.Sprintf("/v1/hosting/web/%s", url.PathEscape(args[0])),
-		WebHostingSpec,
+		&WebHostingSpec,
 		assets.WebhostingOpenapiSchema,
 	); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "%s", err)

--- a/internal/services/xdsl/xdsl.go
+++ b/internal/services/xdsl/xdsl.go
@@ -42,7 +42,7 @@ func EditXdsl(cmd *cobra.Command, args []string) {
 		cmd,
 		"/xdsl/{serviceName}",
 		fmt.Sprintf("/v1/xdsl/%s", url.PathEscape(args[0])),
-		XdslSpec,
+		&XdslSpec,
 		assets.XdslOpenapiSchema,
 	); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "%s", err)


### PR DESCRIPTION
# Description

Edit commands marshal their parameters struct, which uses `omitempty`. A flag set to `false`, `0` or `""` therefore disappears from the request body. That body is then merged into the resource fetched from the API — which restores the remote value. The call succeeds, nothing changes, and the CLI prints `✅ Resource updated successfully`.

Concretely, on a dedicated server:

```
$ ovhcloud baremetal edit ns1234.ip-11.22.33.net --monitoring=false
✅ Resource updated successfully      # monitoring is still enabled
```

The operator finds out during the maintenance window they thought they had silenced.

This PR puts explicitly-set values back into the body before the merge.

**Flags are matched to struct fields by address, not by name.** pflag keeps the pointer it was given (`type boolValue bool`, `newBoolValue(val, p)` returns `(*boolValue)(p)`), so a flag value and the field it writes to share an address. Matching by name would have silently missed the commands that expose a field under an unrelated flag name — `PrivateNetworkRoutingAsDefault` behind `--routing-as-default`, or nested flags using dots such as `--network.private.create.subnet-enable-dhcp` — that is, it would have reproduced the same bug elsewhere.

Nested structs are supported, values already present in the body at the same path are preserved, and fields the user did not mention stay out: an edit remains a partial update.

## Correction — the reach of the first commit was overstated

The automated review was right, and I had it wrong. The first commit claimed the 64 edit commands benefited. They did not.

Matching by address only works on the struct the flags were registered against. `EditResource` received a **copy** from every service but BareMetal, and a copy holds none of those addresses, so the guard clause on a non-pointer argument returned immediately. The mechanism was a silent no-op everywhere else — it fixed nothing and reported nothing, which is the worst of the two.

Measured on this tree before the second commit:

```
call sites of EditResource : 64
  by pointer (fix applies)  :  1   -> baremetal
  by value   (no-op)        : 63
```

The second commit hands the struct over by pointer at 56 further call sites. `EditResource` only marshals that argument to JSON, and a pointer to a struct marshals exactly like the struct, so nothing else changes.

Seven call sites keep their current argument, each for its own reason:

| call site | argument | why |
|---|---|---|
| vrackServices | `nil` | no editable parameter |
| container registry, Swift container, private database | map literal | every key is present by construction, `omitempty` cannot drop anything |
| container registry OIDC | `payload` | already assembles its body from `Flags().Changed` |
| managed database, managed analytics | `userSpec` | a per-engine struct rebuilt locally, so no flag points into the value being sent |

The last two keep the defect, on the name and roles of a database user. Matching by address cannot reach them, and I would rather leave that visible than paper over it.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (improvement of existing commands)
- [ ] Breaking change (fix or feature that can break a current behavior)
- [ ] Documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have commented my code
- [x] I ran `go mod tidy`
- [x] I have added tests that prove my fix is effective or that my feature works

Six unit tests in `internal/services/common/explicit_flags_test.go` — false boolean kept, untouched fields left out, zero values of every kind, nested field reached through an unrelated flag name, siblings preserved, nil inputs tolerated — plus one end-to-end test asserting that `baremetal edit --monitoring=false` sends `"monitoring": false` in the PUT body.

`explicit_flags_callsites_test.go` walks the services tree and fails on any call site handing over a value, naming the file, the line and the fix. It carries a positive control: reverting a single site to its previous form makes it fail, so it gates the behaviour rather than its own presence. It also refuses to pass on an empty walk.

`go build ./...`, `GOOS=js GOARCH=wasm go build ./...`, `go vet ./...` and the full `go test ./...` pass. `make doc` produces no change: the behaviour of existing flags is fixed, not their surface.
