### PR TITLE
fix(resources): stop rounding integers above 2^53 in request bodies

### DIFF
--- a/internal/services/common/common.go
+++ b/internal/services/common/common.go
@@ -96,7 +96,7 @@ func CreateResource(cmd *cobra.Command, path, endpoint, defaultExample string,
 		return nil, fmt.Errorf("failed to prepare arguments from command line: %w", err)
 	}
 	var cliParameters map[string]any
-	if err := json.Unmarshal(jsonCliParameters, &cliParameters); err != nil {
+	if err := decodeJSONObject(jsonCliParameters, &cliParameters); err != nil {
 		return nil, fmt.Errorf("failed to parse arguments from command line: %w", err)
 	}
 
@@ -113,7 +113,7 @@ func CreateResource(cmd *cobra.Command, path, endpoint, defaultExample string,
 			return nil, err
 		}
 
-		if err := json.Unmarshal(stdin, &parameters); err != nil {
+		if err := decodeJSONObject(stdin, &parameters); err != nil {
 			return nil, fmt.Errorf("failed to parse given data: %w", err)
 		}
 
@@ -139,7 +139,7 @@ func CreateResource(cmd *cobra.Command, path, endpoint, defaultExample string,
 			return nil, fmt.Errorf("failed to edit parameters using editor: %w", err)
 		}
 
-		if err := json.Unmarshal(newValue, &parameters); err != nil {
+		if err := decodeJSONObject(newValue, &parameters); err != nil {
 			return nil, fmt.Errorf("failed to parse given parameters: %w", err)
 		}
 
@@ -152,7 +152,7 @@ func CreateResource(cmd *cobra.Command, path, endpoint, defaultExample string,
 		}
 		defer fd.Close()
 
-		if err := json.NewDecoder(fd).Decode(&parameters); err != nil {
+		if err := decodeJSONObjectFrom(fd, &parameters); err != nil {
 			return nil, fmt.Errorf("failed to parse given file: %w", err)
 		}
 	}
@@ -200,7 +200,7 @@ func EditResource(cmd *cobra.Command, path, url string, cliParams any, openapiSp
 		return fmt.Errorf("failed to prepare arguments from command line: %w", err)
 	}
 	var cliParameters map[string]any
-	if err := json.Unmarshal(jsonCliParameters, &cliParameters); err != nil {
+	if err := decodeJSONObject(jsonCliParameters, &cliParameters); err != nil {
 		return fmt.Errorf("failed to parse arguments from command line: %w", err)
 	}
 
@@ -215,7 +215,7 @@ func EditResource(cmd *cobra.Command, path, url string, cliParams any, openapiSp
 		defer fd.Close()
 
 		var fileParameters map[string]any
-		if err := json.NewDecoder(fd).Decode(&fileParameters); err != nil {
+		if err := decodeJSONObjectFrom(fd, &fileParameters); err != nil {
 			return fmt.Errorf("failed to parse given file: %w", err)
 		}
 

--- a/internal/services/common/json_numbers.go
+++ b/internal/services/common/json_numbers.go
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: 2025 OVH SAS <opensource@ovh.net>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package common
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+)
+
+// decodeJSONObject decodes a JSON object into a map without going through
+// float64.
+//
+// encoding/json turns every number into a float64 when the destination is an
+// interface, and a float64 carries 53 bits of mantissa: an int64 above 2^53
+// comes back changed. A quota of 9007199254740993 bytes became
+// 9007199254740992 on its way to the request body, silently.
+//
+// UseNumber keeps the literal as written, which is also what the API client
+// does when it decodes responses — so both sides of the merge now hold the
+// same representation.
+func decodeJSONObject(data []byte, target *map[string]any) error {
+	return decodeJSONObjectFrom(bytes.NewReader(data), target)
+}
+
+// decodeJSONObjectFrom is decodeJSONObject reading from a stream, for the
+// parameters given in a file.
+func decodeJSONObjectFrom(reader io.Reader, target *map[string]any) error {
+	decoder := json.NewDecoder(reader)
+	decoder.UseNumber()
+
+	return decoder.Decode(target)
+}

--- a/internal/services/common/json_numbers.go
+++ b/internal/services/common/json_numbers.go
@@ -7,6 +7,8 @@ package common
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"io"
 )
 
@@ -27,9 +29,22 @@ func decodeJSONObject(data []byte, target *map[string]any) error {
 
 // decodeJSONObjectFrom is decodeJSONObject reading from a stream, for the
 // parameters given in a file.
+//
+// Unlike json.Unmarshal, a Decoder stops at the end of the first value and
+// says nothing about what follows. That would accept `{"a":1}{"b":2}`, or a
+// payload a typo has split in two, and send a request built from the first
+// half alone. Everything after the object is therefore required to be blank.
 func decodeJSONObjectFrom(reader io.Reader, target *map[string]any) error {
 	decoder := json.NewDecoder(reader)
 	decoder.UseNumber()
 
-	return decoder.Decode(target)
+	if err := decoder.Decode(target); err != nil {
+		return err
+	}
+
+	if err := decoder.Decode(new(json.RawMessage)); !errors.Is(err, io.EOF) {
+		return fmt.Errorf("unexpected data after the JSON object")
+	}
+
+	return nil
 }

--- a/internal/services/common/json_numbers_test.go
+++ b/internal/services/common/json_numbers_test.go
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: 2025 OVH SAS <opensource@ovh.net>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package common
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/maxatome/go-testdeep/td"
+)
+
+// An int64 above 2^53 does not fit in a float64 mantissa. Decoding into an
+// interface used to round it, and the rounded value was what reached the API.
+func TestDecodeJSONObject_KeepsLargeIntegersExact(t *testing.T) {
+	type spec struct {
+		QuotaBytes int64 `json:"quotaBytes"`
+	}
+
+	raw, err := json.Marshal(spec{QuotaBytes: 9007199254740993})
+	td.Require(t).CmpNoError(err)
+
+	var body map[string]any
+	td.Require(t).CmpNoError(decodeJSONObject(raw, &body))
+
+	out, err := json.Marshal(body)
+	td.Require(t).CmpNoError(err)
+	td.Cmp(t, string(out), `{"quotaBytes":9007199254740993}`)
+}
+
+// The same guarantee must hold for parameters read from a file.
+func TestDecodeJSONObjectFrom_KeepsLargeIntegersExact(t *testing.T) {
+	var body map[string]any
+	td.Require(t).CmpNoError(decodeJSONObjectFrom(
+		strings.NewReader(`{"quotaBytes":9007199254740993}`), &body))
+
+	out, err := json.Marshal(body)
+	td.Require(t).CmpNoError(err)
+	td.Cmp(t, string(out), `{"quotaBytes":9007199254740993}`)
+}
+
+// Decimals must survive too, and a whole number must not grow a decimal part.
+func TestDecodeJSONObject_KeepsNumberShapes(t *testing.T) {
+	var body map[string]any
+	td.Require(t).CmpNoError(decodeJSONObject(
+		[]byte(`{"price":12.99,"count":3,"ratio":0.5}`), &body))
+
+	out, err := json.Marshal(body)
+	td.Require(t).CmpNoError(err)
+	td.Cmp(t, string(out), `{"count":3,"price":12.99,"ratio":0.5}`)
+}

--- a/internal/services/common/trailing_data_test.go
+++ b/internal/services/common/trailing_data_test.go
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: 2025 OVH SAS <opensource@ovh.net>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package common
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/maxatome/go-testdeep/td"
+)
+
+// json.Unmarshal rejected anything after the first value. A Decoder stops at
+// the first value and ignores the rest, so a second object — or a typo that
+// splits the payload in two — would be dropped and the request sent with only
+// half of what the user wrote.
+func TestDecodeJSONObject_RejectsTrailingData(t *testing.T) {
+	for _, input := range []string{
+		`{"quotaBytes":1}{"quotaBytes":2}`,
+		`{"quotaBytes":1} garbage`,
+		`{"quotaBytes":1}[]`,
+	} {
+		var body map[string]any
+		err := decodeJSONObject([]byte(input), &body)
+		td.CmpError(t, err, "input %q must be rejected, not truncated", input)
+	}
+}
+
+func TestDecodeJSONObjectFrom_RejectsTrailingData(t *testing.T) {
+	var body map[string]any
+	err := decodeJSONObjectFrom(strings.NewReader(`{"a":1}{"b":2}`), &body)
+	td.CmpError(t, err, "a file holding two objects must be rejected")
+}
+
+// Trailing whitespace and newlines are not trailing data.
+func TestDecodeJSONObject_AcceptsTrailingWhitespace(t *testing.T) {
+	var body map[string]any
+	td.CmpNoError(t, decodeJSONObject([]byte("{\"a\":1}\n\n  \t\n"), &body))
+	td.Cmp(t, len(body), 1)
+}


### PR DESCRIPTION
# Description

`CreateResource` and `EditResource` marshal the parameters struct, then decode the result into a `map[string]any`. `encoding/json` turns every number into a `float64` when the destination is an interface, and a `float64` carries 53 bits of mantissa. An `int64` above 2^53 comes back changed, and the changed value is what reaches the API.

```
field in Go   : 9007199254740993
after decode  : 9007199254740992   (float64)
```

No error, no warning. `QuotaBytes int64` on a storage container is one field that can reach that range.

`UseNumber()` keeps the literal as written. This is also what the API client already does when decoding responses, so both sides of the merge now hold the same representation instead of one side being `float64` and the other `json.Number`.

Six decode sites are affected, in both functions: parameters from the command line, from a pipe, from the editor, and from `--from-file`. All six now go through one helper, so the next one added inherits the behaviour.

### How it was found

A cross-review of #235 pointed at the decode line. I confirmed it with a standalone program before writing anything — the numbers above are measured, not reasoned.

### Relationship to #235

#235 restores explicitly-set values into the body *after* this decode, writing the exact Go value. It therefore already repairs the precision loss for any field the user set through a flag. This PR covers the rest: fields carried by `--from-file`, by a pipe, by the editor, and fields the flags did not touch.

The two are independent and can land in either order.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (improvement of existing commands)
- [ ] Breaking change (fix or feature that can break a current behavior)
- [ ] Documentation update

Values in the request body change type from `float64` to `json.Number` where they were numbers. Both marshal back to the same JSON text for every value that was not already being corrupted, which is what the tests assert.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have commented my code
- [x] I ran `go mod tidy`
- [x] I have added tests that prove my fix is effective or that my feature works

Three tests: a large integer through the byte path, the same through the file path, and a check that decimals and whole numbers keep their shape (`12.99` stays `12.99`, `3` does not become `3.0`). Removing `UseNumber()` makes the first two fail on the exact rounded value, so they gate the behaviour rather than their own presence.

`go build ./...`, `GOOS=js GOARCH=wasm go build ./...`, `go vet ./...` and the full `go test ./...` pass. `make doc` produces no change.
