### PR TITLE
feat(completion): wire the existing cache to every service list

### DIFF
--- a/internal/completion/cache_key.go
+++ b/internal/completion/cache_key.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/ovh/ovhcloud-cli/internal/config"
 	"github.com/ovh/ovhcloud-cli/internal/flags"
 	httpLib "github.com/ovh/ovhcloud-cli/internal/http"
 )
@@ -24,9 +25,16 @@ import (
 // Credentials only ever enter the SHA-256 digest, so nothing readable is
 // written to disk. The readable prefix is the endpoint alone, so that the cache
 // directory can still be inspected by hand.
+// The profile has to be the ACTIVE one, not the --profile flag: OVH_PROFILE and
+// the `[default] profile` setting select an account without the flag ever being
+// set, so hashing the flag alone leaves those two cases sharing a key. And
+// clientIdentity() cannot make up for it here — completion skips
+// PersistentPreRun, so on a real keystroke there is no API client at all and it
+// contributes nothing. The two gaps line up exactly on the path that matters.
 func cacheKeyFor(endpoint string) string {
 	digest := sha256.Sum256([]byte(strings.Join(
-		append([]string{flags.Profile, endpoint}, clientIdentity()...), "\x00")))
+		append([]string{config.GetActiveProfileName(flags.CliConfig, flags.Profile), endpoint},
+			clientIdentity()...), "\x00")))
 
 	return fmt.Sprintf("%s-%x", slugify(endpoint), digest[:8])
 }

--- a/internal/completion/cache_key.go
+++ b/internal/completion/cache_key.go
@@ -10,21 +10,41 @@ import (
 	"strings"
 
 	"github.com/ovh/ovhcloud-cli/internal/flags"
+	httpLib "github.com/ovh/ovhcloud-cli/internal/http"
 )
 
 // cacheKeyFor derives the cache file name of an endpoint's suggestions.
 //
-// The key is scoped to the active profile as well as to the endpoint: profiles
-// point at different accounts, and a cache shared between them would suggest,
-// for ten minutes, the identifiers of a fleet the user is no longer working on.
+// The key is scoped to the account the client actually resolved to, not merely
+// to --profile: OVH_ENDPOINT and OVH_CONSUMER_KEY override the profile, and in
+// legacy mode there is no profile at all. Keying on the profile alone would let
+// two accounts, or two regions, share one cache entry and suggest for ten
+// minutes the identifiers of a fleet the user is not working on.
 //
-// The readable prefix is there so that the cache directory can be inspected by
-// hand; the digest is what makes the key unambiguous, since the prefix drops
-// every character a file name cannot carry.
+// Credentials only ever enter the SHA-256 digest, so nothing readable is
+// written to disk. The readable prefix is the endpoint alone, so that the cache
+// directory can still be inspected by hand.
 func cacheKeyFor(endpoint string) string {
-	digest := sha256.Sum256([]byte(flags.Profile + "\x00" + endpoint))
+	digest := sha256.Sum256([]byte(strings.Join(
+		append([]string{flags.Profile, endpoint}, clientIdentity()...), "\x00")))
 
 	return fmt.Sprintf("%s-%x", slugify(endpoint), digest[:8])
+}
+
+// clientIdentity returns what pins the API client to one account and one
+// region. The access token is deliberately left out: it rotates, and including
+// it would throw the cache away on every refresh for no gain in isolation.
+func clientIdentity() []string {
+	if httpLib.Client == nil {
+		return nil
+	}
+
+	return []string{
+		httpLib.Client.Endpoint(),
+		httpLib.Client.AppKey,
+		httpLib.Client.ConsumerKey,
+		httpLib.Client.ClientID,
+	}
 }
 
 // slugify keeps the letters and digits of an endpoint and collapses everything

--- a/internal/completion/cache_key.go
+++ b/internal/completion/cache_key.go
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: 2025 OVH SAS <opensource@ovh.net>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package completion
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"strings"
+
+	"github.com/ovh/ovhcloud-cli/internal/flags"
+)
+
+// cacheKeyFor derives the cache file name of an endpoint's suggestions.
+//
+// The key is scoped to the active profile as well as to the endpoint: profiles
+// point at different accounts, and a cache shared between them would suggest,
+// for ten minutes, the identifiers of a fleet the user is no longer working on.
+//
+// The readable prefix is there so that the cache directory can be inspected by
+// hand; the digest is what makes the key unambiguous, since the prefix drops
+// every character a file name cannot carry.
+func cacheKeyFor(endpoint string) string {
+	digest := sha256.Sum256([]byte(flags.Profile + "\x00" + endpoint))
+
+	return fmt.Sprintf("%s-%x", slugify(endpoint), digest[:8])
+}
+
+// slugify keeps the letters and digits of an endpoint and collapses everything
+// else into single dashes, so the result is safe as a file name on every
+// platform. It is truncated because a path is bounded and an endpoint is not.
+func slugify(endpoint string) string {
+	var out strings.Builder
+	lastWasDash := true // avoids a leading dash
+
+	for _, r := range strings.ToLower(endpoint) {
+		switch {
+		case (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9'):
+			out.WriteRune(r)
+			lastWasDash = false
+		case !lastWasDash:
+			out.WriteByte('-')
+			lastWasDash = true
+		}
+	}
+
+	slug := strings.Trim(out.String(), "-")
+	if len(slug) > 60 {
+		slug = strings.Trim(slug[:60], "-")
+	}
+	if slug == "" {
+		slug = "endpoint"
+	}
+
+	return slug
+}

--- a/internal/completion/cache_key_test.go
+++ b/internal/completion/cache_key_test.go
@@ -113,3 +113,38 @@ func TestCacheKeyFor_IsSafeAsAFileName(t *testing.T) {
 	_, err := os.Stat(filepath.Join(completionCacheDir(), key))
 	td.CmpNoError(t, err, "the key must be usable as a file name")
 }
+
+// The profile is not the only thing that selects an account: environment
+// variables override it, and in legacy mode there is no profile at all. Two
+// credentials must therefore never share a cache entry.
+func TestCacheKeyFor_IsScopedToTheCredentials(t *testing.T) {
+	origClient := httpLib.Client
+	defer func() { httpLib.Client = origClient }()
+
+	newKey := func(consumerKey string) string {
+		client, err := ovh.NewClient("ovh-eu", "app_key", "app_secret", consumerKey)
+		td.Require(t).CmpNoError(err)
+		httpLib.Client = client
+		return cacheKeyFor("/v1/dedicated/server")
+	}
+
+	td.Cmp(t, newKey("consumer_a"), td.Not(newKey("consumer_b")),
+		"two accounts must not share suggestions")
+}
+
+// Regions are separate fleets behind the same profile, and OVH_ENDPOINT is
+// enough to move between them.
+func TestCacheKeyFor_IsScopedToTheRegion(t *testing.T) {
+	origClient := httpLib.Client
+	defer func() { httpLib.Client = origClient }()
+
+	newKey := func(endpoint string) string {
+		client, err := ovh.NewClient(endpoint, "app_key", "app_secret", "consumer_key")
+		td.Require(t).CmpNoError(err)
+		httpLib.Client = client
+		return cacheKeyFor("/v1/dedicated/server")
+	}
+
+	td.Cmp(t, newKey("ovh-eu"), td.Not(newKey("ovh-ca")),
+		"two regions must not share suggestions")
+}

--- a/internal/completion/cache_key_test.go
+++ b/internal/completion/cache_key_test.go
@@ -1,0 +1,115 @@
+// SPDX-FileCopyrightText: 2025 OVH SAS <opensource@ovh.net>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package completion
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jarcoal/httpmock"
+	"github.com/maxatome/go-testdeep/td"
+	"github.com/ovh/go-ovh/ovh"
+	"github.com/ovh/ovhcloud-cli/internal/flags"
+	httpLib "github.com/ovh/ovhcloud-cli/internal/http"
+)
+
+// withMockedAPI points the shared client at httpmock and gives the test its own
+// cache directory, so nothing leaks between tests or onto the developer's disk.
+func withMockedAPI(t *testing.T) {
+	t.Helper()
+	t.Setenv("XDG_CACHE_HOME", t.TempDir())
+
+	// Same wiring as the command test suite: httpmock patches the default
+	// transport, which is the one go-ovh builds its client on.
+	httpmock.Activate(t)
+
+	origClient, origProfile := httpLib.Client, flags.Profile
+	client, err := ovh.NewClient("ovh-eu", "app_key", "app_secret", "consumer_key")
+	td.Require(t).CmpNoError(err)
+	httpLib.Client = client
+
+	// go-ovh computes its clock delta before the first signed call; without
+	// this the request never leaves and the test measures nothing.
+	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/1.0/auth/time",
+		httpmock.NewStringResponder(200, "0"))
+
+	t.Cleanup(func() {
+		httpLib.Client, flags.Profile = origClient, origProfile
+	})
+}
+
+// The acceptance criterion of the requirement: two consecutive <tab> keystrokes
+// must cost one API call, not two. Completion runs as a fresh process each
+// time, which is why the cache lives on disk.
+func TestServiceList_SecondCompletionHitsTheCache(t *testing.T) {
+	withMockedAPI(t)
+	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/v1/dedicated/server",
+		httpmock.NewStringResponder(200, `["ns3168421.ip-51-77-12.eu","ns5012993.ip-141-95-4.eu"]`),
+	)
+
+	complete := ServiceList("/v1/dedicated/server")
+
+	first, _ := complete(nil, nil, "")
+	second, _ := complete(nil, nil, "")
+
+	td.Cmp(t, first, []string{"ns3168421.ip-51-77-12.eu", "ns5012993.ip-141-95-4.eu"})
+	td.Cmp(t, second, first, "the cached answer is the one that was fetched")
+	td.Cmp(t, httpmock.GetCallCountInfo()["GET https://eu.api.ovh.com/v1/dedicated/server"], 1,
+		"the second completion must not call the API again")
+}
+
+// A failed call must not be cached, otherwise a transient error would silence
+// completion for the whole TTL.
+func TestServiceList_FailureIsNotCached(t *testing.T) {
+	withMockedAPI(t)
+	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/v1/dedicated/server",
+		httpmock.NewStringResponder(500, `{"message":"boom"}`),
+	)
+
+	complete := ServiceList("/v1/dedicated/server")
+	complete(nil, nil, "")
+	complete(nil, nil, "")
+
+	td.Cmp(t, httpmock.GetCallCountInfo()["GET https://eu.api.ovh.com/v1/dedicated/server"], 2,
+		"a failure must be retried rather than remembered")
+}
+
+// Profiles point at different accounts: one must never be served the other's
+// fleet, however fresh the cache is.
+func TestCacheKeyFor_IsScopedToTheProfile(t *testing.T) {
+	origProfile := flags.Profile
+	defer func() { flags.Profile = origProfile }()
+
+	flags.Profile = ""
+	withoutProfile := cacheKeyFor("/v1/dedicated/server")
+	flags.Profile = "prod"
+	withProfile := cacheKeyFor("/v1/dedicated/server")
+
+	td.Cmp(t, withProfile, td.Not(withoutProfile))
+}
+
+// Two endpoints must not share a cache entry, including when their readable
+// prefixes collide after slugging.
+func TestCacheKeyFor_DistinguishesEndpoints(t *testing.T) {
+	td.Cmp(t, cacheKeyFor("/v1/dedicated/server"), td.Not(cacheKeyFor("/v1/dedicated/nasha")))
+	td.Cmp(t, cacheKeyFor("/v1/a/b"), td.Not(cacheKeyFor("/v1/a-b")),
+		"slugging must not merge two different endpoints")
+}
+
+// The key becomes a file name, so it must carry nothing a path cannot hold.
+func TestCacheKeyFor_IsSafeAsAFileName(t *testing.T) {
+	t.Setenv("XDG_CACHE_HOME", t.TempDir())
+
+	key := cacheKeyFor("/v1/cloud/project/aa..bb/instance?flavor=b2-7")
+
+	td.Cmp(t, strings.ContainsAny(key, `/\:*?"<>| `), false, "key %q must be path-safe", key)
+	td.Cmp(t, strings.Contains(key, ".."), false, "key %q must not walk up a directory", key)
+
+	writeCachedSuggestions(key, []string{"i-1"})
+	_, err := os.Stat(filepath.Join(completionCacheDir(), key))
+	td.CmpNoError(t, err, "the key must be usable as a file name")
+}

--- a/internal/completion/cache_key_test.go
+++ b/internal/completion/cache_key_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ovh/go-ovh/ovh"
 	"github.com/ovh/ovhcloud-cli/internal/flags"
 	httpLib "github.com/ovh/ovhcloud-cli/internal/http"
+	"gopkg.in/ini.v1"
 )
 
 // withMockedAPI points the shared client at httpmock and gives the test its own
@@ -90,6 +91,50 @@ func TestCacheKeyFor_IsScopedToTheProfile(t *testing.T) {
 	withProfile := cacheKeyFor("/v1/dedicated/server")
 
 	td.Cmp(t, withProfile, td.Not(withoutProfile))
+}
+
+// The flag is the one way of picking a profile that this cache used to see. The
+// two others select an account just as effectively, and on a real keystroke
+// they are the likely ones — a shell completes without anybody typing
+// --profile. Both were sharing a key, and with it the previous account's
+// identifiers, for the whole TTL.
+func TestCacheKeyFor_IsScopedToTheProfileChosenByEnvironment(t *testing.T) {
+	origProfile, origEnv := flags.Profile, os.Getenv("OVH_PROFILE")
+	defer func() { flags.Profile = origProfile; os.Setenv("OVH_PROFILE", origEnv) }()
+
+	flags.Profile = ""
+	os.Unsetenv("OVH_PROFILE")
+	plain := cacheKeyFor("/v1/dedicated/server")
+
+	os.Setenv("OVH_PROFILE", "prod")
+	fromEnv := cacheKeyFor("/v1/dedicated/server")
+	os.Setenv("OVH_PROFILE", "staging")
+	otherFromEnv := cacheKeyFor("/v1/dedicated/server")
+
+	td.Cmp(t, fromEnv, td.Not(plain), "OVH_PROFILE must reach the key")
+	td.Cmp(t, otherFromEnv, td.Not(fromEnv), "and two of them must not collide")
+}
+
+func TestCacheKeyFor_IsScopedToTheProfileChosenByConfig(t *testing.T) {
+	origProfile, origEnv := flags.Profile, os.Getenv("OVH_PROFILE")
+	origConfig := flags.CliConfig
+	defer func() {
+		flags.Profile = origProfile
+		os.Setenv("OVH_PROFILE", origEnv)
+		flags.CliConfig = origConfig
+	}()
+
+	flags.Profile = ""
+	os.Unsetenv("OVH_PROFILE")
+	flags.CliConfig = nil
+	plain := cacheKeyFor("/v1/dedicated/server")
+
+	cfg := ini.Empty()
+	cfg.Section("default").Key("profile").SetValue("prod")
+	flags.CliConfig = cfg
+
+	td.Cmp(t, cacheKeyFor("/v1/dedicated/server"), td.Not(plain),
+		"the profile named by the configuration file must reach the key")
 }
 
 // Two endpoints must not share a cache entry, including when their readable

--- a/internal/completion/completion.go
+++ b/internal/completion/completion.go
@@ -120,7 +120,7 @@ func ServiceList(endpoint string) func(*cobra.Command, []string, string) ([]stri
 		if len(args) > 0 {
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
-		return fetchSuggestions(endpoint, "", "")
+		return fetchSuggestions(endpoint, "", cacheKeyFor(endpoint))
 	}
 }
 
@@ -139,7 +139,8 @@ func CloudResources(pathTemplate string) func(*cobra.Command, []string, string) 
 		if project == "" {
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
-		return fetchSuggestions(fmt.Sprintf(pathTemplate, url.PathEscape(project)), "", "")
+		endpoint := fmt.Sprintf(pathTemplate, url.PathEscape(project))
+		return fetchSuggestions(endpoint, "", cacheKeyFor(endpoint))
 	}
 }
 
@@ -156,9 +157,11 @@ func CloudResourceWithChild(parentTemplate, childTemplate string) func(*cobra.Co
 		}
 		switch len(args) {
 		case 0:
-			return fetchSuggestions(fmt.Sprintf(parentTemplate, url.PathEscape(project)), "", "")
+			endpoint := fmt.Sprintf(parentTemplate, url.PathEscape(project))
+			return fetchSuggestions(endpoint, "", cacheKeyFor(endpoint))
 		case 1:
-			return fetchSuggestions(fmt.Sprintf(childTemplate, url.PathEscape(project), url.PathEscape(args[0])), "", "")
+			endpoint := fmt.Sprintf(childTemplate, url.PathEscape(project), url.PathEscape(args[0]))
+			return fetchSuggestions(endpoint, "", cacheKeyFor(endpoint))
 		default:
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
@@ -166,5 +169,5 @@ func CloudResourceWithChild(parentTemplate, childTemplate string) func(*cobra.Co
 }
 
 func CloudProjects(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
-	return fetchSuggestions("/v2/publicCloud/project", "name", "cloud-projects")
+	return fetchSuggestions("/v2/publicCloud/project", "name", cacheKeyFor("/v2/publicCloud/project"))
 }

--- a/internal/completion/completion.go
+++ b/internal/completion/completion.go
@@ -40,23 +40,24 @@ func resolveCloudProject(cmd *cobra.Command) string {
 // this delay we give up and return no suggestion rather than blocking.
 const completionTimeout = 3 * time.Second
 
-func fetchSuggestions(endpoint, labelField, cacheKey string) ([]string, cobra.ShellCompDirective) {
-	if cacheKey != "" {
-		if cached, ok := readCachedSuggestions(cacheKey); ok {
-			return cached, cobra.ShellCompDirectiveNoFileComp
-		}
-	}
-
+func fetchSuggestions(endpoint, labelField string) ([]string, cobra.ShellCompDirective) {
+	// The client is built first, before the cache is even looked up.
+	// Completion skips PersistentPreRun, so on a <tab> the client is still nil,
+	// and the cache key is scoped to the account the client resolved to: derive
+	// it any earlier and every account on the machine shares one entry.
+	// Building the client reads the configuration only, no request is sent.
 	if httpLib.Client == nil {
-		// Initialize the client the same way commands do (the completion path
-		// skips PersistentPreRun): honour the config file and the active profile,
-		// otherwise profile-based auth would be ignored and the API call would
-		// hit the wrong account / no credentials.
 		config.ActiveProfileOverride = flags.Profile
 		httpLib.InitClientWithProfile(flags.CliConfig, flags.Profile)
 	}
 	if httpLib.Client == nil {
 		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	// Derived here and nowhere else: a caller cannot get the order wrong.
+	cacheKey := cacheKeyFor(endpoint)
+	if cached, ok := readCachedSuggestions(cacheKey); ok {
+		return cached, cobra.ShellCompDirectiveNoFileComp
 	}
 
 	result := make(chan []string, 1)
@@ -102,7 +103,7 @@ func fetchSuggestions(endpoint, labelField, cacheKey string) ([]string, cobra.Sh
 
 	select {
 	case suggestions := <-result:
-		if cacheKey != "" && suggestions != nil {
+		if suggestions != nil {
 			writeCachedSuggestions(cacheKey, suggestions)
 		}
 		return suggestions, cobra.ShellCompDirectiveNoFileComp
@@ -120,7 +121,7 @@ func ServiceList(endpoint string) func(*cobra.Command, []string, string) ([]stri
 		if len(args) > 0 {
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
-		return fetchSuggestions(endpoint, "", cacheKeyFor(endpoint))
+		return fetchSuggestions(endpoint, "")
 	}
 }
 
@@ -140,7 +141,7 @@ func CloudResources(pathTemplate string) func(*cobra.Command, []string, string) 
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
 		endpoint := fmt.Sprintf(pathTemplate, url.PathEscape(project))
-		return fetchSuggestions(endpoint, "", cacheKeyFor(endpoint))
+		return fetchSuggestions(endpoint, "")
 	}
 }
 
@@ -158,10 +159,10 @@ func CloudResourceWithChild(parentTemplate, childTemplate string) func(*cobra.Co
 		switch len(args) {
 		case 0:
 			endpoint := fmt.Sprintf(parentTemplate, url.PathEscape(project))
-			return fetchSuggestions(endpoint, "", cacheKeyFor(endpoint))
+			return fetchSuggestions(endpoint, "")
 		case 1:
 			endpoint := fmt.Sprintf(childTemplate, url.PathEscape(project), url.PathEscape(args[0]))
-			return fetchSuggestions(endpoint, "", cacheKeyFor(endpoint))
+			return fetchSuggestions(endpoint, "")
 		default:
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
@@ -169,5 +170,5 @@ func CloudResourceWithChild(parentTemplate, childTemplate string) func(*cobra.Co
 }
 
 func CloudProjects(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
-	return fetchSuggestions("/v2/publicCloud/project", "name", cacheKeyFor("/v2/publicCloud/project"))
+	return fetchSuggestions("/v2/publicCloud/project", "name")
 }

--- a/internal/completion/completion_path_test.go
+++ b/internal/completion/completion_path_test.go
@@ -1,0 +1,86 @@
+// SPDX-FileCopyrightText: 2025 OVH SAS <opensource@ovh.net>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package completion
+
+import (
+	"testing"
+
+	"github.com/jarcoal/httpmock"
+	"github.com/maxatome/go-testdeep/td"
+	"github.com/ovh/ovhcloud-cli/internal/flags"
+	httpLib "github.com/ovh/ovhcloud-cli/internal/http"
+)
+
+// Completion skips PersistentPreRun, so a <tab> starts with no API client at
+// all. That is the path the cache key has to be right on: derived any earlier
+// than the client, it carries no account and every account on the machine
+// shares one cache entry.
+//
+// This test therefore never sets httpLib.Client itself — it starts from nil,
+// the way a shell does, and switches account through the environment.
+func TestServiceList_TwoAccountsDoNotShareTheCache(t *testing.T) {
+	t.Setenv("XDG_CACHE_HOME", t.TempDir())
+	httpmock.Activate(t)
+
+	origClient, origProfile := httpLib.Client, flags.Profile
+	t.Cleanup(func() { httpLib.Client, flags.Profile = origClient, origProfile })
+
+	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/1.0/auth/time",
+		httpmock.NewStringResponder(200, "0"))
+	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/v1/dedicated/server",
+		httpmock.NewStringResponder(200, `["ns3168421.ip-51-77-12.eu"]`))
+
+	t.Setenv("OVH_ENDPOINT", "ovh-eu")
+	t.Setenv("OVH_APPLICATION_KEY", "app_key")
+	t.Setenv("OVH_APPLICATION_SECRET", "app_secret")
+
+	completeAs := func(consumerKey string) []string {
+		t.Setenv("OVH_CONSUMER_KEY", consumerKey)
+		httpLib.Client = nil // what the shell hands us on every <tab>
+		suggestions, _ := ServiceList("/v1/dedicated/server")(nil, nil, "")
+		return suggestions
+	}
+
+	completeAs("consumer_a")
+	callsAfterA := httpmock.GetCallCountInfo()["GET https://eu.api.ovh.com/v1/dedicated/server"]
+
+	completeAs("consumer_b")
+	callsAfterB := httpmock.GetCallCountInfo()["GET https://eu.api.ovh.com/v1/dedicated/server"]
+
+	td.Cmp(t, callsAfterA, 1, "the first account must be fetched")
+	td.Cmp(t, callsAfterB, 2,
+		"the second account must be fetched too, not served the first one's cache")
+}
+
+// And the cache must still work for one account, or the fix above would have
+// bought correctness by disabling it.
+func TestServiceList_SameAccountStillHitsTheCache(t *testing.T) {
+	t.Setenv("XDG_CACHE_HOME", t.TempDir())
+	httpmock.Activate(t)
+
+	origClient, origProfile := httpLib.Client, flags.Profile
+	t.Cleanup(func() { httpLib.Client, flags.Profile = origClient, origProfile })
+
+	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/1.0/auth/time",
+		httpmock.NewStringResponder(200, "0"))
+	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/v1/dedicated/server",
+		httpmock.NewStringResponder(200, `["ns3168421.ip-51-77-12.eu"]`))
+
+	t.Setenv("OVH_ENDPOINT", "ovh-eu")
+	t.Setenv("OVH_APPLICATION_KEY", "app_key")
+	t.Setenv("OVH_APPLICATION_SECRET", "app_secret")
+	t.Setenv("OVH_CONSUMER_KEY", "consumer_a")
+
+	complete := ServiceList("/v1/dedicated/server")
+
+	httpLib.Client = nil
+	first, _ := complete(nil, nil, "")
+	httpLib.Client = nil
+	second, _ := complete(nil, nil, "")
+
+	td.Cmp(t, second, first)
+	td.Cmp(t, httpmock.GetCallCountInfo()["GET https://eu.api.ovh.com/v1/dedicated/server"], 1,
+		"the second completion of the same account must not call the API again")
+}


### PR DESCRIPTION
# Description

The completion cache was already implemented, tested and working — and wired to one caller out of five.

`ServiceList`, `CloudResources` and `CloudResourceWithChild` all passed an empty cache key, and `fetchSuggestions` only reads and writes the cache when the key is non-empty. Every `<tab>` keystroke therefore went to the API, with a three second grace period and a silent failure past it: on a slow link the completion returns nothing, without saying whether the fleet is empty, the token expired, or the call timed out.

They now derive a key from the endpoint they query.

### The key is scoped to the profile, not only to the endpoint

Profiles point at different accounts. A key built from the endpoint alone would serve, for the ten minutes of the TTL, the identifiers of the fleet the user has just switched away from — suggesting production servers to someone who moved to preprod. `cloud-projects`, the one caller that already had a key, had that defect too and is fixed by the same helper.

The key is a readable slug plus a digest:

- the slug keeps the cache directory inspectable by hand;
- the digest is what makes the key unambiguous, since the slug drops every character a file name cannot carry — `/v1/a/b` and `/v1/a-b` would otherwise collide, and a path parameter could smuggle in a `..`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (improvement of existing commands)
- [ ] Breaking change (fix or feature that can break a current behavior)
- [ ] Documentation update

No user-visible surface changes: same suggestions, fetched once instead of every keystroke. Existing `cloud-projects` cache files simply expire, since the key changed.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have commented my code
- [x] I ran `go mod tidy`
- [x] I have added tests that prove my fix is effective or that my feature works

Five tests, starting with the behaviour itself: two consecutive completions cost one API call. Emptying the key again makes exactly that assertion fail, so it gates the behaviour rather than its own presence.

The others cover what the cache must **not** do: a failed call is not cached, so a transient error does not silence completion for the whole TTL; two profiles do not share an entry; two endpoints do not collide after slugging; and a key built from a path holding `..` and query parameters stays usable as a file name.

`go build ./...`, `GOOS=js GOARCH=wasm go build ./...`, `go vet ./...` and the full `go test ./...` pass. `make doc` produces no change.

Addresses **M7** of the BareMetal CLI audit (defect BM-07).
