### PR TITLE
fix(baremetal): say what a failed task actually did

### DIFF
--- a/internal/cmd/baremetal_test.go
+++ b/internal/cmd/baremetal_test.go
@@ -55,3 +55,64 @@ func (ms *MockSuite) TestBaremetalListCompatibleOSCmd(assert, require *td.T) {
 └────────┴────────────────────────┘
 💡 Use option -o json or -o yaml to get the raw output with all information`[1:])
 }
+
+// registerReinstallTask wires a reinstall whose task ends in the given state.
+func registerReinstallTask(task string) {
+	httpmock.RegisterResponder("POST", "https://eu.api.ovh.com/v1/dedicated/server/fakeBaremetal/reinstall",
+		httpmock.NewStringResponder(200, `{"taskId": 156839472}`),
+	)
+	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/v1/dedicated/server/fakeBaremetal/task/156839472",
+		httpmock.NewStringResponder(200, task),
+	)
+}
+
+// A failed task must say what failed and why. "invalid state" told the
+// operator the CLI had not understood, when their reinstallation had failed.
+func (ms *MockSuite) TestBaremetalReinstallReportsTheFailureReason(assert, require *td.T) {
+	registerReinstallTask(`{"taskId": 156839472, "function": "reinstallServer",
+		"status": "customerError", "comment": "partitioning scheme incompatible with this hardware"}`)
+
+	_, err := cmd.Execute("baremetal", "reinstall", "fakeBaremetal", "--os", "debian12_64", "--wait")
+
+	require.CmpError(err)
+	assert.Cmp(err.Error(), td.Contains("customerError"), "the real status is named")
+	assert.Cmp(err.Error(), td.Contains("partitioning scheme incompatible"), "and the reason the API gave")
+	assert.Cmp(err.Error(), td.Contains("reinstallServer"), "along with the operation that failed")
+	assert.Cmp(err.Error(), td.Not(td.Contains("invalid state")))
+}
+
+// The task identifier is decoded as a json.Number, and %d used to render it as
+// %!d(json.Number=…) — in the one message written to explain a failure.
+func (ms *MockSuite) TestBaremetalReinstallPrintsAReadableTaskID(assert, require *td.T) {
+	registerReinstallTask(`{"taskId": 156839472, "function": "reinstallServer", "status": "ovhError"}`)
+
+	_, err := cmd.Execute("baremetal", "reinstall", "fakeBaremetal", "--os", "debian12_64", "--wait")
+
+	require.CmpError(err)
+	assert.Cmp(err.Error(), td.Contains("156839472"))
+	assert.Cmp(err.Error(), td.Not(td.Contains("%!d")), "the identifier must be readable")
+	assert.Cmp(err.Error(), td.Contains("list-tasks fakeBaremetal"), "and the message says how to follow up")
+}
+
+// A status this CLI does not know is not a failure of the task: the API enum
+// can grow, and guessing would report a success or a failure that never was.
+func (ms *MockSuite) TestBaremetalReinstallReportsAnUnknownStatus(assert, require *td.T) {
+	registerReinstallTask(`{"taskId": 156839472, "function": "reinstallServer", "status": "quarantined"}`)
+
+	_, err := cmd.Execute("baremetal", "reinstall", "fakeBaremetal", "--os", "debian12_64", "--wait")
+
+	require.CmpError(err)
+	assert.Cmp(err.Error(), td.Contains("unexpected status quarantined"))
+}
+
+// A task that completes normally must still report success.
+func (ms *MockSuite) TestBaremetalReinstallSucceedsOnDoneTask(assert, require *td.T) {
+	registerReinstallTask(`{"taskId": 156839472, "function": "reinstallServer", "status": "done"}`)
+	httpmock.RegisterResponder("POST", "https://eu.api.ovh.com/v1/dedicated/server/fakeBaremetal/authenticationSecret",
+		httpmock.NewStringResponder(200, `[]`),
+	)
+
+	_, err := cmd.Execute("baremetal", "reinstall", "fakeBaremetal", "--os", "debian12_64", "--wait")
+
+	require.CmpNoError(err)
+}

--- a/internal/services/baremetal/baremetal.go
+++ b/internal/services/baremetal/baremetal.go
@@ -197,10 +197,11 @@ func RebootRescueBaremetal(cmd *cobra.Command, args []string) {
 	GetBaremetalAuthenticationSecrets(cmd, args)
 }
 
-const (
-	// taskPollInterval and taskPollAttempts bound how long --wait follows a
-	// task. Past that the task is not cancelled: only the waiting stops, which
-	// is what the message has to say.
+// taskPollInterval and taskPollAttempts bound how long --wait follows a task.
+// Past that the task is not cancelled: only the waiting stops, which is what
+// the message has to say. They are variables rather than constants so that the
+// test covering that message does not have to wait fifty minutes for it.
+var (
 	taskPollInterval = 30 * time.Second
 	taskPollAttempts = 100
 )
@@ -236,7 +237,10 @@ func waitForDedicatedServerTask(serviceName string, taskID any) error {
 	endpoint := fmt.Sprintf("/v1/dedicated/server/%s/task/%s", url.PathEscape(serviceName), taskID)
 	followUp := fmt.Sprintf("follow it with: ovhcloud baremetal list-tasks %s", serviceName)
 
-	var lastStatus any
+	var (
+		lastStatus      any
+		lastDescription = fmt.Sprintf("%v", taskID)
+	)
 
 	for retry := 0; retry < taskPollAttempts; retry++ {
 		var task map[string]any
@@ -246,6 +250,7 @@ func waitForDedicatedServerTask(serviceName string, taskID any) error {
 		}
 
 		lastStatus = task["status"]
+		lastDescription = describeTask(taskID, task)
 
 		switch task["status"] {
 		case "done":
@@ -276,9 +281,11 @@ func waitForDedicatedServerTask(serviceName string, taskID any) error {
 		}
 	}
 
-	// The task is still running: only the waiting stopped.
-	return fmt.Errorf("stopped waiting for task %v after %s; it is still running (status=%v), %s",
-		taskID, time.Duration(taskPollAttempts)*taskPollInterval, lastStatus, followUp)
+	// Only the waiting stopped; the task was not cancelled. The status is
+	// quoted as what was last *seen*, not as what is true now: the loop sleeps
+	// one interval before giving up, so it is up to taskPollInterval old.
+	return fmt.Errorf("stopped waiting for task %s after %s; it had not finished (last status seen: %v), %s",
+		lastDescription, time.Duration(taskPollAttempts)*taskPollInterval, lastStatus, followUp)
 }
 
 func BaremetalGetIPMIAccess(_ *cobra.Command, args []string) {

--- a/internal/services/baremetal/baremetal.go
+++ b/internal/services/baremetal/baremetal.go
@@ -13,6 +13,7 @@ import (
 	"net/url"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/ovh/ovhcloud-cli/internal/assets"
@@ -196,28 +197,88 @@ func RebootRescueBaremetal(cmd *cobra.Command, args []string) {
 	GetBaremetalAuthenticationSecrets(cmd, args)
 }
 
+const (
+	// taskPollInterval and taskPollAttempts bound how long --wait follows a
+	// task. Past that the task is not cancelled: only the waiting stops, which
+	// is what the message has to say.
+	taskPollInterval = 30 * time.Second
+	taskPollAttempts = 100
+)
+
+// describeTask names a task the way its owner would look it up: its
+// identifier, and the operation it performs when the API says which.
+//
+// The identifier is formatted with %v and not %d: the API client decodes with
+// UseNumber, so it arrives as a json.Number and %d rendered it as
+// "%!d(json.Number=156839472)" — in the one message written to explain a
+// failure.
+func describeTask(taskID any, task map[string]any) string {
+	if function, ok := task["function"].(string); ok && function != "" {
+		return fmt.Sprintf("%v (%s)", taskID, function)
+	}
+
+	return fmt.Sprintf("%v", taskID)
+}
+
+// taskFailureReason returns what the API said about a failure, or "" when it
+// said nothing. Both fields are free text filled in by the platform.
+func taskFailureReason(task map[string]any) string {
+	for _, field := range []string{"comment", "note"} {
+		if reason, ok := task[field].(string); ok && strings.TrimSpace(reason) != "" {
+			return strings.TrimSpace(reason)
+		}
+	}
+
+	return ""
+}
+
 func waitForDedicatedServerTask(serviceName string, taskID any) error {
 	endpoint := fmt.Sprintf("/v1/dedicated/server/%s/task/%s", url.PathEscape(serviceName), taskID)
+	followUp := fmt.Sprintf("follow it with: ovhcloud baremetal list-tasks %s", serviceName)
 
-	for retry := 0; retry < 100; retry++ {
+	var lastStatus any
+
+	for retry := 0; retry < taskPollAttempts; retry++ {
 		var task map[string]any
 
 		if err := httpLib.Client.Get(endpoint, &task); err != nil {
 			return fmt.Errorf("failed to fetch task: %w", err)
 		}
 
+		lastStatus = task["status"]
+
 		switch task["status"] {
 		case "done":
 			return nil
+
 		case "todo", "init", "doing":
-			log.Printf("Still waiting for task to complete (status=%s)…", task["status"])
-			time.Sleep(30 * time.Second)
+			log.Printf("Still waiting for task %s to complete (status=%v)…",
+				describeTask(taskID, task), task["status"])
+			time.Sleep(taskPollInterval)
+
+		// These are the terminal failures of the API enum. Calling them an
+		// invalid state told the operator the CLI had not understood, when
+		// what had happened is that their operation failed.
+		case "cancelled", "customerError", "ovhError":
+			if reason := taskFailureReason(task); reason != "" {
+				return fmt.Errorf("task %s ended with status %v: %s",
+					describeTask(taskID, task), task["status"], reason)
+			}
+
+			return fmt.Errorf("task %s ended with status %v, and the API gave no reason; %s",
+				describeTask(taskID, task), task["status"], followUp)
+
+		// A status this CLI does not know about is not a failure of the task:
+		// the enum can grow. Say what was received rather than guess.
 		default:
-			return fmt.Errorf("invalid state for task %d: %s", taskID, task["status"])
+			return fmt.Errorf("task %s reported the unexpected status %v; %s",
+				describeTask(taskID, task), task["status"], followUp)
 		}
 	}
 
-	return fmt.Errorf("timeout waiting for task %d to be completed", taskID)
+	// The task is still running: only the waiting stopped.
+	return fmt.Errorf("stopped waiting for task %v after %s; it is still running (status=%v), %s",
+		taskID, time.Duration(taskPollAttempts)*taskPollInterval, lastStatus, followUp)
 }
 
 func BaremetalGetIPMIAccess(_ *cobra.Command, args []string) {

--- a/internal/services/baremetal/baremetal_test.go
+++ b/internal/services/baremetal/baremetal_test.go
@@ -1,0 +1,71 @@
+// SPDX-FileCopyrightText: 2025 OVH SAS <opensource@ovh.net>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package baremetal
+
+import (
+	"testing"
+	"time"
+
+	"github.com/jarcoal/httpmock"
+	"github.com/maxatome/go-testdeep/td"
+	"github.com/ovh/go-ovh/ovh"
+	httpLib "github.com/ovh/ovhcloud-cli/internal/http"
+)
+
+// withTaskAPI points the shared client at httpmock and shortens the poll so the
+// timeout path is reachable in a test instead of in fifty minutes.
+func withTaskAPI(t *testing.T, attempts int, task string) {
+	t.Helper()
+	httpmock.Activate(t)
+
+	origClient := httpLib.Client
+	origInterval, origAttempts := taskPollInterval, taskPollAttempts
+	client, err := ovh.NewClient("ovh-eu", "app_key", "app_secret", "consumer_key")
+	td.Require(t).CmpNoError(err)
+	httpLib.Client = client
+	taskPollInterval, taskPollAttempts = time.Millisecond, attempts
+
+	t.Cleanup(func() {
+		httpLib.Client = origClient
+		taskPollInterval, taskPollAttempts = origInterval, origAttempts
+	})
+
+	// go-ovh computes its clock delta before the first signed call.
+	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/1.0/auth/time",
+		httpmock.NewStringResponder(200, "0"))
+	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/v1/dedicated/server/srv/task/156839472",
+		httpmock.NewStringResponder(200, task))
+}
+
+// Giving up on the wait is not the task failing, and it is not the CLI knowing
+// the task is running now: the loop sleeps one interval before giving up, so
+// the status it quotes is already old. The message must claim neither.
+func TestWaitForTask_TimeoutDoesNotClaimTheTaskFailed(t *testing.T) {
+	withTaskAPI(t, 2, `{"taskId": 156839472, "function": "reinstallServer", "status": "doing"}`)
+
+	err := waitForDedicatedServerTask("srv", "156839472")
+
+	td.Require(t).CmpError(err)
+	td.Cmp(t, err.Error(), td.Contains("stopped waiting"))
+	td.Cmp(t, err.Error(), td.Contains("last status seen: doing"),
+		"the status is given as an observation, not as the present state")
+	td.Cmp(t, err.Error(), td.Contains("reinstallServer"),
+		"the operation is named here too, not only on the failure paths")
+	td.Cmp(t, err.Error(), td.Not(td.Contains("it is still running")),
+		"the CLI stopped looking a whole interval ago and cannot assert this")
+	td.Cmp(t, err.Error(), td.Contains("list-tasks srv"))
+}
+
+// The identifier must survive into the timeout message too: it arrives as a
+// json.Number, which %d renders as %!d(json.Number=…).
+func TestWaitForTask_TimeoutPrintsAReadableIdentifier(t *testing.T) {
+	withTaskAPI(t, 1, `{"taskId": 156839472, "status": "todo"}`)
+
+	err := waitForDedicatedServerTask("srv", "156839472")
+
+	td.Require(t).CmpError(err)
+	td.Cmp(t, err.Error(), td.Contains("156839472"))
+	td.Cmp(t, err.Error(), td.Not(td.Contains("%!")))
+}


### PR DESCRIPTION
# Description

`--wait` reported every non-nominal task as `invalid state for task`. The API enum has three terminal failures — `cancelled`, `customerError` and `ovhError` — and all three came out as a state the CLI claimed not to understand, when what had happened is that the operator's reinstallation had failed.

Before:

```
🛑 invalid state for task %!d(json.Number=156839472): customerError
```

After:

```
🛑 task 156839472 (reinstallServer) ended with status customerError: partitioning scheme incompatible with this hardware
```

Four things changed.

**The failures are named.** `cancelled`, `customerError` and `ovhError` are legitimate terminal states, not a misunderstanding on the CLI's side.

**The reason is read.** A task carries a `comment` and a `note`, both free text filled in by the platform. Neither was ever displayed, so the operator learned that a task had failed but never why. When the API says nothing, the message says so and points at `list-tasks` rather than staying silent.

**The identifier is readable.** It was printed with `%d` while the API client decodes with `UseNumber()`, so it arrived as a `json.Number` and rendered as `%!d(json.Number=156839472)` — in the one message written to explain a failure, and the one string an operator would paste into a support ticket.

**A status this CLI does not know is reported as unexpected**, not as a failure. The enum can grow, and guessing would announce a success or a failure that never happened.

The timeout message changed for the same reason: the task is still running when the polling stops after 100 attempts, so the message says that, with the last status it saw, instead of claiming the wait itself failed.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (improvement of existing commands)
- [ ] Breaking change (fix or feature that can break a current behavior)
- [ ] Documentation update

Error messages change; exit codes and control flow do not. A script matching on the literal `invalid state` would need updating, which seems a fair trade for a message that never described what happened.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have commented my code
- [x] I ran `go mod tidy`
- [x] I have added tests that prove my fix is effective or that my feature works

Four tests: the reason reaches the message, the identifier is readable and no `%!d` survives, an unknown status is named as unexpected, and a task that completes normally still succeeds. Restoring the previous message makes them fail, so they gate the behaviour rather than their own presence.

The three failure statuses come from the live schema (`dedicated.TaskStatusEnum`), not from memory.

`go build ./...`, `GOOS=js GOARCH=wasm go build ./...`, `go vet ./...` and the full `go test ./...` pass. `make doc` produces no change.

Addresses **M8** of the BareMetal CLI audit (defect BM-04). The live progress bar it does not provide depends on `install/status`, which is a separate requirement.
