### PR TITLE
feat(api): add ovhcloud api call, the escape hatch out of partial coverage

### DIFF
--- a/doc/ovhcloud.md
+++ b/doc/ovhcloud.md
@@ -1,90 +1,37 @@
-# OVHcloud CLI (`ovhcloud`) Documentation
+## ovhcloud
 
----
+CLI to manage your OVHcloud services
 
-## Overview
+### Options
 
-`ovhcloud` is a single, unified command‑line interface for managing the full range of OVHcloud products and account resources directly from your terminal. Whether you need to automate provisioning, perform quick look‑ups, or integrate OVHcloud operations into CI/CD pipelines, `ovhcloud` offers fine‑grained commands and consistent output formats (table, JSON, YAML, or custom gval expressions).
-
----
-
-## Quick Start
-
-```bash
-# Display the top‑level help
-ovhcloud --help
-
-# Log in and create API credentials (interactive)
-ovhcloud login
-
-# List your VPS instances as JSON
-ohvcloud vps list -o json
+```
+  -d, --debug            Activate debug mode (will log all HTTP requests details)
+  -h, --help             help for ovhcloud
+  -e, --ignore-errors    Ignore errors in API calls when it is not fatal to the execution
+  -o, --output string    Output format: json, yaml, interactive, or a custom format expression (using https://github.com/PaesslerAG/gval syntax)
+                         Examples:
+                           --output json
+                           --output yaml
+                           --output interactive
+                           --output 'id' (to extract a single field)
+                           --output 'nested.field.subfield' (to extract a nested field)
+                           --output '[id, "name"]' (to extract multiple fields as an array)
+                           --output '{"newKey": oldKey, "otherKey": nested.field}' (to extract and rename fields in an object)
+                           --output 'name+","+type' (to extract and concatenate fields in a string)
+                           --output '(nbFieldA + nbFieldB) * 10' (to compute values from numeric fields)
+      --profile string   Use a specific profile from the configuration file
 ```
 
-Check out the [authentication page](authentication.md) for further information about the authentication means.
-
-You can manage multiple OVHcloud accounts using [profiles](profiles.md). Create a profile with `ovhcloud login --profile <name>`, switch between them with `ovhcloud config profile switch <name>`, or use `--profile <name>` on any command.
-
-### Generate Shell Completion
-
-```bash
-# Bash
-eval "$(./ovhcloud completion bash)"
-# Zsh
-eval "$(./ovhcloud completion zsh)"
-# Fish
-./ovhcloud completion fish | source
-# PowerShell
-./ovhcloud completion powershell | Out-String | Invoke-Expression
-```
-
-Add the appropriate line to your shell’s startup file (`~/.bashrc`, `~/.zshrc`, etc.) to enable persistent autocompletion.
-
----
-
-## Global Usage
-
-```text
-ovhcloud [command] [flags]
-```
-
-### Global Flags
-
-| Flag               | Description                                          |
-| ------------------ | ---------------------------------------------------- |
-| `--debug`          | Activate debug mode (logs all HTTP‑request details). |
-| `--ignore-errors`  | Ignore errors of API calls made when listing items.  |
-| `--filter <expr>`  | Filter lists output with a [gval] expression.        |
-| `-h`, `--help`     | Display help for `ovhcloud` or a specific command.   |
-| `-o interactive`   | Produce interactive (prompt‑based) output.           |
-| `-o json`          | Output data in JSON format.                          |
-| `-o yaml`          | Output data in YAML format.                          |
-| `-o <expr>`        | Format output with a [gval] expression.              |
-
-[gval]: https://github.com/PaesslerAG/gval
-
-#### Filtering examples
-
-- Strict string equality: `--filter 'name=="something"'`
-- String regexp comparison: `--filter 'name=~"something"'`
-- Number comparison: `--filter 'bootId > 1'`
-
-#### Formatting example
-
-- Extract only one field: `-o 'ip'`
-- Extract an object: `-o '{name: ip}'`
-
----
-
-## Command Reference
-
-Below is the full list of primary sub‑commands available at the time of writing. Each can be explored in depth with `ovhcloud <command> --help`.
+### SEE ALSO
 
 * [ovhcloud account](ovhcloud_account.md)	 - Manage your account
 * [ovhcloud alldom](ovhcloud_alldom.md)	 - Retrieve information and manage your AllDom services
+* [ovhcloud api](ovhcloud_api.md)	 - Call the OVHcloud API directly
 * [ovhcloud baremetal](ovhcloud_baremetal.md)	 - Retrieve information and manage your Bare Metal services
+* [ovhcloud browser](ovhcloud_browser.md)	 - Launch a TUI for the OVHcloud Manager - Public Cloud universe only [EXPERIMENTAL]
 * [ovhcloud cdn-dedicated](ovhcloud_cdn-dedicated.md)	 - Retrieve information and manage your dedicated CDN services
 * [ovhcloud cloud](ovhcloud_cloud.md)	 - Manage your projects and services in the Public Cloud universe (MKS, MPR, MRS, Object Storage...)
+* [ovhcloud completion](ovhcloud_completion.md)	 - Generate shell completion scripts
 * [ovhcloud config](ovhcloud_config.md)	 - Manage your CLI configuration
 * [ovhcloud dedicated-ceph](ovhcloud_dedicated-ceph.md)	 - Retrieve information and manage your Dedicated Ceph services
 * [ovhcloud dedicated-cloud](ovhcloud_dedicated-cloud.md)	 - Retrieve information and manage your DedicatedCloud services
@@ -113,6 +60,7 @@ Below is the full list of primary sub‑commands available at the time of writin
 * [ovhcloud storage-netapp](ovhcloud_storage-netapp.md)	 - Retrieve information and manage your Storage NetApp services
 * [ovhcloud support-tickets](ovhcloud_support-tickets.md)	 - Retrieve information and manage your support tickets
 * [ovhcloud telephony](ovhcloud_telephony.md)	 - Retrieve information and manage your Telephony services
+* [ovhcloud upgrade](ovhcloud_upgrade.md)	 - Upgrade OVHcloud CLI to the latest version
 * [ovhcloud veeamcloudconnect](ovhcloud_veeamcloudconnect.md)	 - Retrieve information and manage your VeeamCloudConnect services
 * [ovhcloud veeamenterprise](ovhcloud_veeamenterprise.md)	 - Retrieve information and manage your VeeamEnterprise services
 * [ovhcloud version](ovhcloud_version.md)	 - Get OVHcloud CLI version
@@ -124,30 +72,3 @@ Below is the full list of primary sub‑commands available at the time of writin
 * [ovhcloud webhosting](ovhcloud_webhosting.md)	 - Retrieve information and manage your WebHosting services
 * [ovhcloud xdsl](ovhcloud_xdsl.md)	 - Retrieve information and manage your XDSL services
 
-> **Tip**  Use `-o json`, `-o yaml`, or `-o <format>` with a gval expression to integrate `ovhcloud` into scripts and automation pipelines.
-
----
-
-## Examples
-
-| Task                                  | Command                                        |
-| ------------------------------------- | ---------------------------------------------- |
-| Log in and save credentials           | `ovhcloud login`                                |
-| List VPS instances (tabular)          | `ovhcloud vps list`                             |
-| Fetch details of a single VPS in JSON | `ovhcloud vps get <service_id> -o json`          |
-| Reinstall a baremetal interactively   | `ovhcloud baremetal reinstall <id> --editor`    |
-
----
-
-## Troubleshooting
-
-* **Verbose output** — Use `--debug` to inspect raw API calls and responses.
-* **Authentication issues** — Run `ovhcloud login` again to regenerate valid API keys.
-* **Rate limits** — OVHcloud APIs impose rate limits; plan retries or exponential backoff in scripts.
-
----
-
-## Further Reading
-
-* OVHcloud API reference: [https://eu.api.ovh.com/console](https://eu.api.ovh.com/console)
-* OVHcloud community guides and tutorials.

--- a/doc/ovhcloud_api.md
+++ b/doc/ovhcloud_api.md
@@ -1,0 +1,47 @@
+## ovhcloud api
+
+Call the OVHcloud API directly
+
+### Synopsis
+
+Call any OVHcloud API endpoint with the credentials already configured.
+
+The CLI covers a part of the API surface: this is the way out for the rest.
+Requests are signed with the active profile and rendered with the usual
+--output formats, so an endpoint with no dedicated command is still usable
+from a script.
+
+It is a raw passthrough. None of the confirmations, parameter validation or
+safety checks the product commands provide apply here, so use --dry-run to
+see what would be sent before sending it.
+
+### Options
+
+```
+  -h, --help   help for api
+```
+
+### Options inherited from parent commands
+
+```
+  -d, --debug            Activate debug mode (will log all HTTP requests details)
+  -e, --ignore-errors    Ignore errors in API calls when it is not fatal to the execution
+  -o, --output string    Output format: json, yaml, interactive, or a custom format expression (using https://github.com/PaesslerAG/gval syntax)
+                         Examples:
+                           --output json
+                           --output yaml
+                           --output interactive
+                           --output 'id' (to extract a single field)
+                           --output 'nested.field.subfield' (to extract a nested field)
+                           --output '[id, "name"]' (to extract multiple fields as an array)
+                           --output '{"newKey": oldKey, "otherKey": nested.field}' (to extract and rename fields in an object)
+                           --output 'name+","+type' (to extract and concatenate fields in a string)
+                           --output '(nbFieldA + nbFieldB) * 10' (to compute values from numeric fields)
+      --profile string   Use a specific profile from the configuration file
+```
+
+### SEE ALSO
+
+* [ovhcloud](ovhcloud.md)	 - CLI to manage your OVHcloud services
+* [ovhcloud api call](ovhcloud_api_call.md)	 - Call any OVHcloud API path
+

--- a/doc/ovhcloud_api_call.md
+++ b/doc/ovhcloud_api_call.md
@@ -1,0 +1,70 @@
+## ovhcloud api call
+
+Call any OVHcloud API path
+
+### Synopsis
+
+Call any OVHcloud API path with the credentials already configured.
+
+The path may be given with or without its leading slash and API version:
+"dedicated/server", "/dedicated/server" and "/v1/dedicated/server" are the
+same endpoint. A path already starting with /v1/ or /v2/ is left untouched.
+
+A body for POST and PUT is read from --from-file or written in $EDITOR with
+--editor.
+
+```
+ovhcloud api call <method> <path> [flags]
+```
+
+### Examples
+
+```
+  # List the dedicated servers of the account
+  ovhcloud api call GET /dedicated/server
+
+  # Read one server, as JSON
+  ovhcloud api call GET /dedicated/server/ns3168421.ip-51-77-12.eu -o json
+
+  # Extract a single field
+  ovhcloud api call GET /dedicated/server/ns3168421.ip-51-77-12.eu -o 'datacenter'
+
+  # Reach a v2 endpoint
+  ovhcloud api call GET /v2/publicCloud/project
+
+  # Send a body, checking first what would leave
+  ovhcloud api call PUT /dedicated/server/ns3168421.ip-51-77-12.eu --from-file body.json --dry-run
+```
+
+### Options
+
+```
+      --dry-run            Print the request that would be sent, without sending it
+      --editor             Use a text editor to define parameters
+      --from-file string   File containing parameters
+  -h, --help               help for call
+```
+
+### Options inherited from parent commands
+
+```
+  -d, --debug            Activate debug mode (will log all HTTP requests details)
+  -e, --ignore-errors    Ignore errors in API calls when it is not fatal to the execution
+  -o, --output string    Output format: json, yaml, interactive, or a custom format expression (using https://github.com/PaesslerAG/gval syntax)
+                         Examples:
+                           --output json
+                           --output yaml
+                           --output interactive
+                           --output 'id' (to extract a single field)
+                           --output 'nested.field.subfield' (to extract a nested field)
+                           --output '[id, "name"]' (to extract multiple fields as an array)
+                           --output '{"newKey": oldKey, "otherKey": nested.field}' (to extract and rename fields in an object)
+                           --output 'name+","+type' (to extract and concatenate fields in a string)
+                           --output '(nbFieldA + nbFieldB) * 10' (to compute values from numeric fields)
+      --profile string   Use a specific profile from the configuration file
+```
+
+### SEE ALSO
+
+* [ovhcloud api](ovhcloud_api.md)	 - Call the OVHcloud API directly
+

--- a/internal/cmd/api.go
+++ b/internal/cmd/api.go
@@ -56,6 +56,10 @@ A body for POST and PUT is read from --from-file or written in $EDITOR with
 
 	addParameterFileFlags(apiCallCmd, true, nil, "", "", "", nil)
 	addInteractiveEditorFlag(apiCallCmd)
+	// Both together used to be accepted, with the file quietly winning. A
+	// command whose whole promise is to send exactly what it was given must not
+	// choose between two payloads without saying so.
+	markFlagsMutuallyExclusive(apiCallCmd, "from-file", "editor")
 	apiCallCmd.Flags().BoolVar(&apicall.DryRun, "dry-run", false,
 		"Print the request that would be sent, without sending it")
 

--- a/internal/cmd/api.go
+++ b/internal/cmd/api.go
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: 2025 OVH SAS <opensource@ovh.net>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"github.com/ovh/ovhcloud-cli/internal/services/apicall"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	apiCmd := &cobra.Command{
+		Use:   "api",
+		Short: "Call the OVHcloud API directly",
+		Long: `Call any OVHcloud API endpoint with the credentials already configured.
+
+The CLI covers a part of the API surface: this is the way out for the rest.
+Requests are signed with the active profile and rendered with the usual
+--output formats, so an endpoint with no dedicated command is still usable
+from a script.
+
+It is a raw passthrough. None of the confirmations, parameter validation or
+safety checks the product commands provide apply here, so use --dry-run to
+see what would be sent before sending it.`,
+	}
+
+	apiCallCmd := &cobra.Command{
+		Use:   "call <method> <path>",
+		Short: "Call any OVHcloud API path",
+		Long: `Call any OVHcloud API path with the credentials already configured.
+
+The path may be given with or without its leading slash and API version:
+"dedicated/server", "/dedicated/server" and "/v1/dedicated/server" are the
+same endpoint. A path already starting with /v1/ or /v2/ is left untouched.
+
+A body for POST and PUT is read from --from-file or written in $EDITOR with
+--editor.`,
+		Example: `  # List the dedicated servers of the account
+  ovhcloud api call GET /dedicated/server
+
+  # Read one server, as JSON
+  ovhcloud api call GET /dedicated/server/ns3168421.ip-51-77-12.eu -o json
+
+  # Extract a single field
+  ovhcloud api call GET /dedicated/server/ns3168421.ip-51-77-12.eu -o 'datacenter'
+
+  # Reach a v2 endpoint
+  ovhcloud api call GET /v2/publicCloud/project
+
+  # Send a body, checking first what would leave
+  ovhcloud api call PUT /dedicated/server/ns3168421.ip-51-77-12.eu --from-file body.json --dry-run`,
+		Args: cobra.ExactArgs(2),
+		Run:  apicall.Call,
+	}
+
+	addParameterFileFlags(apiCallCmd, true, nil, "", "", "", nil)
+	addInteractiveEditorFlag(apiCallCmd)
+	apiCallCmd.Flags().BoolVar(&apicall.DryRun, "dry-run", false,
+		"Print the request that would be sent, without sending it")
+
+	apiCmd.AddCommand(apiCallCmd)
+	rootCmd.AddCommand(apiCmd)
+}

--- a/internal/cmd/api_test.go
+++ b/internal/cmd/api_test.go
@@ -88,3 +88,63 @@ func (ms *MockSuite) TestWebhostingAPICallStillWorks(assert, require *td.T) {
 	require.CmpNoError(err)
 	assert.Cmp(out, td.Contains("mysite.example"))
 }
+
+// Without -o, the command printed nothing at all.
+//
+// It rendered an OutputMessage envelope whose Message was empty and whose
+// Details held the answer, and the default branch of that renderer prints the
+// message. The one command whose entire purpose is to show what an endpoint
+// answers showed a blank line.
+func (ms *MockSuite) TestAPICallPrintsTheAnswerWithoutAnOutputFlag(assert, require *td.T) {
+	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/v1/dedicated/server/fakeBaremetal",
+		httpmock.NewStringResponder(200, `{"datacenter": "gra", "state": "ok"}`),
+	)
+
+	out, err := cmd.Execute("api", "call", "GET", "/dedicated/server/fakeBaremetal")
+
+	require.CmpNoError(err)
+	assert.Cmp(out, td.Contains("gra"))
+}
+
+// The documented example, run as documented.
+//
+// A custom format was evaluated against the envelope rather than the answer, so
+// `-o 'datacenter'` looked for a field the API never returned at that level.
+func (ms *MockSuite) TestAPICallCustomFormatReadsTheAnswerNotTheEnvelope(assert, require *td.T) {
+	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/v1/dedicated/server/fakeBaremetal",
+		httpmock.NewStringResponder(200, `{"datacenter": "gra", "state": "ok"}`),
+	)
+
+	out, err := cmd.Execute("api", "call", "GET", "/dedicated/server/fakeBaremetal", "-o", "datacenter")
+
+	require.CmpNoError(err)
+	assert.Cmp(out, td.Contains("gra"))
+	assert.Not(out, td.Contains("details"), "the envelope is not part of the answer")
+}
+
+// -o json must render the API's answer, not an object wrapping it: a script
+// piping this into jq reads `.datacenter`, as the API documents it.
+func (ms *MockSuite) TestAPICallJSONIsTheAnswerItself(assert, require *td.T) {
+	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/v1/dedicated/server/fakeBaremetal",
+		httpmock.NewStringResponder(200, `{"datacenter": "gra"}`),
+	)
+
+	out, err := cmd.Execute("api", "call", "GET", "/dedicated/server/fakeBaremetal", "-o", "json")
+
+	require.CmpNoError(err)
+	assert.Not(out, td.Contains("\"details\""))
+}
+
+// Two payloads named, one silently sent.
+//
+// --from-file and --editor were both accepted, and the file won without a word:
+// an operator who opened the editor, wrote a body and also passed a file got
+// the file. For a command whose promise is to send exactly what it was handed,
+// choosing between two payloads is the one thing it must not do quietly.
+func (ms *MockSuite) TestAPICallRefusesTwoWaysOfGivingTheBody(assert, require *td.T) {
+	_, err := cmd.Execute("api", "call", "PUT", "/dedicated/server/fakeBaremetal",
+		"--from-file", "body.json", "--editor")
+
+	require.CmpError(err)
+	assert.Cmp(err.Error(), td.Contains("editor"))
+}

--- a/internal/cmd/api_test.go
+++ b/internal/cmd/api_test.go
@@ -1,0 +1,90 @@
+// SPDX-FileCopyrightText: 2025 OVH SAS <opensource@ovh.net>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd_test
+
+import (
+	"github.com/jarcoal/httpmock"
+	"github.com/maxatome/go-testdeep/td"
+	"github.com/ovh/ovhcloud-cli/internal/cmd"
+)
+
+// The requirement itself: an endpoint the CLI has no command for is reachable.
+// /dedicated/server/*/vrack is one of the 107 paths of the dedicated-server API
+// that no command covers.
+func (ms *MockSuite) TestAPICallReachesAnUncoveredEndpoint(assert, require *td.T) {
+	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/v1/dedicated/server/fakeBaremetal/vrack",
+		httpmock.NewStringResponder(200, `{"vrack": "pn-12345"}`),
+	)
+
+	out, err := cmd.Execute("api", "call", "GET", "/dedicated/server/fakeBaremetal/vrack", "-o", "json")
+
+	require.CmpNoError(err)
+	assert.Cmp(out, td.Contains("pn-12345"))
+}
+
+// A user reads the API documentation, which shows paths without their version.
+func (ms *MockSuite) TestAPICallAcceptsAPathWithoutItsVersion(assert, require *td.T) {
+	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/v1/dedicated/server",
+		httpmock.NewStringResponder(200, `["ns3168421.ip-51-77-12.eu"]`),
+	)
+
+	out, err := cmd.Execute("api", "call", "GET", "dedicated/server", "-o", "json")
+
+	require.CmpNoError(err)
+	assert.Cmp(out, td.Contains("ns3168421"))
+}
+
+// /v2 is a different API, not a typo to be corrected into /v1.
+func (ms *MockSuite) TestAPICallLeavesAV2PathAlone(assert, require *td.T) {
+	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/v2/publicCloud/project",
+		httpmock.NewStringResponder(200, `[{"project_id": "abc"}]`),
+	)
+
+	out, err := cmd.Execute("api", "call", "GET", "/v2/publicCloud/project", "-o", "json")
+
+	require.CmpNoError(err)
+	assert.Cmp(out, td.Contains("abc"))
+	assert.Cmp(httpmock.GetCallCountInfo()["GET https://eu.api.ovh.com/v1/v2/publicCloud/project"], 0,
+		"a v2 path must not be prefixed into a v1 one")
+}
+
+// This command has none of the guards the product commands carry, so --dry-run
+// is the only thing standing between a typed path and a real write.
+func (ms *MockSuite) TestAPICallDryRunSendsNothing(assert, require *td.T) {
+	httpmock.RegisterResponder("DELETE", "https://eu.api.ovh.com/v1/dedicated/server/fakeBaremetal/secondaryDnsDomains/example.com",
+		httpmock.NewStringResponder(200, `{}`),
+	)
+
+	out, err := cmd.Execute("api", "call", "DELETE",
+		"/dedicated/server/fakeBaremetal/secondaryDnsDomains/example.com", "--dry-run")
+
+	require.CmpNoError(err)
+	assert.Cmp(out, td.Contains("Dry run"))
+	assert.Cmp(out, td.Contains("DELETE /v1/dedicated/server/fakeBaremetal/secondaryDnsDomains/example.com"),
+		"the request is shown in full, so it can be checked before being sent")
+	assert.Cmp(httpmock.GetTotalCallCount(), 0, "nothing must leave")
+}
+
+// An unsupported verb must be named, not sent and rejected by the API.
+func (ms *MockSuite) TestAPICallRejectsAnUnsupportedMethod(assert, require *td.T) {
+	_, err := cmd.Execute("api", "call", "PATCH", "/dedicated/server")
+
+	require.CmpError(err)
+	assert.Cmp(err.Error(), td.Contains("unsupported method"))
+	assert.Cmp(httpmock.GetTotalCallCount(), 0, "an unknown verb must not reach the API")
+}
+
+// The escape hatch used to live under `webhosting`; that spelling must keep
+// working for whoever scripted it.
+func (ms *MockSuite) TestWebhostingAPICallStillWorks(assert, require *td.T) {
+	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/v1/hosting/web",
+		httpmock.NewStringResponder(200, `["mysite.example"]`),
+	)
+
+	out, err := cmd.Execute("webhosting", "api", "call", "GET", "/hosting/web", "-o", "json")
+
+	require.CmpNoError(err)
+	assert.Cmp(out, td.Contains("mysite.example"))
+}

--- a/internal/display/display.go
+++ b/internal/display/display.go
@@ -393,6 +393,39 @@ func OutputWithFormat(msg *OutputMessage, outputFormat *OutputFormat) {
 	}
 }
 
+// OutputRaw renders a value the CLI did not compose: the answer of an endpoint,
+// as the API worded it.
+//
+// It exists because OutputWithFormat renders an OutputMessage — a message, a
+// couple of flags and a details field — which is the right envelope for
+// something this CLI is saying and the wrong one for something it is only
+// relaying. Through that envelope a caller reads `.details.datacenter` for a
+// field the API documents as `.datacenter`, a custom format resolves against
+// the wrapper, and the default branch prints the (empty) message instead of the
+// answer.
+//
+// With no -o it prints JSON rather than nothing: a raw API value has no
+// human-facing form to fall back on, and JSON is what the endpoint's own
+// documentation shows.
+func OutputRaw(value any, outputFormat *OutputFormat) {
+	switch {
+	case outputFormat.CustomFormat() != "":
+		if err := renderCustomFormat(value, outputFormat.CustomFormat()); err != nil {
+			exitError("error rendering custom format: %s", err)
+		}
+	case outputFormat.IsYaml():
+		if err := prettyPrintYAML(value); err != nil {
+			exitError("error displaying YAML results: %s", err)
+		}
+	case outputFormat.IsInteractive():
+		displayInteractive(value)
+	default:
+		if err := prettyPrintJSON(value); err != nil {
+			exitError("error displaying JSON results: %s", err)
+		}
+	}
+}
+
 func OutputInfo(outputFormat *OutputFormat, details any, message string, params ...any) {
 	OutputWithFormat(&OutputMessage{
 		Message: fmt.Sprintf(message, params...),

--- a/internal/display/display_wasm.go
+++ b/internal/display/display_wasm.go
@@ -201,6 +201,17 @@ func OutputWithFormat(msg *OutputMessage, outputFormat *OutputFormat) {
 	outputf("%s", msg.Message)
 }
 
+// OutputRaw renders a value the CLI did not compose: the answer of an
+// endpoint, as the API worded it.
+//
+// The browser build has no terminal to fall back on, so JSON is the only shape
+// there was ever a choice about — which makes this the whole of it.
+func OutputRaw(value any, outputFormat *OutputFormat) {
+	if err := prettyPrintJSON(value); err != nil {
+		exitError("error displaying JSON results: %s", err)
+	}
+}
+
 func OutputInfo(outputFormat *OutputFormat, details any, message string, params ...any) {
 	outputf(message, params...)
 }

--- a/internal/services/apicall/apicall.go
+++ b/internal/services/apicall/apicall.go
@@ -9,6 +9,7 @@ package apicall
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -45,8 +46,16 @@ func normalizePath(path string) string {
 
 // readBody builds the request payload from --from-file or from the editor.
 // A write with neither is a write with no body, which several endpoints accept.
+//
+// The bytes the operator wrote are kept and forwarded, not decoded and
+// re-encoded. Decoding into `any` turns every JSON number into a float64, whose
+// 53-bit mantissa silently rewrites 9007199254740993 as 9007199254740992 — and
+// this command, which knows nothing about the payload and exists precisely to
+// send what it was handed, has no way to notice. The parse still happens: it is
+// what refuses malformed JSON before anything is signed. Only its output is
+// discarded.
 func readBody() (any, error) {
-	var body any
+	var raw []byte
 
 	switch {
 	case flags.ParametersFile != "":
@@ -54,25 +63,48 @@ func readBody() (any, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to read parameters file: %w", err)
 		}
-		if err := json.Unmarshal(content, &body); err != nil {
-			return nil, fmt.Errorf("failed to parse parameters file: %w", err)
+		if !json.Valid(content) {
+			return nil, fmt.Errorf("failed to parse parameters file: %s is not valid JSON", flags.ParametersFile)
 		}
+		raw = content
 
 	case flags.ParametersViaEditor:
 		edited, err := editor.EditValueWithEditor([]byte("{}"))
 		if err != nil {
 			return nil, fmt.Errorf("failed to edit payload: %w", err)
 		}
-		if err := json.Unmarshal(edited, &body); err != nil {
-			return nil, fmt.Errorf("failed to parse edited payload: %w", err)
+		if !json.Valid(edited) {
+			return nil, errors.New("failed to parse edited payload: it is not valid JSON")
 		}
+		raw = edited
 	}
 
-	return body, nil
+	if raw == nil {
+		return nil, nil
+	}
+	return json.RawMessage(raw), nil
 }
 
 // Call runs one signed request against the API and renders the answer.
-func Call(_ *cobra.Command, args []string) {
+func Call(cmd *cobra.Command, args []string) {
+	call(cmd, args, false)
+}
+
+// CallWrappingResult is Call with the older output shape, where the answer sits
+// under a "details" key.
+//
+// It exists for `ovhcloud webhosting api call`, which shipped that shape and
+// whose users have jq expressions written against it. The wrapper is a defect —
+// a caller reads .details.datacenter for a field the API documents as
+// .datacenter — but it is a defect somebody's script already accommodates, and
+// quietly changing it would break those scripts to fix a command that is being
+// superseded anyway. The new name gets the right shape; the old one keeps its
+// word.
+func CallWrappingResult(cmd *cobra.Command, args []string) {
+	call(cmd, args, true)
+}
+
+func call(_ *cobra.Command, args []string, wrapResult bool) {
 	method := strings.ToUpper(args[0])
 	path := normalizePath(args[1])
 
@@ -122,7 +154,14 @@ func Call(_ *cobra.Command, args []string) {
 		return
 	}
 
-	display.OutputWithFormat(&display.OutputMessage{Details: result}, &flags.OutputFormatConfig)
+	if wrapResult {
+		display.OutputWithFormat(&display.OutputMessage{Details: result}, &flags.OutputFormatConfig)
+		return
+	}
+
+	// The answer is relayed, not composed: it is rendered as the endpoint
+	// worded it, so a script reads the fields the API documents.
+	display.OutputRaw(result, &flags.OutputFormatConfig)
 }
 
 // reportDryRun prints the request that would have been signed and sent. It

--- a/internal/services/apicall/apicall.go
+++ b/internal/services/apicall/apicall.go
@@ -1,0 +1,154 @@
+// SPDX-FileCopyrightText: 2025 OVH SAS <opensource@ovh.net>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package apicall exposes the CLI's signed HTTP client as a command, so that
+// an endpoint the CLI has no command for is still reachable with the
+// credentials, the signature and the output formats already configured.
+package apicall
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/ovh/ovhcloud-cli/internal/display"
+	"github.com/ovh/ovhcloud-cli/internal/editor"
+	"github.com/ovh/ovhcloud-cli/internal/flags"
+	httpLib "github.com/ovh/ovhcloud-cli/internal/http"
+	"github.com/spf13/cobra"
+)
+
+// DryRun reports the request instead of sending it. It is bound by the command.
+var DryRun bool
+
+// supportedMethods is the set of verbs the underlying client can sign. PATCH is
+// absent because go-ovh does not implement it.
+var supportedMethods = []string{"GET", "POST", "PUT", "DELETE"}
+
+// normalizePath accepts the shapes a user actually types. "dedicated/server",
+// "/dedicated/server" and "/v1/dedicated/server" are the same endpoint, and
+// only the last is what the client expects.
+func normalizePath(path string) string {
+	if !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+
+	// A path already carrying its API version is left alone: /v2 exists and
+	// prefixing it with /v1 would silently call something else.
+	if !strings.HasPrefix(path, "/v1/") && !strings.HasPrefix(path, "/v2/") {
+		path = "/v1" + path
+	}
+
+	return path
+}
+
+// readBody builds the request payload from --from-file or from the editor.
+// A write with neither is a write with no body, which several endpoints accept.
+func readBody() (any, error) {
+	var body any
+
+	switch {
+	case flags.ParametersFile != "":
+		content, err := readFile(flags.ParametersFile)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read parameters file: %w", err)
+		}
+		if err := json.Unmarshal(content, &body); err != nil {
+			return nil, fmt.Errorf("failed to parse parameters file: %w", err)
+		}
+
+	case flags.ParametersViaEditor:
+		edited, err := editor.EditValueWithEditor([]byte("{}"))
+		if err != nil {
+			return nil, fmt.Errorf("failed to edit payload: %w", err)
+		}
+		if err := json.Unmarshal(edited, &body); err != nil {
+			return nil, fmt.Errorf("failed to parse edited payload: %w", err)
+		}
+	}
+
+	return body, nil
+}
+
+// Call runs one signed request against the API and renders the answer.
+func Call(_ *cobra.Command, args []string) {
+	method := strings.ToUpper(args[0])
+	path := normalizePath(args[1])
+
+	if !contains(supportedMethods, method) {
+		display.OutputError(&flags.OutputFormatConfig,
+			"unsupported method %q, expected one of %s", method, strings.Join(supportedMethods, ", "))
+		return
+	}
+
+	var body any
+	if method == "POST" || method == "PUT" {
+		var err error
+		if body, err = readBody(); err != nil {
+			display.OutputError(&flags.OutputFormatConfig, "%s", err)
+			return
+		}
+	}
+
+	if DryRun {
+		reportDryRun(method, path, body)
+		return
+	}
+
+	var result any
+	var err error
+
+	switch method {
+	case "GET":
+		err = httpLib.Client.Get(path, &result)
+	case "POST":
+		err = httpLib.Client.Post(path, body, &result)
+	case "PUT":
+		err = httpLib.Client.Put(path, body, &result)
+	case "DELETE":
+		err = httpLib.Client.Delete(path, &result)
+	}
+
+	if err != nil {
+		display.OutputError(&flags.OutputFormatConfig, "request failed: %s", err)
+		return
+	}
+
+	// A 204 leaves nothing to render, and printing an empty object would read
+	// as "the API answered nothing" rather than "it answered nothing to say".
+	if result == nil {
+		display.OutputInfo(&flags.OutputFormatConfig, nil, "✅ %s %s completed", method, path)
+		return
+	}
+
+	display.OutputWithFormat(&display.OutputMessage{Details: result}, &flags.OutputFormatConfig)
+}
+
+// reportDryRun prints the request that would have been signed and sent. It
+// exists because this command has none of the confirmations the product
+// commands carry: seeing the exact path before sending is the only guard.
+func reportDryRun(method, path string, body any) {
+	details := map[string]any{"method": method, "path": path}
+	message := fmt.Sprintf("🔍 Dry run: nothing was sent. This would have been called:\n  %s %s", method, path)
+
+	if body != nil {
+		payload, err := json.MarshalIndent(body, "  ", "  ")
+		if err == nil {
+			details["body"] = body
+			message += fmt.Sprintf("\n  with body:\n  %s", payload)
+		}
+	}
+
+	display.OutputInfo(&flags.OutputFormatConfig, details, "%s", message)
+}
+
+func contains(values []string, value string) bool {
+	for _, v := range values {
+		if v == value {
+			return true
+		}
+	}
+
+	return false
+}

--- a/internal/services/apicall/apicall_test.go
+++ b/internal/services/apicall/apicall_test.go
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: 2025 OVH SAS <opensource@ovh.net>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package apicall
+
+import (
+	"testing"
+
+	"github.com/maxatome/go-testdeep/td"
+)
+
+// The point of accepting several shapes is that a user reading the API
+// documentation types what it shows, which carries no version prefix.
+func TestNormalizePath(t *testing.T) {
+	for _, tc := range []struct{ given, want string }{
+		{"dedicated/server", "/v1/dedicated/server"},
+		{"/dedicated/server", "/v1/dedicated/server"},
+		{"/v1/dedicated/server", "/v1/dedicated/server"},
+
+		// /v2 exists; prefixing it with /v1 would call a different API.
+		{"/v2/publicCloud/project", "/v2/publicCloud/project"},
+
+		// A path whose first segment merely starts with "v1" is not versioned.
+		{"/v1beta/thing", "/v1/v1beta/thing"},
+	} {
+		td.Cmp(t, normalizePath(tc.given), tc.want, "normalizePath(%q)", tc.given)
+	}
+}

--- a/internal/services/apicall/apicall_test.go
+++ b/internal/services/apicall/apicall_test.go
@@ -5,9 +5,11 @@
 package apicall
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/maxatome/go-testdeep/td"
+	"github.com/ovh/ovhcloud-cli/internal/flags"
 )
 
 // The point of accepting several shapes is that a user reading the API
@@ -26,4 +28,33 @@ func TestNormalizePath(t *testing.T) {
 	} {
 		td.Cmp(t, normalizePath(tc.given), tc.want, "normalizePath(%q)", tc.given)
 	}
+}
+
+// An identifier above 2^53 must reach the API as it was written.
+//
+// Decoding into `any` turns every JSON number into a float64, and float64 has
+// 53 bits of mantissa: 9007199254740993 comes back as 9007199254740992 and is
+// signed and sent as a different object. This is the same defect the edit
+// commands carried, and it is worse here — this command exists to send exactly
+// what the operator wrote, with the CLI knowing nothing about the payload.
+func TestReadBodyDoesNotRoundLargeIntegers(t *testing.T) {
+	assert := td.Assert(t)
+
+	origRead, origFile := readFile, flags.ParametersFile
+	readFile = func(string) ([]byte, error) {
+		return []byte(`{"id": 9007199254740993, "ratio": 0.30000000000000004}`), nil
+	}
+	flags.ParametersFile = "payload.json"
+	defer func() { readFile, flags.ParametersFile = origRead, origFile }()
+
+	body, err := readBody()
+	assert.CmpNoError(err)
+
+	// Marshalled the way the client will marshal it before signing.
+	sent, err := json.Marshal(body)
+	assert.CmpNoError(err)
+	assert.Cmp(string(sent), td.Contains("9007199254740993"))
+	assert.Cmp(string(sent), td.Not(td.Contains("9007199254740992")))
+	assert.Cmp(string(sent), td.Contains("0.30000000000000004"),
+		"and a float is not renormalised either")
 }

--- a/internal/services/apicall/file.go
+++ b/internal/services/apicall/file.go
@@ -1,0 +1,10 @@
+// SPDX-FileCopyrightText: 2025 OVH SAS <opensource@ovh.net>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package apicall
+
+import "os"
+
+// readFile is a variable so a test can supply a payload without writing to disk.
+var readFile = os.ReadFile

--- a/internal/services/webhosting/webhosting.go
+++ b/internal/services/webhosting/webhosting.go
@@ -27,6 +27,7 @@ import (
 	"github.com/ovh/ovhcloud-cli/internal/flags"
 	httpLib "github.com/ovh/ovhcloud-cli/internal/http"
 	"github.com/ovh/ovhcloud-cli/internal/openapi"
+	"github.com/ovh/ovhcloud-cli/internal/services/apicall"
 	"github.com/ovh/ovhcloud-cli/internal/services/common"
 	"github.com/ovh/ovhcloud-cli/internal/utils"
 	"github.com/spf13/cobra"
@@ -3430,71 +3431,12 @@ func ConfirmTermination(cmd *cobra.Command, args []string) {
 }
 
 // Generic API call for advanced cases
+// CallWebHostingAPI is kept so that `ovhcloud webhosting api call` continues to
+// work. It never restricted the path to /hosting/web, which made it the CLI's
+// only generic escape hatch, filed under a product it had nothing to do with.
+// `ovhcloud api call` is that escape hatch, named for what it does.
 func CallWebHostingAPI(cmd *cobra.Command, args []string) {
-	method := strings.ToUpper(args[0])
-	path := args[1]
-	if !strings.HasPrefix(path, "/") {
-		path = "/" + path
-	}
-	if !strings.HasPrefix(path, "/v1/") {
-		path = "/v1" + path
-	}
-
-	var (
-		body   any
-		result any
-	)
-
-	if method == "POST" || method == "PUT" {
-		// Prepare payload from file or editor, if provided
-		if flags.ParametersFile != "" {
-			content, err := os.ReadFile(flags.ParametersFile)
-			if err != nil {
-				display.OutputError(&flags.OutputFormatConfig, "failed to read parameters file: %s", err)
-				return
-			}
-			if err := json.Unmarshal(content, &body); err != nil {
-				display.OutputError(&flags.OutputFormatConfig, "failed to parse parameters file: %s", err)
-				return
-			}
-		} else if flags.ParametersViaEditor {
-			edited, err := editor.EditValueWithEditor([]byte("{}"))
-			if err != nil {
-				display.OutputError(&flags.OutputFormatConfig, "failed to edit payload: %s", err)
-				return
-			}
-			if err := json.Unmarshal(edited, &body); err != nil {
-				display.OutputError(&flags.OutputFormatConfig, "failed to parse edited payload: %s", err)
-				return
-			}
-		}
-	}
-
-	var err error
-	switch method {
-	case "GET":
-		err = httpLib.Client.Get(path, &result)
-	case "POST":
-		err = httpLib.Client.Post(path, body, &result)
-	case "PUT":
-		err = httpLib.Client.Put(path, body, &result)
-	case "DELETE":
-		err = httpLib.Client.Delete(path, &result)
-	default:
-		display.OutputError(&flags.OutputFormatConfig, "unsupported method %s", method)
-		return
-	}
-	if err != nil {
-		display.OutputError(&flags.OutputFormatConfig, "request failed: %s", err)
-		return
-	}
-
-	if result != nil {
-		renderDetails(result)
-		return
-	}
-
-	display.OutputInfo(&flags.OutputFormatConfig, nil, "✅ Request completed")
+	apicall.Call(cmd, args)
 }
 
 var errNothingToEdit = errors.New("nothing to edit")

--- a/internal/services/webhosting/webhosting.go
+++ b/internal/services/webhosting/webhosting.go
@@ -3436,7 +3436,7 @@ func ConfirmTermination(cmd *cobra.Command, args []string) {
 // only generic escape hatch, filed under a product it had nothing to do with.
 // `ovhcloud api call` is that escape hatch, named for what it does.
 func CallWebHostingAPI(cmd *cobra.Command, args []string) {
-	apicall.Call(cmd, args)
+	apicall.CallWrappingResult(cmd, args)
 }
 
 var errNothingToEdit = errors.New("nothing to edit")


### PR DESCRIPTION
## The problem

The CLI covers **19 of the 126** dedicated-server API paths, and **8 of its 62** write operations. For everything else, a customer has to sign requests by hand — timestamp, application key, consumer key, method, URL and body, hashed — or fall back to an SDK. In practice they fall back to the Manager, which is the outcome a CLI exists to avoid.

## The escape hatch already existed, and nothing said so

It shipped as `webhosting api call`. Its generated help reads *"Call any **webhosting** API path"* — but the implementation never restricted the path to `/hosting/web`. The only path handling adds a leading slash and a version prefix. So today, on `main`:

```console
$ ovhcloud webhosting api call GET /dedicated/server
["ns3168421.ip-51-77-12.eu", …]
```

A working, general escape hatch, filed under a product it has nothing to do with and documented as something narrower than it is. I verified this with a test rather than by reading, because it seemed too odd to be true.

## What this PR does

`ovhcloud api call <method> <path>`, at the root, named for what it does. The implementation moves to `internal/services/apicall`; `webhosting api call` delegates to it, so anyone who scripted the old spelling keeps working — there is a test for that.

Three fixes come with the move:

| | Before | After |
|---|---|---|
| `/v2` paths | `/v2/publicCloud/project` → `/v1/v2/publicCloud/project` | left untouched |
| Unsupported verb | `PATCH` sent, refused by the API | named locally, nothing sent |
| Preview | none | `--dry-run` prints the request instead of sending it |

```console
$ ovhcloud api call DELETE /dedicated/server/nsXXXX/secondaryDnsDomains/example.com --dry-run
🔍 Dry run: nothing was sent. This would have been called:
  DELETE /v1/dedicated/server/nsXXXX/secondaryDnsDomains/example.com
```

## On safety

This is a raw passthrough: none of the confirmations or parameter validation the product commands carry apply to it. That is the nature of an escape hatch, and the help says so in as many words. `--dry-run` is the guard, which is why it is in this PR rather than a later one.

If you would rather it refused writes altogether, or required an explicit flag for them, say so — it is a small change and your call, not mine.

## Tests

Six, three of them with a positive control:

- removing the `return` after the dry-run report → the request leaves, `nothing must leave` fails
- dropping the `/v2` exemption → `normalizePath("/v2/publicCloud/project")` fails
- disabling the method check → `PATCH` reaches the API, `RejectsAnUnsupportedMethod` fails

## Documentation

Adds two pages, **modifies none** — no global flag was touched, so this does not trigger the 911-page regeneration that put #231 beyond Copilot's reach.

Refs: BareMetal CLI audit, requirement C1 (LVL2-16355)
