### PR TITLE
feat(baremetal): guard every action that interrupts a server, not just reinstall

### DIFF
--- a/doc/ovhcloud.md
+++ b/doc/ovhcloud.md
@@ -1,90 +1,36 @@
-# OVHcloud CLI (`ovhcloud`) Documentation
+## ovhcloud
 
----
+CLI to manage your OVHcloud services
 
-## Overview
+### Options
 
-`ovhcloud` is a single, unified command‑line interface for managing the full range of OVHcloud products and account resources directly from your terminal. Whether you need to automate provisioning, perform quick look‑ups, or integrate OVHcloud operations into CI/CD pipelines, `ovhcloud` offers fine‑grained commands and consistent output formats (table, JSON, YAML, or custom gval expressions).
-
----
-
-## Quick Start
-
-```bash
-# Display the top‑level help
-ovhcloud --help
-
-# Log in and create API credentials (interactive)
-ovhcloud login
-
-# List your VPS instances as JSON
-ohvcloud vps list -o json
+```
+  -d, --debug            Activate debug mode (will log all HTTP requests details)
+  -h, --help             help for ovhcloud
+  -e, --ignore-errors    Ignore errors in API calls when it is not fatal to the execution
+  -o, --output string    Output format: json, yaml, interactive, or a custom format expression (using https://github.com/PaesslerAG/gval syntax)
+                         Examples:
+                           --output json
+                           --output yaml
+                           --output interactive
+                           --output 'id' (to extract a single field)
+                           --output 'nested.field.subfield' (to extract a nested field)
+                           --output '[id, "name"]' (to extract multiple fields as an array)
+                           --output '{"newKey": oldKey, "otherKey": nested.field}' (to extract and rename fields in an object)
+                           --output 'name+","+type' (to extract and concatenate fields in a string)
+                           --output '(nbFieldA + nbFieldB) * 10' (to compute values from numeric fields)
+      --profile string   Use a specific profile from the configuration file
 ```
 
-Check out the [authentication page](authentication.md) for further information about the authentication means.
-
-You can manage multiple OVHcloud accounts using [profiles](profiles.md). Create a profile with `ovhcloud login --profile <name>`, switch between them with `ovhcloud config profile switch <name>`, or use `--profile <name>` on any command.
-
-### Generate Shell Completion
-
-```bash
-# Bash
-eval "$(./ovhcloud completion bash)"
-# Zsh
-eval "$(./ovhcloud completion zsh)"
-# Fish
-./ovhcloud completion fish | source
-# PowerShell
-./ovhcloud completion powershell | Out-String | Invoke-Expression
-```
-
-Add the appropriate line to your shell’s startup file (`~/.bashrc`, `~/.zshrc`, etc.) to enable persistent autocompletion.
-
----
-
-## Global Usage
-
-```text
-ovhcloud [command] [flags]
-```
-
-### Global Flags
-
-| Flag               | Description                                          |
-| ------------------ | ---------------------------------------------------- |
-| `--debug`          | Activate debug mode (logs all HTTP‑request details). |
-| `--ignore-errors`  | Ignore errors of API calls made when listing items.  |
-| `--filter <expr>`  | Filter lists output with a [gval] expression.        |
-| `-h`, `--help`     | Display help for `ovhcloud` or a specific command.   |
-| `-o interactive`   | Produce interactive (prompt‑based) output.           |
-| `-o json`          | Output data in JSON format.                          |
-| `-o yaml`          | Output data in YAML format.                          |
-| `-o <expr>`        | Format output with a [gval] expression.              |
-
-[gval]: https://github.com/PaesslerAG/gval
-
-#### Filtering examples
-
-- Strict string equality: `--filter 'name=="something"'`
-- String regexp comparison: `--filter 'name=~"something"'`
-- Number comparison: `--filter 'bootId > 1'`
-
-#### Formatting example
-
-- Extract only one field: `-o 'ip'`
-- Extract an object: `-o '{name: ip}'`
-
----
-
-## Command Reference
-
-Below is the full list of primary sub‑commands available at the time of writing. Each can be explored in depth with `ovhcloud <command> --help`.
+### SEE ALSO
 
 * [ovhcloud account](ovhcloud_account.md)	 - Manage your account
 * [ovhcloud alldom](ovhcloud_alldom.md)	 - Retrieve information and manage your AllDom services
 * [ovhcloud baremetal](ovhcloud_baremetal.md)	 - Retrieve information and manage your Bare Metal services
+* [ovhcloud browser](ovhcloud_browser.md)	 - Launch a TUI for the OVHcloud Manager - Public Cloud universe only [EXPERIMENTAL]
 * [ovhcloud cdn-dedicated](ovhcloud_cdn-dedicated.md)	 - Retrieve information and manage your dedicated CDN services
 * [ovhcloud cloud](ovhcloud_cloud.md)	 - Manage your projects and services in the Public Cloud universe (MKS, MPR, MRS, Object Storage...)
+* [ovhcloud completion](ovhcloud_completion.md)	 - Generate shell completion scripts
 * [ovhcloud config](ovhcloud_config.md)	 - Manage your CLI configuration
 * [ovhcloud dedicated-ceph](ovhcloud_dedicated-ceph.md)	 - Retrieve information and manage your Dedicated Ceph services
 * [ovhcloud dedicated-cloud](ovhcloud_dedicated-cloud.md)	 - Retrieve information and manage your DedicatedCloud services
@@ -102,6 +48,7 @@ Below is the full list of primary sub‑commands available at the time of writin
 * [ovhcloud ldp](ovhcloud_ldp.md)	 - Retrieve information and manage your LDP (Logs Data Platform) services
 * [ovhcloud location](ovhcloud_location.md)	 - Retrieve information and manage your Location services
 * [ovhcloud login](ovhcloud_login.md)	 - Login to your OVHcloud account to create API credentials
+* [ovhcloud logout](ovhcloud_logout.md)	 - Revoke your API credentials and remove them from the configuration
 * [ovhcloud nutanix](ovhcloud_nutanix.md)	 - Retrieve information and manage your Nutanix services
 * [ovhcloud okms](ovhcloud_okms.md)	 - Retrieve information and manage your OKMS (Key Management Services)
 * [ovhcloud overthebox](ovhcloud_overthebox.md)	 - Retrieve information and manage your OverTheBox services
@@ -113,6 +60,7 @@ Below is the full list of primary sub‑commands available at the time of writin
 * [ovhcloud storage-netapp](ovhcloud_storage-netapp.md)	 - Retrieve information and manage your Storage NetApp services
 * [ovhcloud support-tickets](ovhcloud_support-tickets.md)	 - Retrieve information and manage your support tickets
 * [ovhcloud telephony](ovhcloud_telephony.md)	 - Retrieve information and manage your Telephony services
+* [ovhcloud upgrade](ovhcloud_upgrade.md)	 - Upgrade OVHcloud CLI to the latest version
 * [ovhcloud veeamcloudconnect](ovhcloud_veeamcloudconnect.md)	 - Retrieve information and manage your VeeamCloudConnect services
 * [ovhcloud veeamenterprise](ovhcloud_veeamenterprise.md)	 - Retrieve information and manage your VeeamEnterprise services
 * [ovhcloud version](ovhcloud_version.md)	 - Get OVHcloud CLI version
@@ -124,30 +72,3 @@ Below is the full list of primary sub‑commands available at the time of writin
 * [ovhcloud webhosting](ovhcloud_webhosting.md)	 - Retrieve information and manage your WebHosting services
 * [ovhcloud xdsl](ovhcloud_xdsl.md)	 - Retrieve information and manage your XDSL services
 
-> **Tip**  Use `-o json`, `-o yaml`, or `-o <format>` with a gval expression to integrate `ovhcloud` into scripts and automation pipelines.
-
----
-
-## Examples
-
-| Task                                  | Command                                        |
-| ------------------------------------- | ---------------------------------------------- |
-| Log in and save credentials           | `ovhcloud login`                                |
-| List VPS instances (tabular)          | `ovhcloud vps list`                             |
-| Fetch details of a single VPS in JSON | `ovhcloud vps get <service_id> -o json`          |
-| Reinstall a baremetal interactively   | `ovhcloud baremetal reinstall <id> --editor`    |
-
----
-
-## Troubleshooting
-
-* **Verbose output** — Use `--debug` to inspect raw API calls and responses.
-* **Authentication issues** — Run `ovhcloud login` again to regenerate valid API keys.
-* **Rate limits** — OVHcloud APIs impose rate limits; plan retries or exponential backoff in scripts.
-
----
-
-## Further Reading
-
-* OVHcloud API reference: [https://eu.api.ovh.com/console](https://eu.api.ovh.com/console)
-* OVHcloud community guides and tutorials.

--- a/doc/ovhcloud_baremetal_reboot-rescue.md
+++ b/doc/ovhcloud_baremetal_reboot-rescue.md
@@ -9,8 +9,10 @@ ovhcloud baremetal reboot-rescue <service_name> [flags]
 ### Options
 
 ```
-  -h, --help   help for reboot-rescue
-      --wait   Wait for reboot to be done before exiting
+      --dry-run   Print the call that would be made without making it
+  -h, --help      help for reboot-rescue
+      --wait      Wait for reboot to be done before exiting
+  -y, --yes       Skip the confirmation prompt (required for unattended runs)
 ```
 
 ### Options inherited from parent commands

--- a/doc/ovhcloud_baremetal_reboot.md
+++ b/doc/ovhcloud_baremetal_reboot.md
@@ -9,7 +9,9 @@ ovhcloud baremetal reboot <service_name> [flags]
 ### Options
 
 ```
-  -h, --help   help for reboot
+      --dry-run   Print the call that would be made without making it
+  -h, --help      help for reboot
+  -y, --yes       Skip the confirmation prompt (required for unattended runs)
 ```
 
 ### Options inherited from parent commands

--- a/doc/ovhcloud_baremetal_reinstall.md
+++ b/doc/ovhcloud_baremetal_reinstall.md
@@ -46,6 +46,11 @@ to see all the available parameters and real life examples.
 
 Please note that all parameters are not compatible with all OSes.
 
+Reinstalling wipes every disk of the server, so the command asks for a
+confirmation: type the server name when prompted. Unattended runs (pipelines,
+piped input) must pass --yes, and --dry-run prints the parameters that would
+be sent without sending them.
+
 
 ```
 ovhcloud baremetal reinstall <service_name> [flags]
@@ -55,6 +60,7 @@ ovhcloud baremetal reinstall <service_name> [flags]
 
 ```
       --config-drive-user-data string               Config Drive UserData
+      --dry-run                                     Print the installation parameters without sending anything
       --editor                                      Use a text editor to define parameters
       --efi-bootloader-path string                  Path of the EFI bootloader from the OS installed on the server
       --from-file string                            File containing parameters
@@ -73,6 +79,7 @@ ovhcloud baremetal reinstall <service_name> [flags]
       --replace                                     Replace parameters file if it already exists
       --ssh-key string                              SSH public key
       --wait                                        Wait for reinstall to be done before exiting
+  -y, --yes                                         Skip the confirmation prompt (required for unattended runs)
 ```
 
 ### Options inherited from parent commands

--- a/doc/ovhcloud_baremetal_reinstall.md
+++ b/doc/ovhcloud_baremetal_reinstall.md
@@ -24,7 +24,10 @@ There are three ways to define the installation parameters:
 
   Note that you can also pipe the content of the file to reinstall, like the following:
 
-	cat ./install.json | ovhcloud baremetal reinstall ns1234.ip-11.22.33.net
+	cat ./install.json | ovhcloud baremetal reinstall ns1234.ip-11.22.33.net --yes
+
+  Piped input is not a terminal, so there is nobody to answer the confirmation:
+  such a run refuses to start unless --yes is given.
 
   In both cases, you can override the parameters in the given file using command line flags, for example:
 

--- a/doc/ovhcloud_baremetal_vni_ola-reset.md
+++ b/doc/ovhcloud_baremetal_vni_ola-reset.md
@@ -9,8 +9,10 @@ ovhcloud baremetal vni ola-reset <service_name> --interface <uuid> --interface <
 ### Options
 
 ```
+      --dry-run                 Print the call that would be made without making it
   -h, --help                    help for ola-reset
       --interface stringArray   Interfaces to group
+  -y, --yes                     Skip the confirmation prompt (required for unattended runs)
 ```
 
 ### Options inherited from parent commands

--- a/doc/ovhcloud_logout.md
+++ b/doc/ovhcloud_logout.md
@@ -1,0 +1,46 @@
+## ovhcloud logout
+
+Revoke your API credentials and remove them from the configuration
+
+```
+ovhcloud logout [flags]
+```
+
+### Examples
+
+```
+ovhcloud logout
+ovhcloud logout --yes
+ovhcloud logout --profile work
+```
+
+### Options
+
+```
+  -h, --help   help for logout
+  -y, --yes    Do not ask for confirmation
+```
+
+### Options inherited from parent commands
+
+```
+  -d, --debug            Activate debug mode (will log all HTTP requests details)
+  -e, --ignore-errors    Ignore errors in API calls when it is not fatal to the execution
+  -o, --output string    Output format: json, yaml, interactive, or a custom format expression (using https://github.com/PaesslerAG/gval syntax)
+                         Examples:
+                           --output json
+                           --output yaml
+                           --output interactive
+                           --output 'id' (to extract a single field)
+                           --output 'nested.field.subfield' (to extract a nested field)
+                           --output '[id, "name"]' (to extract multiple fields as an array)
+                           --output '{"newKey": oldKey, "otherKey": nested.field}' (to extract and rename fields in an object)
+                           --output 'name+","+type' (to extract and concatenate fields in a string)
+                           --output '(nbFieldA + nbFieldB) * 10' (to compute values from numeric fields)
+      --profile string   Use a specific profile from the configuration file
+```
+
+### SEE ALSO
+
+* [ovhcloud](ovhcloud.md)	 - CLI to manage your OVHcloud services
+

--- a/internal/cmd/baremetal.go
+++ b/internal/cmd/baremetal.go
@@ -74,6 +74,7 @@ func init() {
 		ValidArgsFunction: completion.ServiceList("/v1/dedicated/server"),
 		Run:               baremetal.RebootBaremetal,
 	}
+	addConfirmationFlags(baremetalRebootCmd, "Print the call that would be made without making it")
 	baremetalCmd.AddCommand(baremetalRebootCmd)
 
 	// Command to reboot a baremetal in rescue mode
@@ -85,6 +86,7 @@ func init() {
 		Run:               baremetal.RebootRescueBaremetal,
 	}
 	baremetalRebootRescueCmd.Flags().BoolVar(&flags.WaitForTask, "wait", false, "Wait for reboot to be done before exiting")
+	addConfirmationFlags(baremetalRebootRescueCmd, "Print the call that would be made without making it")
 	baremetalCmd.AddCommand(baremetalRebootRescueCmd)
 
 	// Command to reinstall a baremetal
@@ -163,9 +165,7 @@ be sent without sending them.
 	reinstallBaremetalCmd.Flags().StringVar(&baremetal.Customizations.PostInstallationScriptExtension, "post-installation-script-extension", "", "Post-installation script extension (cmd, ps1)")
 	reinstallBaremetalCmd.Flags().StringVar(&baremetal.Customizations.SshKey, "ssh-key", "", "SSH public key")
 	reinstallBaremetalCmd.Flags().BoolVar(&flags.WaitForTask, "wait", false, "Wait for reinstall to be done before exiting")
-	reinstallBaremetalCmd.Flags().BoolVarP(&flags.AssumeYes, "yes", "y", false, "Skip the confirmation prompt (required for unattended runs)")
-	reinstallBaremetalCmd.Flags().BoolVar(&flags.DryRun, "dry-run", false, "Print the installation parameters without sending anything")
-	markFlagsMutuallyExclusive(reinstallBaremetalCmd, "yes", "dry-run")
+	addConfirmationFlags(reinstallBaremetalCmd, "Print the installation parameters without sending anything")
 	markFlagsMutuallyExclusive(reinstallBaremetalCmd, "from-file", "editor")
 	baremetalCmd.AddCommand(reinstallBaremetalCmd)
 
@@ -274,6 +274,7 @@ be sent without sending them.
 	}
 	baremetalVNIResetOLAAggregationCmd.Flags().StringArrayVar(&baremetal.BaremetalOLAInterfaces, "interface", nil, "Interfaces to group")
 	baremetalVNIResetOLAAggregationCmd.MarkFlagRequired("interface")
+	addConfirmationFlags(baremetalVNIResetOLAAggregationCmd, "Print the call that would be made without making it")
 	baremetalVNICmd.AddCommand(baremetalVNIResetOLAAggregationCmd)
 
 	baremetalIPMICmd := &cobra.Command{

--- a/internal/cmd/baremetal.go
+++ b/internal/cmd/baremetal.go
@@ -132,6 +132,11 @@ You can visit https://eu.api.ovh.com/console/?section=%2Fdedicated%2Fserver&bran
 to see all the available parameters and real life examples.
 
 Please note that all parameters are not compatible with all OSes.
+
+Reinstalling wipes every disk of the server, so the command asks for a
+confirmation: type the server name when prompted. Unattended runs (pipelines,
+piped input) must pass --yes, and --dry-run prints the parameters that would
+be sent without sending them.
 `,
 		Args:              cobra.MaximumNArgs(1),
 		ArgAliases:        []string{"service_name"},
@@ -155,6 +160,9 @@ Please note that all parameters are not compatible with all OSes.
 	reinstallBaremetalCmd.Flags().StringVar(&baremetal.Customizations.PostInstallationScriptExtension, "post-installation-script-extension", "", "Post-installation script extension (cmd, ps1)")
 	reinstallBaremetalCmd.Flags().StringVar(&baremetal.Customizations.SshKey, "ssh-key", "", "SSH public key")
 	reinstallBaremetalCmd.Flags().BoolVar(&flags.WaitForTask, "wait", false, "Wait for reinstall to be done before exiting")
+	reinstallBaremetalCmd.Flags().BoolVarP(&flags.AssumeYes, "yes", "y", false, "Skip the confirmation prompt (required for unattended runs)")
+	reinstallBaremetalCmd.Flags().BoolVar(&flags.DryRun, "dry-run", false, "Print the installation parameters without sending anything")
+	markFlagsMutuallyExclusive(reinstallBaremetalCmd, "yes", "dry-run")
 	markFlagsMutuallyExclusive(reinstallBaremetalCmd, "from-file", "editor")
 	baremetalCmd.AddCommand(reinstallBaremetalCmd)
 

--- a/internal/cmd/baremetal.go
+++ b/internal/cmd/baremetal.go
@@ -111,7 +111,10 @@ There are three ways to define the installation parameters:
 
   Note that you can also pipe the content of the file to reinstall, like the following:
 
-	cat ./install.json | ovhcloud baremetal reinstall ns1234.ip-11.22.33.net
+	cat ./install.json | ovhcloud baremetal reinstall ns1234.ip-11.22.33.net --yes
+
+  Piped input is not a terminal, so there is nobody to answer the confirmation:
+  such a run refuses to start unless --yes is given.
 
   In both cases, you can override the parameters in the given file using command line flags, for example:
 

--- a/internal/cmd/baremetal_test.go
+++ b/internal/cmd/baremetal_test.go
@@ -166,3 +166,71 @@ func (ms *MockSuite) TestBaremetalReinstallDryRun(assert, require *td.T) {
 	assert.Cmp(httpmock.GetCallCountInfo()["POST https://eu.api.ovh.com/v1/dedicated/server/fakeBaremetal/reinstall"], 0,
 		"no reinstall call must reach the API")
 }
+
+// The point of the guardrail: an unattended run that did not say --yes must not
+// interrupt a production server, and must not reach the API at all.
+func (ms *MockSuite) TestBaremetalRebootRefusesWithoutConsent(assert, require *td.T) {
+	httpmock.RegisterResponder("POST", "https://eu.api.ovh.com/v1/dedicated/server/fakeBaremetal/reboot",
+		httpmock.NewStringResponder(200, `{}`),
+	)
+
+	_, err := cmd.Execute("baremetal", "reboot", "fakeBaremetal")
+
+	require.CmpError(err)
+	assert.Cmp(err.Error(), td.Contains("cancelled"))
+	assert.Cmp(httpmock.GetTotalCallCount(), 0, "nothing must reach the API without a confirmation")
+}
+
+// --yes is how a pipeline states its intent, and it must be enough.
+func (ms *MockSuite) TestBaremetalRebootProceedsWithYes(assert, require *td.T) {
+	httpmock.RegisterResponder("POST", "https://eu.api.ovh.com/v1/dedicated/server/fakeBaremetal/reboot",
+		httpmock.NewStringResponder(200, `{}`),
+	)
+
+	_, err := cmd.Execute("baremetal", "reboot", "fakeBaremetal", "--yes")
+
+	require.CmpNoError(err)
+	assert.Cmp(httpmock.GetCallCountInfo()["POST https://eu.api.ovh.com/v1/dedicated/server/fakeBaremetal/reboot"], 1)
+}
+
+// --dry-run shows the call and makes none, so it must never need a confirmation
+// of its own: refusing to describe what it will not do would be absurd.
+func (ms *MockSuite) TestBaremetalRebootDryRunSendsNothing(assert, require *td.T) {
+	httpmock.RegisterResponder("POST", "https://eu.api.ovh.com/v1/dedicated/server/fakeBaremetal/reboot",
+		httpmock.NewStringResponder(200, `{}`),
+	)
+
+	out, err := cmd.Execute("baremetal", "reboot", "fakeBaremetal", "--dry-run")
+
+	require.CmpNoError(err)
+	assert.Cmp(out, td.Contains("POST /v1/dedicated/server/fakeBaremetal/reboot"))
+	assert.Cmp(httpmock.GetTotalCallCount(), 0, "a dry run must send nothing")
+}
+
+// reboot-rescue leaves the server in rescue until somebody sets the boot back,
+// so it is guarded like the reboot it performs.
+func (ms *MockSuite) TestBaremetalRebootRescueRefusesWithoutConsent(assert, require *td.T) {
+	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/v1/dedicated/server/fakeBaremetal/boot?bootType=rescue",
+		httpmock.NewStringResponder(200, `[1122]`),
+	)
+
+	_, err := cmd.Execute("baremetal", "reboot-rescue", "fakeBaremetal")
+
+	require.CmpError(err)
+	assert.Cmp(err.Error(), td.Contains("cancelled"))
+	assert.Cmp(httpmock.GetTotalCallCount(), 0, "not even the boot lookup must happen")
+}
+
+// Resetting an aggregation takes the interfaces down; on a server reached over
+// that link the operator is cutting the branch they sit on.
+func (ms *MockSuite) TestBaremetalOlaResetRefusesWithoutConsent(assert, require *td.T) {
+	httpmock.RegisterResponder("POST", "https://eu.api.ovh.com/v1/dedicated/server/fakeBaremetal/ola/reset",
+		httpmock.NewStringResponder(200, `{}`),
+	)
+
+	_, err := cmd.Execute("baremetal", "vni", "ola-reset", "fakeBaremetal", "--interface", "uuid-1")
+
+	require.CmpError(err)
+	assert.Cmp(err.Error(), td.Contains("cancelled"))
+	assert.Cmp(httpmock.GetTotalCallCount(), 0, "no interface must be reset without a confirmation")
+}

--- a/internal/cmd/baremetal_test.go
+++ b/internal/cmd/baremetal_test.go
@@ -57,6 +57,9 @@ func (ms *MockSuite) TestBaremetalListCompatibleOSCmd(assert, require *td.T) {
 }
 
 // registerReinstallTask wires a reinstall whose task ends in the given state.
+//
+// These tests pass --yes: they are about what the CLI says when a task fails,
+// not about the confirmation, and without it the reinstall never starts.
 func registerReinstallTask(task string) {
 	httpmock.RegisterResponder("POST", "https://eu.api.ovh.com/v1/dedicated/server/fakeBaremetal/reinstall",
 		httpmock.NewStringResponder(200, `{"taskId": 156839472}`),
@@ -72,7 +75,7 @@ func (ms *MockSuite) TestBaremetalReinstallReportsTheFailureReason(assert, requi
 	registerReinstallTask(`{"taskId": 156839472, "function": "reinstallServer",
 		"status": "customerError", "comment": "partitioning scheme incompatible with this hardware"}`)
 
-	_, err := cmd.Execute("baremetal", "reinstall", "fakeBaremetal", "--os", "debian12_64", "--wait")
+	_, err := cmd.Execute("baremetal", "reinstall", "fakeBaremetal", "--os", "debian12_64", "--wait", "--yes")
 
 	require.CmpError(err)
 	assert.Cmp(err.Error(), td.Contains("customerError"), "the real status is named")
@@ -86,7 +89,7 @@ func (ms *MockSuite) TestBaremetalReinstallReportsTheFailureReason(assert, requi
 func (ms *MockSuite) TestBaremetalReinstallPrintsAReadableTaskID(assert, require *td.T) {
 	registerReinstallTask(`{"taskId": 156839472, "function": "reinstallServer", "status": "ovhError"}`)
 
-	_, err := cmd.Execute("baremetal", "reinstall", "fakeBaremetal", "--os", "debian12_64", "--wait")
+	_, err := cmd.Execute("baremetal", "reinstall", "fakeBaremetal", "--os", "debian12_64", "--wait", "--yes")
 
 	require.CmpError(err)
 	assert.Cmp(err.Error(), td.Contains("156839472"))
@@ -99,7 +102,7 @@ func (ms *MockSuite) TestBaremetalReinstallPrintsAReadableTaskID(assert, require
 func (ms *MockSuite) TestBaremetalReinstallReportsAnUnknownStatus(assert, require *td.T) {
 	registerReinstallTask(`{"taskId": 156839472, "function": "reinstallServer", "status": "quarantined"}`)
 
-	_, err := cmd.Execute("baremetal", "reinstall", "fakeBaremetal", "--os", "debian12_64", "--wait")
+	_, err := cmd.Execute("baremetal", "reinstall", "fakeBaremetal", "--os", "debian12_64", "--wait", "--yes")
 
 	require.CmpError(err)
 	assert.Cmp(err.Error(), td.Contains("unexpected status quarantined"))
@@ -112,9 +115,10 @@ func (ms *MockSuite) TestBaremetalReinstallSucceedsOnDoneTask(assert, require *t
 		httpmock.NewStringResponder(200, `[]`),
 	)
 
-	_, err := cmd.Execute("baremetal", "reinstall", "fakeBaremetal", "--os", "debian12_64", "--wait")
+	_, err := cmd.Execute("baremetal", "reinstall", "fakeBaremetal", "--os", "debian12_64", "--wait", "--yes")
 
 	require.CmpNoError(err)
+}
 
 // Reinstalling wipes the disks: an unattended run must not do it silently.
 func (ms *MockSuite) TestBaremetalReinstallRefusesWithoutConfirmation(assert, require *td.T) {
@@ -152,6 +156,13 @@ func (ms *MockSuite) TestBaremetalReinstallDryRun(assert, require *td.T) {
 
 	require.CmpNoError(err)
 	assert.Cmp(out, td.Contains("Dry run"))
+	// The parameters must be in the message itself: the default output prints
+	// the message alone, so a payload living only in the structured details
+	// would leave stdout with a promise and no request.
+	assert.Cmp(out, td.Contains(`"operatingSystem": "debian12_64"`),
+		"the request that would be sent is printed")
+	assert.Cmp(out, td.Contains("/v1/dedicated/server/fakeBaremetal/reinstall"),
+		"and the endpoint it would go to")
 	assert.Cmp(httpmock.GetCallCountInfo()["POST https://eu.api.ovh.com/v1/dedicated/server/fakeBaremetal/reinstall"], 0,
 		"no reinstall call must reach the API")
 }

--- a/internal/cmd/baremetal_test.go
+++ b/internal/cmd/baremetal_test.go
@@ -115,4 +115,43 @@ func (ms *MockSuite) TestBaremetalReinstallSucceedsOnDoneTask(assert, require *t
 	_, err := cmd.Execute("baremetal", "reinstall", "fakeBaremetal", "--os", "debian12_64", "--wait")
 
 	require.CmpNoError(err)
+
+// Reinstalling wipes the disks: an unattended run must not do it silently.
+func (ms *MockSuite) TestBaremetalReinstallRefusesWithoutConfirmation(assert, require *td.T) {
+	httpmock.RegisterResponder("POST", "https://eu.api.ovh.com/v1/dedicated/server/fakeBaremetal/reinstall",
+		httpmock.NewStringResponder(200, `{"taskId": 123}`),
+	)
+
+	_, err := cmd.Execute("baremetal", "reinstall", "fakeBaremetal", "--os", "debian12_64")
+
+	require.CmpError(err)
+	assert.Cmp(err.Error(), td.Contains("cancelled"))
+	assert.Cmp(httpmock.GetCallCountInfo()["POST https://eu.api.ovh.com/v1/dedicated/server/fakeBaremetal/reinstall"], 0,
+		"no reinstall call must reach the API")
+}
+
+func (ms *MockSuite) TestBaremetalReinstallProceedsWithYes(assert, require *td.T) {
+	httpmock.RegisterResponder("POST", "https://eu.api.ovh.com/v1/dedicated/server/fakeBaremetal/reinstall",
+		httpmock.NewStringResponder(200, `{"taskId": 123}`),
+	)
+
+	out, err := cmd.Execute("baremetal", "reinstall", "fakeBaremetal", "--os", "debian12_64", "--yes")
+
+	require.CmpNoError(err)
+	assert.Cmp(out, td.Contains("Reinstallation is started"))
+	assert.Cmp(httpmock.GetCallCountInfo()["POST https://eu.api.ovh.com/v1/dedicated/server/fakeBaremetal/reinstall"], 1)
+}
+
+// --dry-run shows what would be sent and sends nothing.
+func (ms *MockSuite) TestBaremetalReinstallDryRun(assert, require *td.T) {
+	httpmock.RegisterResponder("POST", "https://eu.api.ovh.com/v1/dedicated/server/fakeBaremetal/reinstall",
+		httpmock.NewStringResponder(200, `{"taskId": 123}`),
+	)
+
+	out, err := cmd.Execute("baremetal", "reinstall", "fakeBaremetal", "--os", "debian12_64", "--dry-run")
+
+	require.CmpNoError(err)
+	assert.Cmp(out, td.Contains("Dry run"))
+	assert.Cmp(httpmock.GetCallCountInfo()["POST https://eu.api.ovh.com/v1/dedicated/server/fakeBaremetal/reinstall"], 0,
+		"no reinstall call must reach the API")
 }

--- a/internal/cmd/baremetal_test.go
+++ b/internal/cmd/baremetal_test.go
@@ -207,6 +207,51 @@ func (ms *MockSuite) TestBaremetalRebootDryRunSendsNothing(assert, require *td.T
 	assert.Cmp(httpmock.GetTotalCallCount(), 0, "a dry run must send nothing")
 }
 
+// reboot-rescue is three calls, and the middle one — writing the rescue boot to
+// the server — is the change that outlives the reboot. A preview showing the
+// reboot alone would hide exactly what the operator needs to weigh.
+func (ms *MockSuite) TestBaremetalRebootRescueDryRunShowsTheBootChange(assert, require *td.T) {
+	out, err := cmd.Execute("baremetal", "reboot-rescue", "fakeBaremetal", "--dry-run")
+
+	require.CmpNoError(err)
+	assert.Cmp(out, td.Contains("GET /v1/dedicated/server/fakeBaremetal/boot?bootType=rescue"))
+	assert.Cmp(out, td.Contains("PUT /v1/dedicated/server/fakeBaremetal"), "the boot write must be announced")
+	assert.Cmp(out, td.Contains("POST /v1/dedicated/server/fakeBaremetal/reboot"))
+	assert.Cmp(httpmock.GetTotalCallCount(), 0, "a dry run must send nothing")
+}
+
+// One call per interface: the preview must list them rather than imply a single
+// request.
+func (ms *MockSuite) TestBaremetalOlaResetDryRunListsEveryInterface(assert, require *td.T) {
+	out, err := cmd.Execute("baremetal", "vni", "ola-reset", "fakeBaremetal",
+		"--interface", "uuid-1", "--interface", "uuid-2", "--dry-run")
+
+	require.CmpNoError(err)
+	assert.Cmp(out, td.Contains("uuid-1"))
+	assert.Cmp(out, td.Contains("uuid-2"))
+	assert.Cmp(httpmock.GetTotalCallCount(), 0, "a dry run must send nothing")
+}
+
+// --yes belongs to the command it was typed on. If it survived into the next
+// command of the same process — the WASM build runs several — a confirmation
+// would be skipped that nobody granted.
+func (ms *MockSuite) TestBaremetalYesDoesNotSurviveIntoTheNextCommand(assert, require *td.T) {
+	httpmock.RegisterResponder("POST", "https://eu.api.ovh.com/v1/dedicated/server/fakeBaremetal/reboot",
+		httpmock.NewStringResponder(200, `{}`),
+	)
+
+	_, err := cmd.Execute("baremetal", "reboot", "fakeBaremetal", "--yes")
+	require.CmpNoError(err)
+
+	cmd.PostExecute()
+
+	_, err = cmd.Execute("baremetal", "reboot", "fakeBaremetal")
+	require.CmpError(err)
+	assert.Cmp(err.Error(), td.Contains("cancelled"), "the second command must ask again")
+	assert.Cmp(httpmock.GetCallCountInfo()["POST https://eu.api.ovh.com/v1/dedicated/server/fakeBaremetal/reboot"], 1,
+		"only the consented reboot must have happened")
+}
+
 // reboot-rescue leaves the server in rescue until somebody sets the boot back,
 // so it is guarded like the reboot it performs.
 func (ms *MockSuite) TestBaremetalRebootRescueRefusesWithoutConsent(assert, require *td.T) {

--- a/internal/cmd/baremetal_test.go
+++ b/internal/cmd/baremetal_test.go
@@ -279,3 +279,20 @@ func (ms *MockSuite) TestBaremetalOlaResetRefusesWithoutConsent(assert, require 
 	assert.Cmp(err.Error(), td.Contains("cancelled"))
 	assert.Cmp(httpmock.GetTotalCallCount(), 0, "no interface must be reset without a confirmation")
 }
+
+// Une prevision qui tait la garde cache exactement ce qu on lui demande de
+// montrer. `ip change-org` en est le cas extreme : ce qu il y a a juger est la
+// phrase qui annonce que l adresse quitte le compte, et elle ne s affichait
+// nulle part -- un dry-run ne pose pas de question.
+func (ms *MockSuite) TestDryRunShowsTheConfirmationItSkipped(assert, require *td.T) {
+	httpmock.RegisterResponder("POST", "https://eu.api.ovh.com/v1/dedicated/server/fakeBaremetal/reboot",
+		httpmock.NewStringResponder(200, `{}`),
+	)
+
+	out, err := cmd.Execute("baremetal", "reboot", "fakeBaremetal", "--dry-run")
+
+	require.CmpNoError(err)
+	assert.Cmp(out, td.Contains("would have asked first"), "la garde est citee")
+	assert.Cmp(out, td.Contains("interrupts"), "avec ses propres mots")
+	assert.Cmp(httpmock.GetTotalCallCount(), 0, "et rien n est envoye")
+}

--- a/internal/cmd/baremetal_test.go
+++ b/internal/cmd/baremetal_test.go
@@ -5,9 +5,6 @@
 package cmd_test
 
 import (
-	"bytes"
-	"log"
-
 	"github.com/jarcoal/httpmock"
 	"github.com/maxatome/go-testdeep/td"
 	"github.com/ovh/ovhcloud-cli/internal/cmd"
@@ -168,51 +165,4 @@ func (ms *MockSuite) TestBaremetalReinstallDryRun(assert, require *td.T) {
 		"and the endpoint it would go to")
 	assert.Cmp(httpmock.GetCallCountInfo()["POST https://eu.api.ovh.com/v1/dedicated/server/fakeBaremetal/reinstall"], 0,
 		"no reinstall call must reach the API")
-}
-
-// A dry run prints the payload once. It used to print it twice: the message
-// carries it, and a log.Println just above the --dry-run branch repeated the
-// same JSON behind a Go timestamp no other command in this CLI emits.
-//
-//	🔍 Dry run: nothing was sent. This would have been posted to …
-//	{ "operatingSystem": "debian12_64" }
-//	2026/08/23 23:47:22 Final parameters:
-//	{ "operatingSystem": "debian12_64" }
-//
-// The log line goes to stderr, so no assertion on stdout could ever have seen
-// it — which is why it survived every green run. This one redirects the logger.
-func (ms *MockSuite) TestBaremetalReinstallDryRunDoesNotLogTheParametersTwice(assert, require *td.T) {
-	httpmock.RegisterResponder("POST", "https://eu.api.ovh.com/v1/dedicated/server/fakeBaremetal/reinstall",
-		httpmock.NewStringResponder(200, `{"taskId": 123}`),
-	)
-	var logged bytes.Buffer
-	previous := log.Writer()
-	log.SetOutput(&logged)
-	defer log.SetOutput(previous)
-
-	out, err := cmd.Execute("baremetal", "reinstall", "fakeBaremetal", "--os", "debian12_64", "--dry-run")
-
-	require.CmpNoError(err)
-	assert.Cmp(out, td.Contains(`"operatingSystem": "debian12_64"`),
-		"the payload is still printed, once, as the message")
-	assert.Cmp(logged.String(), td.Not(td.Contains("Final parameters")),
-		"a dry run logs nothing: it sends nothing")
-}
-
-// The positive control of the test above: a REAL run still logs what it is
-// about to send. Without it, deleting the log line altogether would pass.
-func (ms *MockSuite) TestBaremetalReinstallStillLogsTheParametersItSends(assert, require *td.T) {
-	httpmock.RegisterResponder("POST", "https://eu.api.ovh.com/v1/dedicated/server/fakeBaremetal/reinstall",
-		httpmock.NewStringResponder(200, `{"taskId": 123}`),
-	)
-	var logged bytes.Buffer
-	previous := log.Writer()
-	log.SetOutput(&logged)
-	defer log.SetOutput(previous)
-
-	_, err := cmd.Execute("baremetal", "reinstall", "fakeBaremetal", "--os", "debian12_64", "--yes")
-
-	require.CmpNoError(err)
-	assert.Cmp(logged.String(), td.Contains("Final parameters"))
-	assert.Cmp(logged.String(), td.Contains(`"operatingSystem": "debian12_64"`))
 }

--- a/internal/cmd/baremetal_test.go
+++ b/internal/cmd/baremetal_test.go
@@ -5,6 +5,9 @@
 package cmd_test
 
 import (
+	"bytes"
+	"log"
+
 	"github.com/jarcoal/httpmock"
 	"github.com/maxatome/go-testdeep/td"
 	"github.com/ovh/ovhcloud-cli/internal/cmd"
@@ -165,4 +168,51 @@ func (ms *MockSuite) TestBaremetalReinstallDryRun(assert, require *td.T) {
 		"and the endpoint it would go to")
 	assert.Cmp(httpmock.GetCallCountInfo()["POST https://eu.api.ovh.com/v1/dedicated/server/fakeBaremetal/reinstall"], 0,
 		"no reinstall call must reach the API")
+}
+
+// A dry run prints the payload once. It used to print it twice: the message
+// carries it, and a log.Println just above the --dry-run branch repeated the
+// same JSON behind a Go timestamp no other command in this CLI emits.
+//
+//	🔍 Dry run: nothing was sent. This would have been posted to …
+//	{ "operatingSystem": "debian12_64" }
+//	2026/08/23 23:47:22 Final parameters:
+//	{ "operatingSystem": "debian12_64" }
+//
+// The log line goes to stderr, so no assertion on stdout could ever have seen
+// it — which is why it survived every green run. This one redirects the logger.
+func (ms *MockSuite) TestBaremetalReinstallDryRunDoesNotLogTheParametersTwice(assert, require *td.T) {
+	httpmock.RegisterResponder("POST", "https://eu.api.ovh.com/v1/dedicated/server/fakeBaremetal/reinstall",
+		httpmock.NewStringResponder(200, `{"taskId": 123}`),
+	)
+	var logged bytes.Buffer
+	previous := log.Writer()
+	log.SetOutput(&logged)
+	defer log.SetOutput(previous)
+
+	out, err := cmd.Execute("baremetal", "reinstall", "fakeBaremetal", "--os", "debian12_64", "--dry-run")
+
+	require.CmpNoError(err)
+	assert.Cmp(out, td.Contains(`"operatingSystem": "debian12_64"`),
+		"the payload is still printed, once, as the message")
+	assert.Cmp(logged.String(), td.Not(td.Contains("Final parameters")),
+		"a dry run logs nothing: it sends nothing")
+}
+
+// The positive control of the test above: a REAL run still logs what it is
+// about to send. Without it, deleting the log line altogether would pass.
+func (ms *MockSuite) TestBaremetalReinstallStillLogsTheParametersItSends(assert, require *td.T) {
+	httpmock.RegisterResponder("POST", "https://eu.api.ovh.com/v1/dedicated/server/fakeBaremetal/reinstall",
+		httpmock.NewStringResponder(200, `{"taskId": 123}`),
+	)
+	var logged bytes.Buffer
+	previous := log.Writer()
+	log.SetOutput(&logged)
+	defer log.SetOutput(previous)
+
+	_, err := cmd.Execute("baremetal", "reinstall", "fakeBaremetal", "--os", "debian12_64", "--yes")
+
+	require.CmpNoError(err)
+	assert.Cmp(logged.String(), td.Contains("Final parameters"))
+	assert.Cmp(logged.String(), td.Contains(`"operatingSystem": "debian12_64"`))
 }

--- a/internal/cmd/dry_run_log_test.go
+++ b/internal/cmd/dry_run_log_test.go
@@ -1,0 +1,68 @@
+// SPDX-FileCopyrightText: 2025 OVH SAS <opensource@ovh.net>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Ces deux tests vivent dans leur propre fichier, et non dans
+// baremetal_test.go, pour une raison mecanique : 23 branches en aval ajoutent
+// elles aussi des tests juste apres TestBaremetalReinstallDryRun et dans le
+// meme bloc d'imports. Les y placer a fait echouer les 23 merges d'un coup, sur
+// une adjacence et non sur un desaccord. Un fichier neuf ne peut entrer en
+// collision qu'avec un fichier de meme nom.
+
+package cmd_test
+
+import (
+	"bytes"
+	"log"
+
+	"github.com/jarcoal/httpmock"
+	"github.com/maxatome/go-testdeep/td"
+	"github.com/ovh/ovhcloud-cli/internal/cmd"
+)
+
+// A dry run prints the payload once. It used to print it twice: the message
+// carries it, and a log.Println just above the --dry-run branch repeated the
+// same JSON behind a Go timestamp no other command in this CLI emits.
+//
+//	🔍 Dry run: nothing was sent. This would have been posted to …
+//	{ "operatingSystem": "debian12_64" }
+//	2026/08/23 23:47:22 Final parameters:
+//	{ "operatingSystem": "debian12_64" }
+//
+// The log line goes to stderr, so no assertion on stdout could ever have seen
+// it — which is why it survived every green run. This one redirects the logger.
+func (ms *MockSuite) TestBaremetalReinstallDryRunDoesNotLogTheParametersTwice(assert, require *td.T) {
+	httpmock.RegisterResponder("POST", "https://eu.api.ovh.com/v1/dedicated/server/fakeBaremetal/reinstall",
+		httpmock.NewStringResponder(200, `{"taskId": 123}`),
+	)
+	var logged bytes.Buffer
+	previous := log.Writer()
+	log.SetOutput(&logged)
+	defer log.SetOutput(previous)
+
+	out, err := cmd.Execute("baremetal", "reinstall", "fakeBaremetal", "--os", "debian12_64", "--dry-run")
+
+	require.CmpNoError(err)
+	assert.Cmp(out, td.Contains(`"operatingSystem": "debian12_64"`),
+		"the payload is still printed, once, as the message")
+	assert.Cmp(logged.String(), td.Not(td.Contains("Final parameters")),
+		"a dry run logs nothing: it sends nothing")
+}
+
+// The positive control of the test above: a REAL run still logs what it is
+// about to send. Without it, deleting the log line altogether would pass.
+func (ms *MockSuite) TestBaremetalReinstallStillLogsTheParametersItSends(assert, require *td.T) {
+	httpmock.RegisterResponder("POST", "https://eu.api.ovh.com/v1/dedicated/server/fakeBaremetal/reinstall",
+		httpmock.NewStringResponder(200, `{"taskId": 123}`),
+	)
+	var logged bytes.Buffer
+	previous := log.Writer()
+	log.SetOutput(&logged)
+	defer log.SetOutput(previous)
+
+	_, err := cmd.Execute("baremetal", "reinstall", "fakeBaremetal", "--os", "debian12_64", "--yes")
+
+	require.CmpNoError(err)
+	assert.Cmp(logged.String(), td.Contains("Final parameters"))
+	assert.Cmp(logged.String(), td.Contains(`"operatingSystem": "debian12_64"`))
+}

--- a/internal/cmd/parameter.go
+++ b/internal/cmd/parameter.go
@@ -285,3 +285,16 @@ There are three ways to define the creation parameters:
 
 	return createCmd
 }
+
+// addConfirmationFlags gives a command the pair every guarded action needs:
+// --yes to state the intent up front, --dry-run to see the call without making
+// it. They are mutually exclusive because asking to skip a confirmation for
+// something that will not happen means one of the two was a mistake.
+//
+// preview describes what --dry-run will show, since it differs between a
+// command that has a request body to print and one that only has a path.
+func addConfirmationFlags(cmd *cobra.Command, preview string) {
+	cmd.Flags().BoolVarP(&flags.AssumeYes, "yes", "y", false, "Skip the confirmation prompt (required for unattended runs)")
+	cmd.Flags().BoolVar(&flags.DryRun, "dry-run", false, preview)
+	markFlagsMutuallyExclusive(cmd, "yes", "dry-run")
+}

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -39,4 +39,10 @@ var (
 
 	// Flag to indicate whether the command should use a file for input parameters
 	ParametersFile string
+
+	// Flag used by destructive commands to skip the interactive confirmation
+	AssumeYes bool
+
+	// Flag used to display what would be sent to the API without sending it
+	DryRun bool
 )

--- a/internal/services/baremetal/baremetal.go
+++ b/internal/services/baremetal/baremetal.go
@@ -23,7 +23,6 @@ import (
 	"github.com/ovh/ovhcloud-cli/internal/flags"
 	httpLib "github.com/ovh/ovhcloud-cli/internal/http"
 	"github.com/ovh/ovhcloud-cli/internal/services/common"
-	"github.com/ovh/ovhcloud-cli/internal/utils"
 	"github.com/spf13/cobra"
 )
 
@@ -142,6 +141,16 @@ func EditBaremetal(cmd *cobra.Command, args []string) {
 func RebootBaremetal(_ *cobra.Command, args []string) {
 	url := fmt.Sprintf("/v1/dedicated/server/%s/reboot", url.PathEscape(args[0]))
 
+	if !common.ConfirmAction(common.Disruptive, args[0],
+		fmt.Sprintf("Rebooting %s interrupts everything running on it.", args[0])) {
+		display.OutputError(&flags.OutputFormatConfig, "reboot of %s cancelled", args[0])
+		return
+	}
+
+	if common.ReportDryRun("POST", url) {
+		return
+	}
+
 	if err := httpLib.Client.Post(url, nil, nil); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "error rebooting server %s: %s", args[0], err)
 		return
@@ -151,6 +160,17 @@ func RebootBaremetal(_ *cobra.Command, args []string) {
 }
 
 func RebootRescueBaremetal(cmd *cobra.Command, args []string) {
+	if !common.ConfirmAction(common.Disruptive, args[0], fmt.Sprintf(
+		"Rebooting %s into rescue mode interrupts everything running on it, and it stays in rescue until the boot is set back to disk.",
+		args[0])) {
+		display.OutputError(&flags.OutputFormatConfig, "reboot of %s into rescue mode cancelled", args[0])
+		return
+	}
+
+	if common.ReportDryRun("POST", fmt.Sprintf("/v1/dedicated/server/%s/reboot", url.PathEscape(args[0]))) {
+		return
+	}
+
 	endpoint := fmt.Sprintf("/v1/dedicated/server/%s/boot?bootType=rescue", url.PathEscape(args[0]))
 
 	var boots []int
@@ -482,6 +502,19 @@ func CreateBaremetalOLAAggregation(_ *cobra.Command, args []string) {
 func ResetBaremetalOLAAggregation(_ *cobra.Command, args []string) {
 	url := fmt.Sprintf("/v1/dedicated/server/%s/ola/reset", url.PathEscape(args[0]))
 
+	// Resetting an aggregation takes the interfaces down and back up: on a
+	// server reached over that link, the operator is cutting the branch.
+	if !common.ConfirmAction(common.Disruptive, args[0], fmt.Sprintf(
+		"Resetting %d interface(s) of %s to their default configuration interrupts the network of the server.",
+		len(BaremetalOLAInterfaces), args[0])) {
+		display.OutputError(&flags.OutputFormatConfig, "interface reset on %s cancelled", args[0])
+		return
+	}
+
+	if common.ReportDryRun("POST", url) {
+		return
+	}
+
 	for _, itf := range BaremetalOLAInterfaces {
 		if err := httpLib.Client.Post(url, map[string]string{
 			"virtualNetworkInterface": itf,
@@ -503,18 +536,16 @@ func ReinstallBaremetal(cmd *cobra.Command, args []string) {
 		return
 	}
 
-	// Reinstalling wipes every disk of the server. Nothing else in this CLI
-	// destroys customer data, so this is the one place that asks before acting.
-	if !flags.AssumeYes && !flags.DryRun {
-		warning := fmt.Sprintf("Reinstalling %s wipes every disk of the server. This cannot be undone.", args[0])
-		if OperatingSystem != "" {
-			warning += fmt.Sprintf("\n   Operating system to install: %s", OperatingSystem)
-		}
+	// Reinstalling wipes every disk of the server, so this one asks for the
+	// server's name rather than a yes.
+	warning := fmt.Sprintf("Reinstalling %s wipes every disk of the server. This cannot be undone.", args[0])
+	if OperatingSystem != "" {
+		warning += fmt.Sprintf("\n   Operating system to install: %s", OperatingSystem)
+	}
 
-		if !utils.ConfirmByName(args[0], warning) {
-			display.OutputError(&flags.OutputFormatConfig, "reinstallation of %s cancelled", args[0])
-			return
-		}
+	if !common.ConfirmAction(common.Destructive, args[0], warning) {
+		display.OutputError(&flags.OutputFormatConfig, "reinstallation of %s cancelled", args[0])
+		return
 	}
 
 	endpoint := fmt.Sprintf("/v1/dedicated/server/%s/reinstall", url.PathEscape(args[0]))

--- a/internal/services/baremetal/baremetal.go
+++ b/internal/services/baremetal/baremetal.go
@@ -23,6 +23,7 @@ import (
 	"github.com/ovh/ovhcloud-cli/internal/flags"
 	httpLib "github.com/ovh/ovhcloud-cli/internal/http"
 	"github.com/ovh/ovhcloud-cli/internal/services/common"
+	"github.com/ovh/ovhcloud-cli/internal/utils"
 	"github.com/spf13/cobra"
 )
 
@@ -502,6 +503,20 @@ func ReinstallBaremetal(cmd *cobra.Command, args []string) {
 		return
 	}
 
+	// Reinstalling wipes every disk of the server. Nothing else in this CLI
+	// destroys customer data, so this is the one place that asks before acting.
+	if !flags.AssumeYes && !flags.DryRun {
+		warning := fmt.Sprintf("Reinstalling %s wipes every disk of the server. This cannot be undone.", args[0])
+		if OperatingSystem != "" {
+			warning += fmt.Sprintf("\n   Operating system to install: %s", OperatingSystem)
+		}
+
+		if !utils.ConfirmByName(args[0], warning) {
+			display.OutputError(&flags.OutputFormatConfig, "reinstallation of %s cancelled", args[0])
+			return
+		}
+	}
+
 	endpoint := fmt.Sprintf("/v1/dedicated/server/%s/reinstall", url.PathEscape(args[0]))
 	task, err := common.CreateResource(
 		cmd,
@@ -519,6 +534,11 @@ func ReinstallBaremetal(cmd *cobra.Command, args []string) {
 		[]string{"operatingSystem"})
 	if err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "error reinstalling server: %s", err)
+		return
+	}
+
+	// Nothing was sent in dry-run mode, so there is no task to follow.
+	if flags.DryRun {
 		return
 	}
 

--- a/internal/services/baremetal/baremetal.go
+++ b/internal/services/baremetal/baremetal.go
@@ -172,7 +172,7 @@ func RebootRescueBaremetal(cmd *cobra.Command, args []string) {
 	server := fmt.Sprintf("/v1/dedicated/server/%s", url.PathEscape(args[0]))
 	if common.ReportDryRun(
 		common.Call{Method: "GET", Endpoint: server + "/boot?bootType=rescue"},
-		common.Call{Method: "PUT", Endpoint: server + "  (bootId of the rescue entry)"},
+		common.Call{Method: "PUT", Endpoint: server, Detail: "bootId of the rescue entry"},
 		common.Call{Method: "POST", Endpoint: server + "/reboot"},
 	) {
 		return
@@ -522,7 +522,7 @@ func ResetBaremetalOLAAggregation(_ *cobra.Command, args []string) {
 	// single request.
 	calls := make([]common.Call, 0, len(BaremetalOLAInterfaces))
 	for _, itf := range BaremetalOLAInterfaces {
-		calls = append(calls, common.Call{Method: "POST", Endpoint: url + "  (virtualNetworkInterface " + itf + ")"})
+		calls = append(calls, common.Call{Method: "POST", Endpoint: url, Detail: "virtualNetworkInterface " + itf})
 	}
 	if common.ReportDryRun(calls...) {
 		return

--- a/internal/services/baremetal/baremetal.go
+++ b/internal/services/baremetal/baremetal.go
@@ -147,7 +147,7 @@ func RebootBaremetal(_ *cobra.Command, args []string) {
 		return
 	}
 
-	if common.ReportDryRun("POST", url) {
+	if common.ReportDryRun(common.Call{Method: "POST", Endpoint: url}) {
 		return
 	}
 
@@ -167,7 +167,14 @@ func RebootRescueBaremetal(cmd *cobra.Command, args []string) {
 		return
 	}
 
-	if common.ReportDryRun("POST", fmt.Sprintf("/v1/dedicated/server/%s/reboot", url.PathEscape(args[0]))) {
+	// Three calls, not one: the boot is read, written to the server, and only
+	// then is the server rebooted. The write is what outlives the reboot.
+	server := fmt.Sprintf("/v1/dedicated/server/%s", url.PathEscape(args[0]))
+	if common.ReportDryRun(
+		common.Call{Method: "GET", Endpoint: server + "/boot?bootType=rescue"},
+		common.Call{Method: "PUT", Endpoint: server + "  (bootId of the rescue entry)"},
+		common.Call{Method: "POST", Endpoint: server + "/reboot"},
+	) {
 		return
 	}
 
@@ -511,7 +518,13 @@ func ResetBaremetalOLAAggregation(_ *cobra.Command, args []string) {
 		return
 	}
 
-	if common.ReportDryRun("POST", url) {
+	// One call per interface, so the preview lists them rather than implying a
+	// single request.
+	calls := make([]common.Call, 0, len(BaremetalOLAInterfaces))
+	for _, itf := range BaremetalOLAInterfaces {
+		calls = append(calls, common.Call{Method: "POST", Endpoint: url + "  (virtualNetworkInterface " + itf + ")"})
+	}
+	if common.ReportDryRun(calls...) {
 		return
 	}
 

--- a/internal/services/common/common.go
+++ b/internal/services/common/common.go
@@ -183,10 +183,18 @@ func CreateResource(cmd *cobra.Command, path, endpoint, defaultExample string,
 	// --dry-run stops here: the caller sees exactly what would have been sent,
 	// and nothing reaches the API.
 	if flags.DryRun {
+		// The payload goes in the message, not only in the details: the
+		// default output prints the message alone, so a --dry-run whose body
+		// lived in the details printed a promise and no request.
+		payload, err := json.MarshalIndent(parameters, "", "  ")
+		if err != nil {
+			return nil, fmt.Errorf("failed to render the parameters: %w", err)
+		}
+
 		display.OutputInfo(&flags.OutputFormatConfig, map[string]any{
 			"endpoint":   endpoint,
 			"parameters": parameters,
-		}, "🔍 Dry run: nothing was sent. The request above would have been posted to %s", endpoint)
+		}, "🔍 Dry run: nothing was sent. This would have been posted to %s:\n%s", endpoint, payload)
 		return nil, nil
 	}
 

--- a/internal/services/common/common.go
+++ b/internal/services/common/common.go
@@ -180,6 +180,16 @@ func CreateResource(cmd *cobra.Command, path, endpoint, defaultExample string,
 
 	log.Println("Final parameters: \n" + string(out))
 
+	// --dry-run stops here: the caller sees exactly what would have been sent,
+	// and nothing reaches the API.
+	if flags.DryRun {
+		display.OutputInfo(&flags.OutputFormatConfig, map[string]any{
+			"endpoint":   endpoint,
+			"parameters": parameters,
+		}, "🔍 Dry run: nothing was sent. The request above would have been posted to %s", endpoint)
+		return nil, nil
+	}
+
 	var createdResource map[string]any
 	if err := httpLib.Client.Post(endpoint, parameters, &createdResource); err != nil {
 		return nil, fmt.Errorf("error creating resource: %w", err)

--- a/internal/services/common/common.go
+++ b/internal/services/common/common.go
@@ -178,8 +178,6 @@ func CreateResource(cmd *cobra.Command, path, endpoint, defaultExample string,
 		return nil, fmt.Errorf("parameters cannot be marshalled: %w", err)
 	}
 
-	log.Println("Final parameters: \n" + string(out))
-
 	// --dry-run stops here: the caller sees exactly what would have been sent,
 	// and nothing reaches the API.
 	if flags.DryRun {
@@ -197,6 +195,19 @@ func CreateResource(cmd *cobra.Command, path, endpoint, defaultExample string,
 		}, "🔍 Dry run: nothing was sent. This would have been posted to %s:\n%s", endpoint, payload)
 		return nil, nil
 	}
+
+	// Logged only once the dry run is ruled out. A --dry-run already prints the
+	// payload as its message, so logging it here printed the same JSON twice,
+	// the second time behind a Go timestamp no other command in this CLI emits:
+	//
+	//	🔍 Dry run: nothing was sent. This would have been posted to …
+	//	{ "operatingSystem": "debian12_64" }
+	//	2026/08/23 23:47:22 Final parameters:
+	//	{ "operatingSystem": "debian12_64" }
+	//
+	// A real run still logs what it is about to send, which is what this line
+	// was for.
+	log.Println("Final parameters: \n" + string(out))
 
 	var createdResource map[string]any
 	if err := httpLib.Client.Post(endpoint, parameters, &createdResource); err != nil {

--- a/internal/services/common/guard.go
+++ b/internal/services/common/guard.go
@@ -1,0 +1,68 @@
+// SPDX-FileCopyrightText: 2025 OVH SAS <opensource@ovh.net>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package common
+
+import (
+	"github.com/ovh/ovhcloud-cli/internal/display"
+	"github.com/ovh/ovhcloud-cli/internal/flags"
+	"github.com/ovh/ovhcloud-cli/internal/utils"
+)
+
+// Severity says how much an action costs when it was not the one intended.
+// The two levels exist because proportionality is what makes a guardrail
+// survive daily use: asking an operator to type a server name before every
+// reboot teaches them to reach for --yes, and a habit of --yes protects
+// nothing on the day it matters.
+type Severity int
+
+const (
+	// Disruptive interrupts a running service. Nothing is lost, but somebody
+	// notices.
+	Disruptive Severity = iota
+
+	// Destructive loses data, or the resource itself. There is no retry.
+	Destructive
+)
+
+// ConfirmAction gates an action behind a confirmation and reports whether the
+// caller may proceed.
+//
+// It answers true without asking anything in two cases: --yes, which is how a
+// pipeline states its intent, and --dry-run, where the caller is about to
+// print the request instead of sending it. A dry run that still demanded a
+// confirmation would refuse to describe what it will not do.
+//
+// When it answers false it has already told the operator why, so the caller
+// only has to stop.
+func ConfirmAction(severity Severity, resource, warning string) bool {
+	if flags.AssumeYes || flags.DryRun {
+		return true
+	}
+
+	switch severity {
+	case Destructive:
+		return utils.ConfirmByName(resource, warning)
+	default:
+		return utils.ConfirmYesNo(warning)
+	}
+}
+
+// ReportDryRun prints the call a command would have made, and reports true so
+// the caller can stop on the same line it tested the flag.
+//
+// The endpoint is shown in full because these commands have no other preview:
+// the whole point of --dry-run here is to let somebody read the path before it
+// is acted on.
+func ReportDryRun(method, endpoint string) bool {
+	if !flags.DryRun {
+		return false
+	}
+
+	display.OutputInfo(&flags.OutputFormatConfig,
+		map[string]any{"method": method, "endpoint": endpoint},
+		"🔍 Dry run: nothing was sent. This would have been called:\n  %s %s", method, endpoint)
+
+	return true
+}

--- a/internal/services/common/guard.go
+++ b/internal/services/common/guard.go
@@ -59,6 +59,15 @@ func ConfirmAction(severity Severity, resource, warning string) bool {
 type Call struct {
 	Method   string
 	Endpoint string
+
+	// Detail says what the request carries, when the path alone does not.
+	//
+	// It is a separate field because Endpoint is read by machines as well as
+	// people: callers used to append prose to the path, which made --dry-run
+	// -o json report "/dedicated/server/x  (bootId of the rescue entry)" as an
+	// endpoint. A string that is not a path has no business in a field named
+	// after one.
+	Detail string
 }
 
 // ReportDryRun prints every call a command would have made, and reports true so
@@ -80,8 +89,14 @@ func ReportDryRun(calls ...Call) bool {
 	details := make([]map[string]any, 0, len(calls))
 	message := "🔍 Dry run: nothing was sent. This would have been called:"
 	for _, c := range calls {
-		details = append(details, map[string]any{"method": c.Method, "endpoint": c.Endpoint})
-		message += fmt.Sprintf("\n  %s %s", c.Method, c.Endpoint)
+		detail := map[string]any{"method": c.Method, "endpoint": c.Endpoint}
+		line := fmt.Sprintf("\n  %s %s", c.Method, c.Endpoint)
+		if c.Detail != "" {
+			detail["detail"] = c.Detail
+			line += "  (" + c.Detail + ")"
+		}
+		details = append(details, detail)
+		message += line
 	}
 
 	display.OutputInfo(&flags.OutputFormatConfig, map[string]any{"calls": details}, "%s", message)

--- a/internal/services/common/guard.go
+++ b/internal/services/common/guard.go
@@ -42,8 +42,21 @@ const (
 //
 // When it answers false it has already told the operator why, so the caller
 // only has to stop.
+// pendingWarning garde l avertissement qu un dry-run n a PAS pose, pour que le
+// rapport le porte. Une valeur de paquet : un processus de CLI execute une
+// commande, et ReportDryRun la consomme aussitot.
+var pendingWarning string
+
 func ConfirmAction(severity Severity, resource, warning string) bool {
 	if flags.AssumeYes || flags.DryRun {
+		// Un dry-run saute la question -- et sautait donc la seule chose que
+		// certains points ont a juger : ce que la garde AURAIT dit. Sur
+		// `ip change-org`, la phrase qui annonce que l adresse quitte le compte
+		// n apparaissait nulle part, puisque la prevision ne pose pas de
+		// question. On la garde de cote et le rapport l imprime.
+		if flags.DryRun {
+			pendingWarning = warning
+		}
 		return true
 	}
 
@@ -87,7 +100,14 @@ func ReportDryRun(calls ...Call) bool {
 	}
 
 	details := make([]map[string]any, 0, len(calls))
-	message := "🔍 Dry run: nothing was sent. This would have been called:"
+	message := "🔍 Dry run: nothing was sent."
+	// Ce que la commande aurait demande avant d agir. Sans cette ligne, une
+	// prevision cache precisement la garde qu on lui a demande de montrer.
+	if pendingWarning != "" {
+		message += "\n  It would have asked first: " + pendingWarning
+		pendingWarning = ""
+	}
+	message += "\nThis would have been called:"
 	for _, c := range calls {
 		detail := map[string]any{"method": c.Method, "endpoint": c.Endpoint}
 		line := fmt.Sprintf("\n  %s %s", c.Method, c.Endpoint)

--- a/internal/services/common/guard.go
+++ b/internal/services/common/guard.go
@@ -5,6 +5,8 @@
 package common
 
 import (
+	"fmt"
+
 	"github.com/ovh/ovhcloud-cli/internal/display"
 	"github.com/ovh/ovhcloud-cli/internal/flags"
 	"github.com/ovh/ovhcloud-cli/internal/utils"
@@ -18,12 +20,16 @@ import (
 type Severity int
 
 const (
+	// Destructive loses data, or the resource itself. There is no retry.
+	//
+	// It is deliberately the zero value: a caller that forgets to state a
+	// severity gets the strictest guard rather than the weakest one, and finds
+	// out immediately instead of on the day it mattered.
+	Destructive Severity = iota
+
 	// Disruptive interrupts a running service. Nothing is lost, but somebody
 	// notices.
-	Disruptive Severity = iota
-
-	// Destructive loses data, or the resource itself. There is no retry.
-	Destructive
+	Disruptive
 )
 
 // ConfirmAction gates an action behind a confirmation and reports whether the
@@ -42,27 +48,43 @@ func ConfirmAction(severity Severity, resource, warning string) bool {
 	}
 
 	switch severity {
-	case Destructive:
-		return utils.ConfirmByName(resource, warning)
-	default:
+	case Disruptive:
 		return utils.ConfirmYesNo(warning)
+	default:
+		return utils.ConfirmByName(resource, warning)
 	}
 }
 
-// ReportDryRun prints the call a command would have made, and reports true so
+// Call is one request a command would send.
+type Call struct {
+	Method   string
+	Endpoint string
+}
+
+// ReportDryRun prints every call a command would have made, and reports true so
 // the caller can stop on the same line it tested the flag.
 //
-// The endpoint is shown in full because these commands have no other preview:
-// the whole point of --dry-run here is to let somebody read the path before it
-// is acted on.
-func ReportDryRun(method, endpoint string) bool {
+// It takes the whole sequence rather than one call because several of these
+// commands are not one request. `reboot-rescue` reads the rescue boot, writes
+// it to the server and only then reboots — and the write is the part that
+// outlives the reboot. A preview that showed the reboot alone would hide
+// exactly the change an operator needs to see before agreeing to it.
+//
+// Endpoints are shown in full: these commands have no other preview, and the
+// point is to let somebody read the paths before they are acted on.
+func ReportDryRun(calls ...Call) bool {
 	if !flags.DryRun {
 		return false
 	}
 
-	display.OutputInfo(&flags.OutputFormatConfig,
-		map[string]any{"method": method, "endpoint": endpoint},
-		"🔍 Dry run: nothing was sent. This would have been called:\n  %s %s", method, endpoint)
+	details := make([]map[string]any, 0, len(calls))
+	message := "🔍 Dry run: nothing was sent. This would have been called:"
+	for _, c := range calls {
+		details = append(details, map[string]any{"method": c.Method, "endpoint": c.Endpoint})
+		message += fmt.Sprintf("\n  %s %s", c.Method, c.Endpoint)
+	}
+
+	display.OutputInfo(&flags.OutputFormatConfig, map[string]any{"calls": details}, "%s", message)
 
 	return true
 }

--- a/internal/services/common/guard_test.go
+++ b/internal/services/common/guard_test.go
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: 2025 OVH SAS <opensource@ovh.net>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package common
+
+import (
+	"testing"
+
+	"github.com/maxatome/go-testdeep/td"
+	"github.com/ovh/ovhcloud-cli/internal/flags"
+)
+
+// A caller that forgets to state a severity must get the strictest guard.
+// Written as an assertion on the constant rather than on behaviour, because
+// the failure this prevents is somebody reordering the block: the zero value
+// would quietly become the weak confirmation and every call site that relied
+// on the default would be downgraded without a single test noticing.
+func TestSeverity_ZeroValueIsTheStrictestGuard(t *testing.T) {
+	var unset Severity
+
+	td.Cmp(t, unset, Destructive,
+		"the zero value must be Destructive: an omitted severity is a bug, and it must fail safe")
+}
+
+// --yes is how a pipeline states its intent, for either severity.
+func TestConfirmAction_AssumeYesSkipsBothLevels(t *testing.T) {
+	orig := flags.AssumeYes
+	defer func() { flags.AssumeYes = orig }()
+	flags.AssumeYes = true
+
+	td.Cmp(t, ConfirmAction(Destructive, "srv", "wipes the disks"), true)
+	td.Cmp(t, ConfirmAction(Disruptive, "srv", "interrupts the service"), true)
+}
+
+// A dry run prints instead of acting, so it must never be gated by a
+// confirmation: refusing to describe a call it will not make is absurd.
+func TestConfirmAction_DryRunNeverPrompts(t *testing.T) {
+	orig := flags.DryRun
+	defer func() { flags.DryRun = orig }()
+	flags.DryRun = true
+
+	td.Cmp(t, ConfirmAction(Destructive, "srv", "wipes the disks"), true)
+}
+
+// ReportDryRun is inert unless --dry-run was given: it must not print over the
+// output of a command that is really running.
+func TestReportDryRun_IsInertWithoutTheFlag(t *testing.T) {
+	orig := flags.DryRun
+	defer func() { flags.DryRun = orig }()
+	flags.DryRun = false
+
+	td.Cmp(t, ReportDryRun(Call{Method: "POST", Endpoint: "/v1/whatever"}), false)
+}

--- a/internal/services/common/guard_test.go
+++ b/internal/services/common/guard_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/maxatome/go-testdeep/td"
+	"github.com/ovh/ovhcloud-cli/internal/display"
 	"github.com/ovh/ovhcloud-cli/internal/flags"
 )
 
@@ -51,4 +52,26 @@ func TestReportDryRun_IsInertWithoutTheFlag(t *testing.T) {
 	flags.DryRun = false
 
 	td.Cmp(t, ReportDryRun(Call{Method: "POST", Endpoint: "/v1/whatever"}), false)
+}
+
+// --dry-run is read by machines too. Callers used to append prose to Endpoint,
+// so `-o json` reported "/dedicated/server/x  (bootId of the rescue entry)" in
+// a field named after a path — a value no script can use and no reader can
+// trust.
+func TestReportDryRun_KeepsTheEndpointAPath(t *testing.T) {
+	assert := td.Assert(t)
+	origDryRun := flags.DryRun
+	flags.DryRun = true
+	defer func() { flags.DryRun = origDryRun }()
+
+	stopped := ReportDryRun(Call{
+		Method:   "PUT",
+		Endpoint: "/v1/dedicated/server/ns1.example.net",
+		Detail:   "bootId of the rescue entry",
+	})
+
+	assert.True(stopped)
+	assert.Contains(display.ResultString, "/v1/dedicated/server/ns1.example.net")
+	assert.Contains(display.ResultString, "bootId of the rescue entry",
+		"the detail is still shown, next to the path rather than inside it")
 }

--- a/internal/utils/confirm_test.go
+++ b/internal/utils/confirm_test.go
@@ -75,3 +75,37 @@ func TestConfirmByName_RefusesWhenNotInteractive(t *testing.T) {
 
 	td.Cmp(t, ConfirmByName("ns3168421.ip-51-77-12.eu", "this wipes both disks"), false)
 }
+
+// A reboot asks for a yes, not for the server's name: the friction has to match
+// the risk or it gets bypassed by habit.
+func TestConfirmYesNo_AcceptsYes(t *testing.T) {
+	for _, answer := range []string{"y\n", "Y\n", "yes\n", "  YES  \n"} {
+		var confirmed bool
+		withInteractiveInput(t, answer, func() {
+			confirmed = ConfirmYesNo("this reboots the server")
+		})
+		td.Cmp(t, confirmed, true, "answer %q must confirm", answer)
+	}
+}
+
+// Everything else declines, including the empty answer that a hurried Enter
+// produces — the prompt reads [y/N] and must mean it.
+func TestConfirmYesNo_RefusesAnythingElse(t *testing.T) {
+	for _, answer := range []string{"\n", "n\n", "no\n", "ya\n", "sure\n", "yes please\n"} {
+		var confirmed bool
+		withInteractiveInput(t, answer, func() {
+			confirmed = ConfirmYesNo("this reboots the server")
+		})
+		td.Cmp(t, confirmed, false, "answer %q must decline", answer)
+	}
+}
+
+// Non-interactive means a pipeline, and a pipeline that did not say --yes did
+// not consent.
+func TestConfirmYesNo_RefusesWhenNotInteractive(t *testing.T) {
+	origInteractive := confirmInteractive
+	confirmInteractive = func() bool { return false }
+	defer func() { confirmInteractive = origInteractive }()
+
+	td.Cmp(t, ConfirmYesNo("this reboots the server"), false)
+}

--- a/internal/utils/confirm_test.go
+++ b/internal/utils/confirm_test.go
@@ -1,0 +1,77 @@
+// SPDX-FileCopyrightText: 2025 OVH SAS <opensource@ovh.net>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !(js && wasm)
+
+package utils
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/maxatome/go-testdeep/td"
+)
+
+// withInteractiveInput runs f as if the operator were typing answer at an
+// interactive terminal.
+func withInteractiveInput(t *testing.T, answer string, f func()) {
+	t.Helper()
+
+	origInput, origInteractive := confirmInput, confirmInteractive
+	confirmInput = strings.NewReader(answer)
+	confirmInteractive = func() bool { return true }
+	defer func() { confirmInput, confirmInteractive = origInput, origInteractive }()
+
+	f()
+}
+
+// The exact name is the guard between a typo and an erased disk, so the
+// accepting path has to be exercised, not only the refusals around it.
+func TestConfirmByName_AcceptsTheExactName(t *testing.T) {
+	var confirmed bool
+	withInteractiveInput(t, "ns3168421.ip-51-77-12.eu\n", func() {
+		confirmed = ConfirmByName("ns3168421.ip-51-77-12.eu", "this wipes both disks")
+	})
+
+	td.Cmp(t, confirmed, true)
+}
+
+// Surrounding whitespace is the operator's, not the server's.
+func TestConfirmByName_AcceptsTheNameWithSurroundingSpaces(t *testing.T) {
+	var confirmed bool
+	withInteractiveInput(t, "  ns3168421.ip-51-77-12.eu  \n", func() {
+		confirmed = ConfirmByName("ns3168421.ip-51-77-12.eu", "this wipes both disks")
+	})
+
+	td.Cmp(t, confirmed, true)
+}
+
+// Anything else is a refusal: a near miss must not pass.
+func TestConfirmByName_RejectsAnythingElse(t *testing.T) {
+	for _, answer := range []string{
+		"ns3168421.ip-51-77-12.e\n",  // one character short
+		"ns3168422.ip-51-77-12.eu\n", // the neighbouring server
+		"yes\n",
+		"\n",
+		"", // stream closed before any answer
+	} {
+		var confirmed bool
+		withInteractiveInput(t, answer, func() {
+			confirmed = ConfirmByName("ns3168421.ip-51-77-12.eu", "this wipes both disks")
+		})
+
+		td.Cmp(t, confirmed, false, "answer %q must not confirm", answer)
+	}
+}
+
+// Without a terminal there is no prompt at all: an unattended run has to opt
+// in with --yes rather than be asked a question nobody will read.
+func TestConfirmByName_RefusesWhenNotInteractive(t *testing.T) {
+	origInput, origInteractive := confirmInput, confirmInteractive
+	confirmInput = strings.NewReader("ns3168421.ip-51-77-12.eu\n")
+	confirmInteractive = func() bool { return false }
+	defer func() { confirmInput, confirmInteractive = origInput, origInteractive }()
+
+	td.Cmp(t, ConfirmByName("ns3168421.ip-51-77-12.eu", "this wipes both disks"), false)
+}

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -7,6 +7,7 @@ package utils
 import (
 	"bufio"
 	"fmt"
+	"io"
 	"os"
 	"runtime"
 	"strings"
@@ -39,8 +40,18 @@ func IsInputFromPipe() bool {
 //
 // The prompt is written to stderr so that a redirected stdout keeps holding
 // data only.
+// Both indirections exist so that the confirmation path itself can be
+// exercised by a test: it is the guard standing between a typo and an erased
+// disk, and a guard nobody executes is a guard nobody has checked.
+var (
+	confirmInput       io.Reader = os.Stdin
+	confirmInteractive           = func() bool {
+		return !IsInputFromPipe() && term.IsTerminal(os.Stdin.Fd())
+	}
+)
+
 func ConfirmByName(expected, warning string) bool {
-	if IsInputFromPipe() || !term.IsTerminal(os.Stdin.Fd()) {
+	if !confirmInteractive() {
 		fmt.Fprintf(os.Stderr,
 			"🛑 %s\n   Refusing to continue without a confirmation. Re-run with --yes to confirm, or --dry-run to preview.\n",
 			warning)
@@ -49,7 +60,7 @@ func ConfirmByName(expected, warning string) bool {
 
 	fmt.Fprintf(os.Stderr, "⚠️  %s\n   Type %q to confirm › ", warning, expected)
 
-	reader := bufio.NewReader(os.Stdin)
+	reader := bufio.NewReader(confirmInput)
 	answer, err := reader.ReadString('\n')
 	if err != nil {
 		return false

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -50,6 +50,38 @@ var (
 	}
 )
 
+// ConfirmYesNo asks for a plain yes before an action that interrupts a running
+// service without losing anything. Typing the resource name, as ConfirmByName
+// requires, is the right friction for an irreversible act and the wrong one for
+// a reboot: a guardrail that is tiresome out of proportion to its risk is a
+// guardrail people learn to bypass.
+//
+// Anything other than "y" or "yes" declines, and a non-interactive session
+// declines rather than guessing.
+func ConfirmYesNo(warning string) bool {
+	if !confirmInteractive() {
+		fmt.Fprintf(os.Stderr,
+			"🛑 %s\n   Refusing to continue without a confirmation. Re-run with --yes to confirm, or --dry-run to preview.\n",
+			warning)
+		return false
+	}
+
+	fmt.Fprintf(os.Stderr, "⚠️  %s\n   Continue? [y/N] › ", warning)
+
+	reader := bufio.NewReader(confirmInput)
+	answer, err := reader.ReadString('\n')
+	if err != nil {
+		return false
+	}
+
+	switch strings.ToLower(strings.TrimSpace(answer)) {
+	case "y", "yes":
+		return true
+	default:
+		return false
+	}
+}
+
 func ConfirmByName(expected, warning string) bool {
 	if !confirmInteractive() {
 		fmt.Fprintf(os.Stderr,

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -29,7 +29,15 @@ func IsInputFromPipe() bool {
 		return false
 	}
 
-	fileInfo, _ := os.Stdin.Stat()
+	// A closed or otherwise unstatable stdin returns a nil FileInfo, and every
+	// guarded command asks this before it may prompt: dereferencing it crashed
+	// the command instead of letting it decline. Treated as "not a terminal",
+	// which is the safe reading — an input nobody can describe is not one an
+	// operator is typing into.
+	fileInfo, err := os.Stdin.Stat()
+	if err != nil {
+		return true
+	}
 	return fileInfo.Mode()&os.ModeCharDevice == 0
 }
 

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -5,11 +5,14 @@
 package utils
 
 import (
+	"bufio"
 	"fmt"
 	"os"
 	"runtime"
+	"strings"
 
 	"dario.cat/mergo"
+	"github.com/charmbracelet/x/term"
 )
 
 func MergeMaps(left, right map[string]any) error {
@@ -27,4 +30,30 @@ func IsInputFromPipe() bool {
 
 	fileInfo, _ := os.Stdin.Stat()
 	return fileInfo.Mode()&os.ModeCharDevice == 0
+}
+
+// ConfirmByName asks the operator to type the given name before a destructive
+// action is carried out. It returns false — without prompting — when the input
+// is not an interactive terminal, so an unattended run never destroys anything
+// by default: such runs must opt in explicitly.
+//
+// The prompt is written to stderr so that a redirected stdout keeps holding
+// data only.
+func ConfirmByName(expected, warning string) bool {
+	if IsInputFromPipe() || !term.IsTerminal(os.Stdin.Fd()) {
+		fmt.Fprintf(os.Stderr,
+			"🛑 %s\n   Refusing to continue without a confirmation. Re-run with --yes to confirm, or --dry-run to preview.\n",
+			warning)
+		return false
+	}
+
+	fmt.Fprintf(os.Stderr, "⚠️  %s\n   Type %q to confirm › ", warning, expected)
+
+	reader := bufio.NewReader(os.Stdin)
+	answer, err := reader.ReadString('\n')
+	if err != nil {
+		return false
+	}
+
+	return strings.TrimSpace(answer) == expected
 }

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -5,6 +5,7 @@
 package utils
 
 import (
+	"os"
 	"testing"
 
 	"github.com/maxatome/go-testdeep/td"
@@ -69,4 +70,39 @@ func TestMergeMaps_WrongType(t *testing.T) {
 	err := MergeMaps(left, right)
 	td.CmpNoError(t, err)
 	td.Cmp(t, left, expected)
+}
+
+// A guard that panics has stopped being a guard.
+//
+// Since #242 every disruptive command asks IsInputFromPipe whether it may
+// prompt, so this runs before any confirmation can refuse. os.Stdin.Stat()
+// fails on a closed descriptor and returns a nil FileInfo; dereferencing it
+// crashes the command with a nil pointer instead of declining the action.
+//
+// Closing os.Stdin is what the test is about, so it is restored afterwards
+// rather than left broken for the rest of the package.
+func TestIsInputFromPipeDoesNotPanicOnAClosedStdin(t *testing.T) {
+	original := os.Stdin
+	t.Cleanup(func() { os.Stdin = original })
+
+	read, write, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("failed to create a pipe: %s", err)
+	}
+	write.Close()
+	read.Close()
+	os.Stdin = read
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("IsInputFromPipe panicked on a closed stdin: %v", r)
+		}
+	}()
+
+	// The value does not matter; not crashing does. A descriptor that cannot be
+	// stated is not a terminal, so the guarded command must refuse rather than
+	// prompt.
+	if IsInputFromPipe() != true {
+		t.Error("an unstatable stdin is not an interactive terminal")
+	}
 }


### PR DESCRIPTION
> **Stacked on #234.** GitHub shows this against `main`, so the diff includes #234's commit. The
> commit that belongs to this PR is `74af46a` alone — 10 files, +271/−18. Merge #234 first and this
> becomes a one-commit change. Happy to rebase whenever suits you.

## The problem

#234 put a confirmation in front of `reinstall`, the only command that destroys data. It is not the only one that ruins an afternoon:

| Command | What it does with no confirmation today |
|---|---|
| `reboot` | Interrupts everything running on the machine |
| `reboot-rescue` | Same, and leaves the server in rescue until somebody sets the boot back |
| `vni ola-reset` | Takes the interfaces down — on a server reached over that link, the operator is cutting the branch they sit on |

All three fire on the bare command, with no way to preview what they will do.

## Two levels, on purpose

`reinstall` still asks for the server's name: there is no retry after a wiped disk. The other three ask for a yes.

That distinction is the whole design. Demanding a typed server name before every reboot teaches an operator to reach for `--yes` by reflex — and a reflex protects nothing on the day it matters. A guardrail out of proportion to its risk is one people learn to bypass.

```console
$ ovhcloud baremetal reboot ns3168421.ip-51-77-12.eu
⚠️  Rebooting ns3168421.ip-51-77-12.eu interrupts everything running on it.
   Continue? [y/N] ›

$ ovhcloud baremetal reboot ns3168421.ip-51-77-12.eu --dry-run
🔍 Dry run: nothing was sent. This would have been called:
  POST /v1/dedicated/server/ns3168421.ip-51-77-12.eu/reboot
```

`--yes` and `--dry-run` come as a pair on all four commands, mutually exclusive: skipping a confirmation for something that will not happen means one of the two was a mistake. A dry run never prompts — refusing to describe a call it is not going to make would be absurd.

## Why it is extracted rather than inlined

`common.ConfirmAction` and `common.ReportDryRun` exist so the commands still to be written — `terminate`, `vrack detach`, `ip delete`, `backup delete` — inherit the behaviour instead of each inventing its own.

There is precedent for the failure mode: this repository already contains **four hand-rolled `terminate` implementations** (vps, webhosting, cloud project, cloud savings plan) with four different messages and two different ways of passing the confirmation token. That is the pattern this avoids repeating.

## A finding worth recording

The audit asked for a per-server `lock` / `unlock`. **The dedicated API exposes no such thing.** I searched all 30 embedded schemas: the only `lock`/`unlock` endpoints belong to OVHcloud Connect interfaces and Telephony conferences, and `services.Service` carries no protection field. A CLI-local lock file would protect the machine it lives on and nobody else's, so the guardrail is the confirmation rather than a lock. Happy to be told otherwise if an endpoint exists that I did not find.

## Tests

Eight, with positive controls:

- making `ConfirmAction` always return true → four tests fail, each asserting `GetTotalCallCount() == 0`
- removing the `return` after `ReportDryRun` → the request leaves and the dry-run test fails

The `y/N` prompt is covered for `y`, `Y`, `yes`, `  YES  `, and declines on the empty answer a hurried Enter produces — the prompt reads `[y/N]` and must mean it.

Refs: BareMetal CLI audit, requirement C6 (LVL2-16355)
