### PR TITLE
fix(service-info): send only the renewal settings the operator asked to change

### DIFF
--- a/doc/ovhcloud_vps_service-info_edit.md
+++ b/doc/ovhcloud_vps_service-info_edit.md
@@ -11,11 +11,11 @@ ovhcloud vps service-info edit <service_name> [flags]
 ```
       --editor                       Use a text editor to define parameters
   -h, --help                         help for edit
-      --renew-automatic              Enable automatic renewal
-      --renew-delete-at-expiration   Delete service at expiration
-      --renew-forced                 Force renewal
-      --renew-manual-payment         Enable manual payment for renewal
-      --renew-period int             Renewal period (in months)
+      --renew-automatic              Renew the service automatically
+      --renew-delete-at-expiration   Delete the service when it expires
+      --renew-forced                 Force the renewal
+      --renew-manual-payment         Pay the renewal manually
+      --renew-period int             Renewal period, in months
 ```
 
 ### Options inherited from parent commands

--- a/doc/ovhcloud_webhosting_cdn_service-info_update.md
+++ b/doc/ovhcloud_webhosting_cdn_service-info_update.md
@@ -12,11 +12,11 @@ ovhcloud webhosting cdn service-info update <service_name> [flags]
       --editor                       Use a text editor to define parameters
       --from-file string             File containing parameters
   -h, --help                         help for update
-      --renew-automatic              Enable automatic renewal
-      --renew-delete-at-expiration   Delete service at expiration
-      --renew-forced                 Force renewal
-      --renew-manual-payment         Enable manual payment for renewal
-      --renew-period int             Renewal period in months
+      --renew-automatic              Renew the service automatically
+      --renew-delete-at-expiration   Delete the service when it expires
+      --renew-forced                 Force the renewal
+      --renew-manual-payment         Pay the renewal manually
+      --renew-period int             Renewal period, in months
 ```
 
 ### Options inherited from parent commands

--- a/doc/ovhcloud_webhosting_extra-sql_service-info_update.md
+++ b/doc/ovhcloud_webhosting_extra-sql_service-info_update.md
@@ -12,11 +12,11 @@ ovhcloud webhosting extra-sql service-info update <service_name> <id> [flags]
       --editor                       Use a text editor to define parameters
       --from-file string             File containing parameters
   -h, --help                         help for update
-      --renew-automatic              Enable automatic renewal
-      --renew-delete-at-expiration   Delete service at expiration
-      --renew-forced                 Force renewal
-      --renew-manual-payment         Enable manual payment for renewal
-      --renew-period int             Renewal period in months
+      --renew-automatic              Renew the service automatically
+      --renew-delete-at-expiration   Delete the service when it expires
+      --renew-forced                 Force the renewal
+      --renew-manual-payment         Pay the renewal manually
+      --renew-period int             Renewal period, in months
 ```
 
 ### Options inherited from parent commands

--- a/doc/ovhcloud_webhosting_local-seo_location_service-info_update.md
+++ b/doc/ovhcloud_webhosting_local-seo_location_service-info_update.md
@@ -12,11 +12,11 @@ ovhcloud webhosting local-seo location service-info update <service_name> <id> [
       --editor                       Use a text editor to define parameters
       --from-file string             File containing parameters
   -h, --help                         help for update
-      --renew-automatic              Enable automatic renewal
-      --renew-delete-at-expiration   Delete service at expiration
-      --renew-forced                 Force renewal
-      --renew-manual-payment         Enable manual payment for renewal
-      --renew-period int             Renewal period in months
+      --renew-automatic              Renew the service automatically
+      --renew-delete-at-expiration   Delete the service when it expires
+      --renew-forced                 Force the renewal
+      --renew-manual-payment         Pay the renewal manually
+      --renew-period int             Renewal period, in months
 ```
 
 ### Options inherited from parent commands

--- a/doc/ovhcloud_webhosting_service-info_update.md
+++ b/doc/ovhcloud_webhosting_service-info_update.md
@@ -12,11 +12,11 @@ ovhcloud webhosting service-info update <service_name> [flags]
       --editor                       Use a text editor to define parameters
       --from-file string             File containing parameters
   -h, --help                         help for update
-      --renew-automatic              Enable automatic renewal
-      --renew-delete-at-expiration   Delete service at expiration
-      --renew-forced                 Force renewal
-      --renew-manual-payment         Enable manual payment for renewal
-      --renew-period int             Renewal period in months
+      --renew-automatic              Renew the service automatically
+      --renew-delete-at-expiration   Delete the service when it expires
+      --renew-forced                 Force the renewal
+      --renew-manual-payment         Pay the renewal manually
+      --renew-period int             Renewal period, in months
 ```
 
 ### Options inherited from parent commands

--- a/internal/cmd/service_info.go
+++ b/internal/cmd/service_info.go
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: 2025 OVH SAS <opensource@ovh.net>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"github.com/ovh/ovhcloud-cli/internal/services/common"
+	"github.com/spf13/cobra"
+)
+
+// addServiceInfoRenewFlags registers the renewal flags on a `service-info edit`
+// command.
+//
+// It sits here, beside the other shared flag helpers, rather than in the
+// service package: declaring cobra flags is the command layer's job, and
+// internal/services/common was the only service package doing it. The flag
+// names still come from common.ServiceInfoRenewFlags, which is also what the
+// payload builder reads — one table, so the two halves cannot drift.
+func addServiceInfoRenewFlags(cmd *cobra.Command) {
+	for _, flag := range common.ServiceInfoRenewFlags {
+		if flag.Period {
+			cmd.Flags().Int(flag.Name, 0, flag.Usage)
+			continue
+		}
+		cmd.Flags().Bool(flag.Name, false, flag.Usage)
+	}
+}

--- a/internal/cmd/vps.go
+++ b/internal/cmd/vps.go
@@ -221,11 +221,7 @@ func init() {
 		ValidArgsFunction: completion.ServiceList("/v1/vps"),
 		Run:               vps.EditVpsServiceInfo,
 	}
-	serviceInfoEditCmd.Flags().BoolVar(&common.ServiceInfoSpec.Renew.Automatic, "renew-automatic", false, "Enable automatic renewal")
-	serviceInfoEditCmd.Flags().BoolVar(&common.ServiceInfoSpec.Renew.DeleteAtExpiration, "renew-delete-at-expiration", false, "Delete service at expiration")
-	serviceInfoEditCmd.Flags().BoolVar(&common.ServiceInfoSpec.Renew.Forced, "renew-forced", false, "Force renewal")
-	serviceInfoEditCmd.Flags().BoolVar(&common.ServiceInfoSpec.Renew.ManualPayment, "renew-manual-payment", false, "Enable manual payment for renewal")
-	serviceInfoEditCmd.Flags().IntVar(&common.ServiceInfoSpec.Renew.Period, "renew-period", 0, "Renewal period (in months)")
+	common.AddServiceInfoRenewFlags(serviceInfoEditCmd)
 	addInteractiveEditorFlag(serviceInfoEditCmd)
 	serviceInfoCmd.AddCommand(serviceInfoEditCmd)
 

--- a/internal/cmd/vps.go
+++ b/internal/cmd/vps.go
@@ -11,7 +11,6 @@ import (
 	"github.com/ovh/ovhcloud-cli/internal/assets"
 	"github.com/ovh/ovhcloud-cli/internal/completion"
 	"github.com/ovh/ovhcloud-cli/internal/flags"
-	"github.com/ovh/ovhcloud-cli/internal/services/common"
 	"github.com/ovh/ovhcloud-cli/internal/services/vps"
 	"github.com/spf13/cobra"
 )
@@ -221,7 +220,7 @@ func init() {
 		ValidArgsFunction: completion.ServiceList("/v1/vps"),
 		Run:               vps.EditVpsServiceInfo,
 	}
-	common.AddServiceInfoRenewFlags(serviceInfoEditCmd)
+	addServiceInfoRenewFlags(serviceInfoEditCmd)
 	addInteractiveEditorFlag(serviceInfoEditCmd)
 	serviceInfoCmd.AddCommand(serviceInfoEditCmd)
 

--- a/internal/cmd/vps_test.go
+++ b/internal/cmd/vps_test.go
@@ -6,6 +6,8 @@ package cmd_test
 
 import (
 	"encoding/json"
+	"io"
+	"net/http"
 
 	"github.com/jarcoal/httpmock"
 	"github.com/maxatome/go-testdeep/td"
@@ -62,4 +64,60 @@ func (ms *MockSuite) TestVpsGetCmd(assert, require *td.T) {
 			"longName": "Region OpenStack: os-gra1"
 		}
 	}`))
+}
+
+// registerVpsServiceInfos wires a service whose renewal is currently automatic,
+// and captures whatever the CLI decides to write back.
+func registerVpsServiceInfos(captured *map[string]any) {
+	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/v1/vps/fakeVps/serviceInfos",
+		httpmock.NewStringResponder(200, `{
+			"serviceId": 1,
+			"domain": "fakeVps",
+			"renew": {"automatic": true, "deleteAtExpiration": false, "forced": false, "manualPayment": false, "period": 1}
+		}`),
+	)
+	httpmock.RegisterResponder("PUT", "https://eu.api.ovh.com/v1/vps/fakeVps/serviceInfos",
+		func(req *http.Request) (*http.Response, error) {
+			body, err := io.ReadAll(req.Body)
+			if err != nil {
+				return nil, err
+			}
+			var sent map[string]any
+			if err := json.Unmarshal(body, &sent); err != nil {
+				return nil, err
+			}
+			*captured = sent
+			return httpmock.NewStringResponse(200, `null`), nil
+		},
+	)
+}
+
+// Editing the renewal period used to send every other renewal setting along
+// with it, at its zero value: a service that renewed itself automatically for
+// years stopped doing so, and nothing in the output said it had changed.
+func (ms *MockSuite) TestVpsServiceInfoEditSendsOnlyWhatWasAsked(assert, require *td.T) {
+	var sent map[string]any
+	registerVpsServiceInfos(&sent)
+
+	_, err := cmd.Execute("vps", "service-info", "edit", "fakeVps", "--renew-period", "12")
+
+	require.CmpNoError(err)
+	renew, _ := sent["renew"].(map[string]any)
+	require.NotNil(renew, "the renewal block must be written")
+	assert.Cmp(renew["period"], float64(12), "the period the operator asked for")
+	assert.Cmp(renew["automatic"], true, "automatic renewal must survive untouched")
+}
+
+// The flag being absent and the flag being set to false are different
+// intentions, and pflag can tell them apart: an explicit false must be sent.
+func (ms *MockSuite) TestVpsServiceInfoEditSendsAnExplicitFalse(assert, require *td.T) {
+	var sent map[string]any
+	registerVpsServiceInfos(&sent)
+
+	_, err := cmd.Execute("vps", "service-info", "edit", "fakeVps", "--renew-automatic=false")
+
+	require.CmpNoError(err)
+	renew, _ := sent["renew"].(map[string]any)
+	require.NotNil(renew)
+	assert.Cmp(renew["automatic"], false, "the operator asked for it, so it is sent")
 }

--- a/internal/cmd/webhosting.go
+++ b/internal/cmd/webhosting.go
@@ -605,11 +605,7 @@ func init() {
 		ValidArgsFunction: completion.ServiceList("/v1/hosting/web"),
 		Run:               webhosting.UpdateExtraSqlServiceInfo,
 	}
-	extraSQLServiceInfoUpdateCmd.Flags().BoolVar(&common.ServiceInfoSpec.Renew.Automatic, "renew-automatic", false, "Enable automatic renewal")
-	extraSQLServiceInfoUpdateCmd.Flags().BoolVar(&common.ServiceInfoSpec.Renew.DeleteAtExpiration, "renew-delete-at-expiration", false, "Delete service at expiration")
-	extraSQLServiceInfoUpdateCmd.Flags().BoolVar(&common.ServiceInfoSpec.Renew.Forced, "renew-forced", false, "Force renewal")
-	extraSQLServiceInfoUpdateCmd.Flags().BoolVar(&common.ServiceInfoSpec.Renew.ManualPayment, "renew-manual-payment", false, "Enable manual payment for renewal")
-	extraSQLServiceInfoUpdateCmd.Flags().IntVar(&common.ServiceInfoSpec.Renew.Period, "renew-period", 0, "Renewal period in months")
+	common.AddServiceInfoRenewFlags(extraSQLServiceInfoUpdateCmd)
 	addParameterFileFlags(extraSQLServiceInfoUpdateCmd, true, nil, "", "", "", nil)
 	addInteractiveEditorFlag(extraSQLServiceInfoUpdateCmd)
 	extraSQLServiceInfoCmd.AddCommand(extraSQLServiceInfoUpdateCmd)
@@ -1330,11 +1326,7 @@ func init() {
 		ValidArgsFunction: completion.ServiceList("/v1/hosting/web"),
 		Run:               webhosting.UpdateCdnServiceInfo,
 	}
-	cdnServiceInfoUpdateCmd.Flags().BoolVar(&common.ServiceInfoSpec.Renew.Automatic, "renew-automatic", false, "Enable automatic renewal")
-	cdnServiceInfoUpdateCmd.Flags().BoolVar(&common.ServiceInfoSpec.Renew.DeleteAtExpiration, "renew-delete-at-expiration", false, "Delete service at expiration")
-	cdnServiceInfoUpdateCmd.Flags().BoolVar(&common.ServiceInfoSpec.Renew.Forced, "renew-forced", false, "Force renewal")
-	cdnServiceInfoUpdateCmd.Flags().BoolVar(&common.ServiceInfoSpec.Renew.ManualPayment, "renew-manual-payment", false, "Enable manual payment for renewal")
-	cdnServiceInfoUpdateCmd.Flags().IntVar(&common.ServiceInfoSpec.Renew.Period, "renew-period", 0, "Renewal period in months")
+	common.AddServiceInfoRenewFlags(cdnServiceInfoUpdateCmd)
 	addParameterFileFlags(cdnServiceInfoUpdateCmd, true, nil, "", "", "", nil)
 	addInteractiveEditorFlag(cdnServiceInfoUpdateCmd)
 	cdnServiceInfoCmd.AddCommand(cdnServiceInfoUpdateCmd)
@@ -1468,11 +1460,7 @@ func init() {
 		ValidArgsFunction: completion.ServiceList("/v1/hosting/web"),
 		Run:               webhosting.UpdateServiceInfo,
 	}
-	serviceInfoUpdateCmd.Flags().BoolVar(&common.ServiceInfoSpec.Renew.Automatic, "renew-automatic", false, "Enable automatic renewal")
-	serviceInfoUpdateCmd.Flags().BoolVar(&common.ServiceInfoSpec.Renew.DeleteAtExpiration, "renew-delete-at-expiration", false, "Delete service at expiration")
-	serviceInfoUpdateCmd.Flags().BoolVar(&common.ServiceInfoSpec.Renew.Forced, "renew-forced", false, "Force renewal")
-	serviceInfoUpdateCmd.Flags().BoolVar(&common.ServiceInfoSpec.Renew.ManualPayment, "renew-manual-payment", false, "Enable manual payment for renewal")
-	serviceInfoUpdateCmd.Flags().IntVar(&common.ServiceInfoSpec.Renew.Period, "renew-period", 0, "Renewal period in months")
+	common.AddServiceInfoRenewFlags(serviceInfoUpdateCmd)
 	addParameterFileFlags(serviceInfoUpdateCmd, true, nil, "", "", "", nil)
 	addInteractiveEditorFlag(serviceInfoUpdateCmd)
 	serviceInfoCmd.AddCommand(serviceInfoUpdateCmd)
@@ -1583,11 +1571,7 @@ func init() {
 		ValidArgsFunction: completion.ServiceList("/v1/hosting/web"),
 		Run:               webhosting.UpdateLocalSeoLocationServiceInfo,
 	}
-	localSeoLocationServiceInfoUpdateCmd.Flags().BoolVar(&common.ServiceInfoSpec.Renew.Automatic, "renew-automatic", false, "Enable automatic renewal")
-	localSeoLocationServiceInfoUpdateCmd.Flags().BoolVar(&common.ServiceInfoSpec.Renew.DeleteAtExpiration, "renew-delete-at-expiration", false, "Delete service at expiration")
-	localSeoLocationServiceInfoUpdateCmd.Flags().BoolVar(&common.ServiceInfoSpec.Renew.Forced, "renew-forced", false, "Force renewal")
-	localSeoLocationServiceInfoUpdateCmd.Flags().BoolVar(&common.ServiceInfoSpec.Renew.ManualPayment, "renew-manual-payment", false, "Enable manual payment for renewal")
-	localSeoLocationServiceInfoUpdateCmd.Flags().IntVar(&common.ServiceInfoSpec.Renew.Period, "renew-period", 0, "Renewal period in months")
+	common.AddServiceInfoRenewFlags(localSeoLocationServiceInfoUpdateCmd)
 	addParameterFileFlags(localSeoLocationServiceInfoUpdateCmd, true, nil, "", "", "", nil)
 	addInteractiveEditorFlag(localSeoLocationServiceInfoUpdateCmd)
 	localSeoLocationServiceInfoCmd.AddCommand(localSeoLocationServiceInfoUpdateCmd)

--- a/internal/cmd/webhosting.go
+++ b/internal/cmd/webhosting.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 
 	"github.com/ovh/ovhcloud-cli/internal/completion"
-	"github.com/ovh/ovhcloud-cli/internal/services/common"
 	"github.com/ovh/ovhcloud-cli/internal/services/webhosting"
 	"github.com/spf13/cobra"
 )
@@ -605,7 +604,7 @@ func init() {
 		ValidArgsFunction: completion.ServiceList("/v1/hosting/web"),
 		Run:               webhosting.UpdateExtraSqlServiceInfo,
 	}
-	common.AddServiceInfoRenewFlags(extraSQLServiceInfoUpdateCmd)
+	addServiceInfoRenewFlags(extraSQLServiceInfoUpdateCmd)
 	addParameterFileFlags(extraSQLServiceInfoUpdateCmd, true, nil, "", "", "", nil)
 	addInteractiveEditorFlag(extraSQLServiceInfoUpdateCmd)
 	extraSQLServiceInfoCmd.AddCommand(extraSQLServiceInfoUpdateCmd)
@@ -1326,7 +1325,7 @@ func init() {
 		ValidArgsFunction: completion.ServiceList("/v1/hosting/web"),
 		Run:               webhosting.UpdateCdnServiceInfo,
 	}
-	common.AddServiceInfoRenewFlags(cdnServiceInfoUpdateCmd)
+	addServiceInfoRenewFlags(cdnServiceInfoUpdateCmd)
 	addParameterFileFlags(cdnServiceInfoUpdateCmd, true, nil, "", "", "", nil)
 	addInteractiveEditorFlag(cdnServiceInfoUpdateCmd)
 	cdnServiceInfoCmd.AddCommand(cdnServiceInfoUpdateCmd)
@@ -1460,7 +1459,7 @@ func init() {
 		ValidArgsFunction: completion.ServiceList("/v1/hosting/web"),
 		Run:               webhosting.UpdateServiceInfo,
 	}
-	common.AddServiceInfoRenewFlags(serviceInfoUpdateCmd)
+	addServiceInfoRenewFlags(serviceInfoUpdateCmd)
 	addParameterFileFlags(serviceInfoUpdateCmd, true, nil, "", "", "", nil)
 	addInteractiveEditorFlag(serviceInfoUpdateCmd)
 	serviceInfoCmd.AddCommand(serviceInfoUpdateCmd)
@@ -1571,7 +1570,7 @@ func init() {
 		ValidArgsFunction: completion.ServiceList("/v1/hosting/web"),
 		Run:               webhosting.UpdateLocalSeoLocationServiceInfo,
 	}
-	common.AddServiceInfoRenewFlags(localSeoLocationServiceInfoUpdateCmd)
+	addServiceInfoRenewFlags(localSeoLocationServiceInfoUpdateCmd)
 	addParameterFileFlags(localSeoLocationServiceInfoUpdateCmd, true, nil, "", "", "", nil)
 	addInteractiveEditorFlag(localSeoLocationServiceInfoUpdateCmd)
 	localSeoLocationServiceInfoCmd.AddCommand(localSeoLocationServiceInfoUpdateCmd)

--- a/internal/services/common/common.go
+++ b/internal/services/common/common.go
@@ -24,20 +24,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var (
-	//go:embed templates/service_info.tmpl
-	ServiceInfoTemplate string
-
-	ServiceInfoSpec struct {
-		Renew struct {
-			Automatic          bool `json:"automatic"`
-			DeleteAtExpiration bool `json:"deleteAtExpiration"`
-			Forced             bool `json:"forced"`
-			ManualPayment      bool `json:"manualPayment"`
-			Period             int  `json:"period"`
-		} `json:"renew"`
-	}
-)
+//go:embed templates/service_info.tmpl
+var ServiceInfoTemplate string
 
 func ManageListRequest(path, idField string, columnsToDisplay, filters []string) {
 	body, err := httpLib.FetchExpandedArray(path, idField)

--- a/internal/services/common/service_info.go
+++ b/internal/services/common/service_info.go
@@ -1,0 +1,82 @@
+// SPDX-FileCopyrightText: 2025 OVH SAS <opensource@ovh.net>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package common
+
+import "github.com/spf13/cobra"
+
+// The renewal flags shared by every `service-info edit` command, paired with
+// the field each one sets in the API object.
+//
+// The registration and the payload builder live side by side on purpose: the
+// flag name is the only thing that ties them together, so a rename that
+// touches one and not the other would silently stop sending a setting rather
+// than fail to compile.
+var serviceInfoRenewFlags = []struct {
+	name  string
+	field string
+	usage string
+}{
+	{"renew-automatic", "automatic", "Renew the service automatically"},
+	{"renew-delete-at-expiration", "deleteAtExpiration", "Delete the service when it expires"},
+	{"renew-forced", "forced", "Force the renewal"},
+	{"renew-manual-payment", "manualPayment", "Pay the renewal manually"},
+	{"renew-period", "period", "Renewal period, in months"},
+}
+
+// AddServiceInfoRenewFlags registers the renewal flags on a `service-info
+// edit` command.
+func AddServiceInfoRenewFlags(cmd *cobra.Command) {
+	for _, flag := range serviceInfoRenewFlags {
+		if flag.field == "period" {
+			cmd.Flags().Int(flag.name, 0, flag.usage)
+			continue
+		}
+		cmd.Flags().Bool(flag.name, false, flag.usage)
+	}
+}
+
+// ServiceInfoRenewPayload returns the renewal settings the operator actually
+// asked to change, and nothing else.
+//
+// The distinction matters more than it looks. These settings are booleans
+// bound to a struct with no `omitempty`, so building the payload from that
+// struct sends every one of them on every call — and a merge that lets the
+// command line win then turns `--renew-period 12` into "set the period to 12
+// AND switch automatic renewal off". The service kept renewing itself for
+// years; one unrelated edit stopped it, and nothing said so.
+//
+// Reading `Changed` rather than the values also keeps `--renew-automatic=false`
+// working: pflag records a flag as changed whatever value it was given, so an
+// explicit false is sent while an absent flag stays absent.
+func ServiceInfoRenewPayload(cmd *cobra.Command) map[string]any {
+	renew := map[string]any{}
+
+	for _, flag := range serviceInfoRenewFlags {
+		if !cmd.Flags().Changed(flag.name) {
+			continue
+		}
+
+		if flag.field == "period" {
+			period, err := cmd.Flags().GetInt(flag.name)
+			if err != nil {
+				continue
+			}
+			renew[flag.field] = period
+			continue
+		}
+
+		value, err := cmd.Flags().GetBool(flag.name)
+		if err != nil {
+			continue
+		}
+		renew[flag.field] = value
+	}
+
+	if len(renew) == 0 {
+		return map[string]any{}
+	}
+
+	return map[string]any{"renew": renew}
+}

--- a/internal/services/common/service_info.go
+++ b/internal/services/common/service_info.go
@@ -6,35 +6,31 @@ package common
 
 import "github.com/spf13/cobra"
 
-// The renewal flags shared by every `service-info edit` command, paired with
-// the field each one sets in the API object.
-//
-// The registration and the payload builder live side by side on purpose: the
-// flag name is the only thing that ties them together, so a rename that
-// touches one and not the other would silently stop sending a setting rather
-// than fail to compile.
-var serviceInfoRenewFlags = []struct {
-	name  string
-	field string
-	usage string
-}{
-	{"renew-automatic", "automatic", "Renew the service automatically"},
-	{"renew-delete-at-expiration", "deleteAtExpiration", "Delete the service when it expires"},
-	{"renew-forced", "forced", "Force the renewal"},
-	{"renew-manual-payment", "manualPayment", "Pay the renewal manually"},
-	{"renew-period", "period", "Renewal period, in months"},
+// ServiceInfoRenewFlag describes one renewal flag: what it is called on the
+// command line, and which field of the API object it sets.
+type ServiceInfoRenewFlag struct {
+	Name  string
+	Field string
+	Usage string
+
+	// Period is the one flag that carries a number rather than a yes or no.
+	Period bool
 }
 
-// AddServiceInfoRenewFlags registers the renewal flags on a `service-info
-// edit` command.
-func AddServiceInfoRenewFlags(cmd *cobra.Command) {
-	for _, flag := range serviceInfoRenewFlags {
-		if flag.field == "period" {
-			cmd.Flags().Int(flag.name, 0, flag.usage)
-			continue
-		}
-		cmd.Flags().Bool(flag.name, false, flag.usage)
-	}
+// ServiceInfoRenewFlags is the single description of the renewal flags shared
+// by every `service-info edit` command.
+//
+// It is exported rather than kept private because the command layer registers
+// the flags and this layer reads them back: the flag name is the only thing
+// tying the two halves together, so they must not each hold their own copy of
+// it. One table, read twice — a rename in it changes both sides at once, and a
+// rename anywhere else does not compile.
+var ServiceInfoRenewFlags = []ServiceInfoRenewFlag{
+	{Name: "renew-automatic", Field: "automatic", Usage: "Renew the service automatically"},
+	{Name: "renew-delete-at-expiration", Field: "deleteAtExpiration", Usage: "Delete the service when it expires"},
+	{Name: "renew-forced", Field: "forced", Usage: "Force the renewal"},
+	{Name: "renew-manual-payment", Field: "manualPayment", Usage: "Pay the renewal manually"},
+	{Name: "renew-period", Field: "period", Usage: "Renewal period, in months", Period: true},
 }
 
 // ServiceInfoRenewPayload returns the renewal settings the operator actually
@@ -53,25 +49,25 @@ func AddServiceInfoRenewFlags(cmd *cobra.Command) {
 func ServiceInfoRenewPayload(cmd *cobra.Command) map[string]any {
 	renew := map[string]any{}
 
-	for _, flag := range serviceInfoRenewFlags {
-		if !cmd.Flags().Changed(flag.name) {
+	for _, flag := range ServiceInfoRenewFlags {
+		if !cmd.Flags().Changed(flag.Name) {
 			continue
 		}
 
-		if flag.field == "period" {
-			period, err := cmd.Flags().GetInt(flag.name)
+		if flag.Period {
+			period, err := cmd.Flags().GetInt(flag.Name)
 			if err != nil {
 				continue
 			}
-			renew[flag.field] = period
+			renew[flag.Field] = period
 			continue
 		}
 
-		value, err := cmd.Flags().GetBool(flag.name)
+		value, err := cmd.Flags().GetBool(flag.Name)
 		if err != nil {
 			continue
 		}
-		renew[flag.field] = value
+		renew[flag.Field] = value
 	}
 
 	if len(renew) == 0 {

--- a/internal/services/vps/vps.go
+++ b/internal/services/vps/vps.go
@@ -310,11 +310,13 @@ func GetVpsServiceInfo(_ *cobra.Command, args []string) {
 }
 
 func EditVpsServiceInfo(cmd *cobra.Command, args []string) {
+	renewPayload := common.ServiceInfoRenewPayload(cmd)
+
 	if err := common.EditResource(
 		cmd,
 		"/vps/{serviceName}/serviceInfos",
 		fmt.Sprintf("/v1/vps/%s/serviceInfos", url.PathEscape(args[0])),
-		common.ServiceInfoSpec,
+		renewPayload,
 		assets.VpsOpenapiSchema,
 	); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "%s", err)

--- a/internal/services/webhosting/webhosting.go
+++ b/internal/services/webhosting/webhosting.go
@@ -940,7 +940,7 @@ func GetExtraSqlServiceInfo(_ *cobra.Command, args []string) {
 }
 
 func UpdateExtraSqlServiceInfo(cmd *cobra.Command, args []string) {
-	payload := buildServiceInfoRenewPayload(cmd)
+	payload := common.ServiceInfoRenewPayload(cmd)
 	if len(payload) == 0 && !flags.ParametersViaEditor && flags.ParametersFile == "" {
 		display.OutputInfo(&flags.OutputFormatConfig, nil, "🟠 No parameters given, nothing to edit")
 		return
@@ -2532,7 +2532,7 @@ func GetCdnServiceInfo(_ *cobra.Command, args []string) {
 }
 
 func UpdateCdnServiceInfo(cmd *cobra.Command, args []string) {
-	payload := buildServiceInfoRenewPayload(cmd)
+	payload := common.ServiceInfoRenewPayload(cmd)
 	if len(payload) == 0 && !flags.ParametersViaEditor && flags.ParametersFile == "" {
 		display.OutputInfo(&flags.OutputFormatConfig, nil, "🟠 No parameters given, nothing to edit")
 		return
@@ -2733,31 +2733,6 @@ func buildCdnOptionConfig(cmd *cobra.Command) map[string]any {
 	}
 
 	return config
-}
-
-func buildServiceInfoRenewPayload(cmd *cobra.Command) map[string]any {
-	renew := map[string]any{}
-	if cmd.Flags().Changed("renew-automatic") {
-		renew["automatic"] = common.ServiceInfoSpec.Renew.Automatic
-	}
-	if cmd.Flags().Changed("renew-delete-at-expiration") {
-		renew["deleteAtExpiration"] = common.ServiceInfoSpec.Renew.DeleteAtExpiration
-	}
-	if cmd.Flags().Changed("renew-forced") {
-		renew["forced"] = common.ServiceInfoSpec.Renew.Forced
-	}
-	if cmd.Flags().Changed("renew-manual-payment") {
-		renew["manualPayment"] = common.ServiceInfoSpec.Renew.ManualPayment
-	}
-	if cmd.Flags().Changed("renew-period") {
-		renew["period"] = common.ServiceInfoSpec.Renew.Period
-	}
-
-	if len(renew) == 0 {
-		return map[string]any{}
-	}
-
-	return map[string]any{"renew": renew}
 }
 
 func formatQuota(value any) (string, bool) {
@@ -2980,7 +2955,7 @@ func GetServiceInfo(_ *cobra.Command, args []string) {
 }
 
 func UpdateServiceInfo(cmd *cobra.Command, args []string) {
-	payload := buildServiceInfoRenewPayload(cmd)
+	payload := common.ServiceInfoRenewPayload(cmd)
 	if len(payload) == 0 && !flags.ParametersViaEditor && flags.ParametersFile == "" && !utils.IsInputFromPipe() {
 		display.OutputInfo(&flags.OutputFormatConfig, nil, "🟠 No parameters given, nothing to edit")
 		return
@@ -3240,7 +3215,7 @@ func GetLocalSeoLocationServiceInfo(_ *cobra.Command, args []string) {
 }
 
 func UpdateLocalSeoLocationServiceInfo(cmd *cobra.Command, args []string) {
-	payload := buildServiceInfoRenewPayload(cmd)
+	payload := common.ServiceInfoRenewPayload(cmd)
 	if len(payload) == 0 && !flags.ParametersViaEditor && flags.ParametersFile == "" {
 		display.OutputInfo(&flags.OutputFormatConfig, nil, "🟠 No parameters given, nothing to edit")
 		return


### PR DESCRIPTION
# Description

`vps service-info edit myvps --renew-period 12` sends this today:

```json
{"renew":{"automatic":false,"deleteAtExpiration":false,"forced":false,
          "manualPayment":false,"period":12}}
```

The API had `automatic: true`. The operator asked for a renewal period and also
switched automatic renewal off, on a service that had been renewing itself for
years. Nothing in the output said so.

The cause is that the renewal settings are booleans bound to a shared struct
with no `omitempty`, so all five are marshalled at their zero value, and
`MergeMaps` lets the command line win over the fetched resource.

Measured with an httpmock probe against the existing command, not deduced.

## Where the fix comes from

Webhosting already did it right: `buildServiceInfoRenewPayload` builds the body
from `cmd.Flags().Changed`, so it only ever sends what was asked for. This
promotes that builder into `common` and routes `vps` through it, so the four
webhosting commands and the VPS one now share a single implementation.

Reading `Changed` rather than the values matters for the other half of the
problem: pflag records a flag as changed whatever value it was given, so
`--renew-automatic=false` is still sent while an absent flag stays absent.
Adding `omitempty` would have fixed the first case and broken the second.

The shared mutable `common.ServiceInfoSpec` goes away with the last thing that
read it. The five flag registrations repeated across four commands become one
call, which also settles the two spellings of the period's help text — hence
the five regenerated documentation pages.

## Tests

Two, both checked against the failure they exist to catch:

- editing the period leaves `automatic` untouched — reintroducing the original
  bug fails this one and only this one;
- `--renew-automatic=false` is sent — simulating `omitempty` fails this one and
  only this one.

## Note for whoever merges

PR #235 adds an AST guard requiring `EditResource` call sites to pass a pointer.
A body already built from `Changed()` is a documented exception there, and the
entry for this one has been added to #235 already, so **either merge order is
green**. Verified by merging the two branches locally and running the guard.

# Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have commented my code
- [X] I ran `go mod tidy`
- [X] I have added tests that prove my fix is effective
