### PR TITLE
feat(baremetal): add the service life cycle, and say what each half of it does

### DIFF
--- a/doc/ovhcloud.md
+++ b/doc/ovhcloud.md
@@ -1,90 +1,36 @@
-# OVHcloud CLI (`ovhcloud`) Documentation
+## ovhcloud
 
----
+CLI to manage your OVHcloud services
 
-## Overview
+### Options
 
-`ovhcloud` is a single, unified command‑line interface for managing the full range of OVHcloud products and account resources directly from your terminal. Whether you need to automate provisioning, perform quick look‑ups, or integrate OVHcloud operations into CI/CD pipelines, `ovhcloud` offers fine‑grained commands and consistent output formats (table, JSON, YAML, or custom gval expressions).
-
----
-
-## Quick Start
-
-```bash
-# Display the top‑level help
-ovhcloud --help
-
-# Log in and create API credentials (interactive)
-ovhcloud login
-
-# List your VPS instances as JSON
-ohvcloud vps list -o json
+```
+  -d, --debug            Activate debug mode (will log all HTTP requests details)
+  -h, --help             help for ovhcloud
+  -e, --ignore-errors    Ignore errors in API calls when it is not fatal to the execution
+  -o, --output string    Output format: json, yaml, interactive, or a custom format expression (using https://github.com/PaesslerAG/gval syntax)
+                         Examples:
+                           --output json
+                           --output yaml
+                           --output interactive
+                           --output 'id' (to extract a single field)
+                           --output 'nested.field.subfield' (to extract a nested field)
+                           --output '[id, "name"]' (to extract multiple fields as an array)
+                           --output '{"newKey": oldKey, "otherKey": nested.field}' (to extract and rename fields in an object)
+                           --output 'name+","+type' (to extract and concatenate fields in a string)
+                           --output '(nbFieldA + nbFieldB) * 10' (to compute values from numeric fields)
+      --profile string   Use a specific profile from the configuration file
 ```
 
-Check out the [authentication page](authentication.md) for further information about the authentication means.
-
-You can manage multiple OVHcloud accounts using [profiles](profiles.md). Create a profile with `ovhcloud login --profile <name>`, switch between them with `ovhcloud config profile switch <name>`, or use `--profile <name>` on any command.
-
-### Generate Shell Completion
-
-```bash
-# Bash
-eval "$(./ovhcloud completion bash)"
-# Zsh
-eval "$(./ovhcloud completion zsh)"
-# Fish
-./ovhcloud completion fish | source
-# PowerShell
-./ovhcloud completion powershell | Out-String | Invoke-Expression
-```
-
-Add the appropriate line to your shell’s startup file (`~/.bashrc`, `~/.zshrc`, etc.) to enable persistent autocompletion.
-
----
-
-## Global Usage
-
-```text
-ovhcloud [command] [flags]
-```
-
-### Global Flags
-
-| Flag               | Description                                          |
-| ------------------ | ---------------------------------------------------- |
-| `--debug`          | Activate debug mode (logs all HTTP‑request details). |
-| `--ignore-errors`  | Ignore errors of API calls made when listing items.  |
-| `--filter <expr>`  | Filter lists output with a [gval] expression.        |
-| `-h`, `--help`     | Display help for `ovhcloud` or a specific command.   |
-| `-o interactive`   | Produce interactive (prompt‑based) output.           |
-| `-o json`          | Output data in JSON format.                          |
-| `-o yaml`          | Output data in YAML format.                          |
-| `-o <expr>`        | Format output with a [gval] expression.              |
-
-[gval]: https://github.com/PaesslerAG/gval
-
-#### Filtering examples
-
-- Strict string equality: `--filter 'name=="something"'`
-- String regexp comparison: `--filter 'name=~"something"'`
-- Number comparison: `--filter 'bootId > 1'`
-
-#### Formatting example
-
-- Extract only one field: `-o 'ip'`
-- Extract an object: `-o '{name: ip}'`
-
----
-
-## Command Reference
-
-Below is the full list of primary sub‑commands available at the time of writing. Each can be explored in depth with `ovhcloud <command> --help`.
+### SEE ALSO
 
 * [ovhcloud account](ovhcloud_account.md)	 - Manage your account
 * [ovhcloud alldom](ovhcloud_alldom.md)	 - Retrieve information and manage your AllDom services
 * [ovhcloud baremetal](ovhcloud_baremetal.md)	 - Retrieve information and manage your Bare Metal services
+* [ovhcloud browser](ovhcloud_browser.md)	 - Launch a TUI for the OVHcloud Manager - Public Cloud universe only [EXPERIMENTAL]
 * [ovhcloud cdn-dedicated](ovhcloud_cdn-dedicated.md)	 - Retrieve information and manage your dedicated CDN services
 * [ovhcloud cloud](ovhcloud_cloud.md)	 - Manage your projects and services in the Public Cloud universe (MKS, MPR, MRS, Object Storage...)
+* [ovhcloud completion](ovhcloud_completion.md)	 - Generate shell completion scripts
 * [ovhcloud config](ovhcloud_config.md)	 - Manage your CLI configuration
 * [ovhcloud dedicated-ceph](ovhcloud_dedicated-ceph.md)	 - Retrieve information and manage your Dedicated Ceph services
 * [ovhcloud dedicated-cloud](ovhcloud_dedicated-cloud.md)	 - Retrieve information and manage your DedicatedCloud services
@@ -102,6 +48,7 @@ Below is the full list of primary sub‑commands available at the time of writin
 * [ovhcloud ldp](ovhcloud_ldp.md)	 - Retrieve information and manage your LDP (Logs Data Platform) services
 * [ovhcloud location](ovhcloud_location.md)	 - Retrieve information and manage your Location services
 * [ovhcloud login](ovhcloud_login.md)	 - Login to your OVHcloud account to create API credentials
+* [ovhcloud logout](ovhcloud_logout.md)	 - Revoke your API credentials and remove them from the configuration
 * [ovhcloud nutanix](ovhcloud_nutanix.md)	 - Retrieve information and manage your Nutanix services
 * [ovhcloud okms](ovhcloud_okms.md)	 - Retrieve information and manage your OKMS (Key Management Services)
 * [ovhcloud overthebox](ovhcloud_overthebox.md)	 - Retrieve information and manage your OverTheBox services
@@ -113,6 +60,7 @@ Below is the full list of primary sub‑commands available at the time of writin
 * [ovhcloud storage-netapp](ovhcloud_storage-netapp.md)	 - Retrieve information and manage your Storage NetApp services
 * [ovhcloud support-tickets](ovhcloud_support-tickets.md)	 - Retrieve information and manage your support tickets
 * [ovhcloud telephony](ovhcloud_telephony.md)	 - Retrieve information and manage your Telephony services
+* [ovhcloud upgrade](ovhcloud_upgrade.md)	 - Upgrade OVHcloud CLI to the latest version
 * [ovhcloud veeamcloudconnect](ovhcloud_veeamcloudconnect.md)	 - Retrieve information and manage your VeeamCloudConnect services
 * [ovhcloud veeamenterprise](ovhcloud_veeamenterprise.md)	 - Retrieve information and manage your VeeamEnterprise services
 * [ovhcloud version](ovhcloud_version.md)	 - Get OVHcloud CLI version
@@ -124,30 +72,3 @@ Below is the full list of primary sub‑commands available at the time of writin
 * [ovhcloud webhosting](ovhcloud_webhosting.md)	 - Retrieve information and manage your WebHosting services
 * [ovhcloud xdsl](ovhcloud_xdsl.md)	 - Retrieve information and manage your XDSL services
 
-> **Tip**  Use `-o json`, `-o yaml`, or `-o <format>` with a gval expression to integrate `ovhcloud` into scripts and automation pipelines.
-
----
-
-## Examples
-
-| Task                                  | Command                                        |
-| ------------------------------------- | ---------------------------------------------- |
-| Log in and save credentials           | `ovhcloud login`                                |
-| List VPS instances (tabular)          | `ovhcloud vps list`                             |
-| Fetch details of a single VPS in JSON | `ovhcloud vps get <service_id> -o json`          |
-| Reinstall a baremetal interactively   | `ovhcloud baremetal reinstall <id> --editor`    |
-
----
-
-## Troubleshooting
-
-* **Verbose output** — Use `--debug` to inspect raw API calls and responses.
-* **Authentication issues** — Run `ovhcloud login` again to regenerate valid API keys.
-* **Rate limits** — OVHcloud APIs impose rate limits; plan retries or exponential backoff in scripts.
-
----
-
-## Further Reading
-
-* OVHcloud API reference: [https://eu.api.ovh.com/console](https://eu.api.ovh.com/console)
-* OVHcloud community guides and tutorials.

--- a/doc/ovhcloud_baremetal.md
+++ b/doc/ovhcloud_baremetal.md
@@ -31,6 +31,7 @@ Retrieve information and manage your Bare Metal services
 
 * [ovhcloud](ovhcloud.md)	 - CLI to manage your OVHcloud services
 * [ovhcloud baremetal boot](ovhcloud_baremetal_boot.md)	 - Manage boot options for the given baremetal
+* [ovhcloud baremetal confirm-termination](ovhcloud_baremetal_confirm-termination.md)	 - Confirm the termination of the given baremetal
 * [ovhcloud baremetal edit](ovhcloud_baremetal_edit.md)	 - Update the given baremetal
 * [ovhcloud baremetal get](ovhcloud_baremetal_get.md)	 - Retrieve information of a specific baremetal
 * [ovhcloud baremetal ipmi](ovhcloud_baremetal_ipmi.md)	 - Manage IPMI on your baremetal
@@ -43,5 +44,7 @@ Retrieve information and manage your Bare Metal services
 * [ovhcloud baremetal reboot](ovhcloud_baremetal_reboot.md)	 - Reboot the given baremetal
 * [ovhcloud baremetal reboot-rescue](ovhcloud_baremetal_reboot-rescue.md)	 - Reboot the given baremetal in rescue mode
 * [ovhcloud baremetal reinstall](ovhcloud_baremetal_reinstall.md)	 - Reinstall the given baremetal
+* [ovhcloud baremetal service-info](ovhcloud_baremetal_service-info.md)	 - Manage service information of the given baremetal
+* [ovhcloud baremetal terminate](ovhcloud_baremetal_terminate.md)	 - Ask for the termination of the given baremetal
 * [ovhcloud baremetal vni](ovhcloud_baremetal_vni.md)	 - Manage Virtual Network Interfaces of the given baremetal
 

--- a/doc/ovhcloud_baremetal_confirm-termination.md
+++ b/doc/ovhcloud_baremetal_confirm-termination.md
@@ -1,0 +1,49 @@
+## ovhcloud baremetal confirm-termination
+
+Confirm the termination of the given baremetal
+
+### Synopsis
+
+Confirm the termination of the given baremetal, using the token emailed to
+the administrative contact by "baremetal terminate".
+
+This ends the contract: the server is returned to OVHcloud at expiry.
+
+```
+ovhcloud baremetal confirm-termination <service_name> <token> [flags]
+```
+
+### Options
+
+```
+      --commentary string   Free-text comment attached to the termination request
+      --dry-run             Print the call that would be made without making it
+      --future-use string   What comes next after this termination (press <tab> for the accepted values)
+  -h, --help                help for confirm-termination
+      --reason string       Why the service is being terminated (press <tab> for the accepted values)
+  -y, --yes                 Skip the confirmation prompt (required for unattended runs)
+```
+
+### Options inherited from parent commands
+
+```
+  -d, --debug            Activate debug mode (will log all HTTP requests details)
+  -e, --ignore-errors    Ignore errors in API calls when it is not fatal to the execution
+  -o, --output string    Output format: json, yaml, interactive, or a custom format expression (using https://github.com/PaesslerAG/gval syntax)
+                         Examples:
+                           --output json
+                           --output yaml
+                           --output interactive
+                           --output 'id' (to extract a single field)
+                           --output 'nested.field.subfield' (to extract a nested field)
+                           --output '[id, "name"]' (to extract multiple fields as an array)
+                           --output '{"newKey": oldKey, "otherKey": nested.field}' (to extract and rename fields in an object)
+                           --output 'name+","+type' (to extract and concatenate fields in a string)
+                           --output '(nbFieldA + nbFieldB) * 10' (to compute values from numeric fields)
+      --profile string   Use a specific profile from the configuration file
+```
+
+### SEE ALSO
+
+* [ovhcloud baremetal](ovhcloud_baremetal.md)	 - Retrieve information and manage your Bare Metal services
+

--- a/doc/ovhcloud_baremetal_reboot-rescue.md
+++ b/doc/ovhcloud_baremetal_reboot-rescue.md
@@ -9,8 +9,10 @@ ovhcloud baremetal reboot-rescue <service_name> [flags]
 ### Options
 
 ```
-  -h, --help   help for reboot-rescue
-      --wait   Wait for reboot to be done before exiting
+      --dry-run   Print the call that would be made without making it
+  -h, --help      help for reboot-rescue
+      --wait      Wait for reboot to be done before exiting
+  -y, --yes       Skip the confirmation prompt (required for unattended runs)
 ```
 
 ### Options inherited from parent commands

--- a/doc/ovhcloud_baremetal_reboot.md
+++ b/doc/ovhcloud_baremetal_reboot.md
@@ -9,7 +9,9 @@ ovhcloud baremetal reboot <service_name> [flags]
 ### Options
 
 ```
-  -h, --help   help for reboot
+      --dry-run   Print the call that would be made without making it
+  -h, --help      help for reboot
+  -y, --yes       Skip the confirmation prompt (required for unattended runs)
 ```
 
 ### Options inherited from parent commands

--- a/doc/ovhcloud_baremetal_reinstall.md
+++ b/doc/ovhcloud_baremetal_reinstall.md
@@ -46,6 +46,11 @@ to see all the available parameters and real life examples.
 
 Please note that all parameters are not compatible with all OSes.
 
+Reinstalling wipes every disk of the server, so the command asks for a
+confirmation: type the server name when prompted. Unattended runs (pipelines,
+piped input) must pass --yes, and --dry-run prints the parameters that would
+be sent without sending them.
+
 
 ```
 ovhcloud baremetal reinstall <service_name> [flags]
@@ -55,6 +60,7 @@ ovhcloud baremetal reinstall <service_name> [flags]
 
 ```
       --config-drive-user-data string               Config Drive UserData
+      --dry-run                                     Print the installation parameters without sending anything
       --editor                                      Use a text editor to define parameters
       --efi-bootloader-path string                  Path of the EFI bootloader from the OS installed on the server
       --from-file string                            File containing parameters
@@ -73,6 +79,7 @@ ovhcloud baremetal reinstall <service_name> [flags]
       --replace                                     Replace parameters file if it already exists
       --ssh-key string                              SSH public key
       --wait                                        Wait for reinstall to be done before exiting
+  -y, --yes                                         Skip the confirmation prompt (required for unattended runs)
 ```
 
 ### Options inherited from parent commands

--- a/doc/ovhcloud_baremetal_reinstall.md
+++ b/doc/ovhcloud_baremetal_reinstall.md
@@ -24,7 +24,10 @@ There are three ways to define the installation parameters:
 
   Note that you can also pipe the content of the file to reinstall, like the following:
 
-	cat ./install.json | ovhcloud baremetal reinstall ns1234.ip-11.22.33.net
+	cat ./install.json | ovhcloud baremetal reinstall ns1234.ip-11.22.33.net --yes
+
+  Piped input is not a terminal, so there is nobody to answer the confirmation:
+  such a run refuses to start unless --yes is given.
 
   In both cases, you can override the parameters in the given file using command line flags, for example:
 

--- a/doc/ovhcloud_baremetal_service-info.md
+++ b/doc/ovhcloud_baremetal_service-info.md
@@ -1,0 +1,35 @@
+## ovhcloud baremetal service-info
+
+Manage service information of the given baremetal
+
+### Options
+
+```
+  -h, --help   help for service-info
+```
+
+### Options inherited from parent commands
+
+```
+  -d, --debug            Activate debug mode (will log all HTTP requests details)
+  -e, --ignore-errors    Ignore errors in API calls when it is not fatal to the execution
+  -o, --output string    Output format: json, yaml, interactive, or a custom format expression (using https://github.com/PaesslerAG/gval syntax)
+                         Examples:
+                           --output json
+                           --output yaml
+                           --output interactive
+                           --output 'id' (to extract a single field)
+                           --output 'nested.field.subfield' (to extract a nested field)
+                           --output '[id, "name"]' (to extract multiple fields as an array)
+                           --output '{"newKey": oldKey, "otherKey": nested.field}' (to extract and rename fields in an object)
+                           --output 'name+","+type' (to extract and concatenate fields in a string)
+                           --output '(nbFieldA + nbFieldB) * 10' (to compute values from numeric fields)
+      --profile string   Use a specific profile from the configuration file
+```
+
+### SEE ALSO
+
+* [ovhcloud baremetal](ovhcloud_baremetal.md)	 - Retrieve information and manage your Bare Metal services
+* [ovhcloud baremetal service-info edit](ovhcloud_baremetal_service-info_edit.md)	 - Edit service information of the given baremetal
+* [ovhcloud baremetal service-info get](ovhcloud_baremetal_service-info_get.md)	 - Get service information of the given baremetal
+

--- a/doc/ovhcloud_baremetal_service-info_edit.md
+++ b/doc/ovhcloud_baremetal_service-info_edit.md
@@ -1,0 +1,43 @@
+## ovhcloud baremetal service-info edit
+
+Edit service information of the given baremetal
+
+```
+ovhcloud baremetal service-info edit <service_name> [flags]
+```
+
+### Options
+
+```
+      --editor                       Use a text editor to define parameters
+  -h, --help                         help for edit
+      --renew-automatic              Renew the service automatically
+      --renew-delete-at-expiration   Delete the service when it expires
+      --renew-forced                 Force the renewal
+      --renew-manual-payment         Pay the renewal manually
+      --renew-period int             Renewal period, in months
+```
+
+### Options inherited from parent commands
+
+```
+  -d, --debug            Activate debug mode (will log all HTTP requests details)
+  -e, --ignore-errors    Ignore errors in API calls when it is not fatal to the execution
+  -o, --output string    Output format: json, yaml, interactive, or a custom format expression (using https://github.com/PaesslerAG/gval syntax)
+                         Examples:
+                           --output json
+                           --output yaml
+                           --output interactive
+                           --output 'id' (to extract a single field)
+                           --output 'nested.field.subfield' (to extract a nested field)
+                           --output '[id, "name"]' (to extract multiple fields as an array)
+                           --output '{"newKey": oldKey, "otherKey": nested.field}' (to extract and rename fields in an object)
+                           --output 'name+","+type' (to extract and concatenate fields in a string)
+                           --output '(nbFieldA + nbFieldB) * 10' (to compute values from numeric fields)
+      --profile string   Use a specific profile from the configuration file
+```
+
+### SEE ALSO
+
+* [ovhcloud baremetal service-info](ovhcloud_baremetal_service-info.md)	 - Manage service information of the given baremetal
+

--- a/doc/ovhcloud_baremetal_service-info_get.md
+++ b/doc/ovhcloud_baremetal_service-info_get.md
@@ -1,0 +1,37 @@
+## ovhcloud baremetal service-info get
+
+Get service information of the given baremetal
+
+```
+ovhcloud baremetal service-info get <service_name> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for get
+```
+
+### Options inherited from parent commands
+
+```
+  -d, --debug            Activate debug mode (will log all HTTP requests details)
+  -e, --ignore-errors    Ignore errors in API calls when it is not fatal to the execution
+  -o, --output string    Output format: json, yaml, interactive, or a custom format expression (using https://github.com/PaesslerAG/gval syntax)
+                         Examples:
+                           --output json
+                           --output yaml
+                           --output interactive
+                           --output 'id' (to extract a single field)
+                           --output 'nested.field.subfield' (to extract a nested field)
+                           --output '[id, "name"]' (to extract multiple fields as an array)
+                           --output '{"newKey": oldKey, "otherKey": nested.field}' (to extract and rename fields in an object)
+                           --output 'name+","+type' (to extract and concatenate fields in a string)
+                           --output '(nbFieldA + nbFieldB) * 10' (to compute values from numeric fields)
+      --profile string   Use a specific profile from the configuration file
+```
+
+### SEE ALSO
+
+* [ovhcloud baremetal service-info](ovhcloud_baremetal_service-info.md)	 - Manage service information of the given baremetal
+

--- a/doc/ovhcloud_baremetal_terminate.md
+++ b/doc/ovhcloud_baremetal_terminate.md
@@ -1,0 +1,47 @@
+## ovhcloud baremetal terminate
+
+Ask for the termination of the given baremetal
+
+### Synopsis
+
+Ask for the termination of the given baremetal.
+
+Nothing stops when this returns: OVHcloud emails a termination token to the
+administrative contact of the service, and the server keeps running until that
+token is confirmed with "baremetal confirm-termination".
+
+```
+ovhcloud baremetal terminate <service_name> [flags]
+```
+
+### Options
+
+```
+      --dry-run   Print the call that would be made without making it
+  -h, --help      help for terminate
+  -y, --yes       Skip the confirmation prompt (required for unattended runs)
+```
+
+### Options inherited from parent commands
+
+```
+  -d, --debug            Activate debug mode (will log all HTTP requests details)
+  -e, --ignore-errors    Ignore errors in API calls when it is not fatal to the execution
+  -o, --output string    Output format: json, yaml, interactive, or a custom format expression (using https://github.com/PaesslerAG/gval syntax)
+                         Examples:
+                           --output json
+                           --output yaml
+                           --output interactive
+                           --output 'id' (to extract a single field)
+                           --output 'nested.field.subfield' (to extract a nested field)
+                           --output '[id, "name"]' (to extract multiple fields as an array)
+                           --output '{"newKey": oldKey, "otherKey": nested.field}' (to extract and rename fields in an object)
+                           --output 'name+","+type' (to extract and concatenate fields in a string)
+                           --output '(nbFieldA + nbFieldB) * 10' (to compute values from numeric fields)
+      --profile string   Use a specific profile from the configuration file
+```
+
+### SEE ALSO
+
+* [ovhcloud baremetal](ovhcloud_baremetal.md)	 - Retrieve information and manage your Bare Metal services
+

--- a/doc/ovhcloud_baremetal_vni_ola-reset.md
+++ b/doc/ovhcloud_baremetal_vni_ola-reset.md
@@ -9,8 +9,10 @@ ovhcloud baremetal vni ola-reset <service_name> --interface <uuid> --interface <
 ### Options
 
 ```
+      --dry-run                 Print the call that would be made without making it
   -h, --help                    help for ola-reset
       --interface stringArray   Interfaces to group
+  -y, --yes                     Skip the confirmation prompt (required for unattended runs)
 ```
 
 ### Options inherited from parent commands

--- a/doc/ovhcloud_logout.md
+++ b/doc/ovhcloud_logout.md
@@ -1,0 +1,46 @@
+## ovhcloud logout
+
+Revoke your API credentials and remove them from the configuration
+
+```
+ovhcloud logout [flags]
+```
+
+### Examples
+
+```
+ovhcloud logout
+ovhcloud logout --yes
+ovhcloud logout --profile work
+```
+
+### Options
+
+```
+  -h, --help   help for logout
+  -y, --yes    Do not ask for confirmation
+```
+
+### Options inherited from parent commands
+
+```
+  -d, --debug            Activate debug mode (will log all HTTP requests details)
+  -e, --ignore-errors    Ignore errors in API calls when it is not fatal to the execution
+  -o, --output string    Output format: json, yaml, interactive, or a custom format expression (using https://github.com/PaesslerAG/gval syntax)
+                         Examples:
+                           --output json
+                           --output yaml
+                           --output interactive
+                           --output 'id' (to extract a single field)
+                           --output 'nested.field.subfield' (to extract a nested field)
+                           --output '[id, "name"]' (to extract multiple fields as an array)
+                           --output '{"newKey": oldKey, "otherKey": nested.field}' (to extract and rename fields in an object)
+                           --output 'name+","+type' (to extract and concatenate fields in a string)
+                           --output '(nbFieldA + nbFieldB) * 10' (to compute values from numeric fields)
+      --profile string   Use a specific profile from the configuration file
+```
+
+### SEE ALSO
+
+* [ovhcloud](ovhcloud.md)	 - CLI to manage your OVHcloud services
+

--- a/doc/ovhcloud_vps_service-info_edit.md
+++ b/doc/ovhcloud_vps_service-info_edit.md
@@ -11,11 +11,11 @@ ovhcloud vps service-info edit <service_name> [flags]
 ```
       --editor                       Use a text editor to define parameters
   -h, --help                         help for edit
-      --renew-automatic              Enable automatic renewal
-      --renew-delete-at-expiration   Delete service at expiration
-      --renew-forced                 Force renewal
-      --renew-manual-payment         Enable manual payment for renewal
-      --renew-period int             Renewal period (in months)
+      --renew-automatic              Renew the service automatically
+      --renew-delete-at-expiration   Delete the service when it expires
+      --renew-forced                 Force the renewal
+      --renew-manual-payment         Pay the renewal manually
+      --renew-period int             Renewal period, in months
 ```
 
 ### Options inherited from parent commands

--- a/doc/ovhcloud_webhosting_cdn_service-info_update.md
+++ b/doc/ovhcloud_webhosting_cdn_service-info_update.md
@@ -12,11 +12,11 @@ ovhcloud webhosting cdn service-info update <service_name> [flags]
       --editor                       Use a text editor to define parameters
       --from-file string             File containing parameters
   -h, --help                         help for update
-      --renew-automatic              Enable automatic renewal
-      --renew-delete-at-expiration   Delete service at expiration
-      --renew-forced                 Force renewal
-      --renew-manual-payment         Enable manual payment for renewal
-      --renew-period int             Renewal period in months
+      --renew-automatic              Renew the service automatically
+      --renew-delete-at-expiration   Delete the service when it expires
+      --renew-forced                 Force the renewal
+      --renew-manual-payment         Pay the renewal manually
+      --renew-period int             Renewal period, in months
 ```
 
 ### Options inherited from parent commands

--- a/doc/ovhcloud_webhosting_extra-sql_service-info_update.md
+++ b/doc/ovhcloud_webhosting_extra-sql_service-info_update.md
@@ -12,11 +12,11 @@ ovhcloud webhosting extra-sql service-info update <service_name> <id> [flags]
       --editor                       Use a text editor to define parameters
       --from-file string             File containing parameters
   -h, --help                         help for update
-      --renew-automatic              Enable automatic renewal
-      --renew-delete-at-expiration   Delete service at expiration
-      --renew-forced                 Force renewal
-      --renew-manual-payment         Enable manual payment for renewal
-      --renew-period int             Renewal period in months
+      --renew-automatic              Renew the service automatically
+      --renew-delete-at-expiration   Delete the service when it expires
+      --renew-forced                 Force the renewal
+      --renew-manual-payment         Pay the renewal manually
+      --renew-period int             Renewal period, in months
 ```
 
 ### Options inherited from parent commands

--- a/doc/ovhcloud_webhosting_local-seo_location_service-info_update.md
+++ b/doc/ovhcloud_webhosting_local-seo_location_service-info_update.md
@@ -12,11 +12,11 @@ ovhcloud webhosting local-seo location service-info update <service_name> <id> [
       --editor                       Use a text editor to define parameters
       --from-file string             File containing parameters
   -h, --help                         help for update
-      --renew-automatic              Enable automatic renewal
-      --renew-delete-at-expiration   Delete service at expiration
-      --renew-forced                 Force renewal
-      --renew-manual-payment         Enable manual payment for renewal
-      --renew-period int             Renewal period in months
+      --renew-automatic              Renew the service automatically
+      --renew-delete-at-expiration   Delete the service when it expires
+      --renew-forced                 Force the renewal
+      --renew-manual-payment         Pay the renewal manually
+      --renew-period int             Renewal period, in months
 ```
 
 ### Options inherited from parent commands

--- a/doc/ovhcloud_webhosting_service-info_update.md
+++ b/doc/ovhcloud_webhosting_service-info_update.md
@@ -12,11 +12,11 @@ ovhcloud webhosting service-info update <service_name> [flags]
       --editor                       Use a text editor to define parameters
       --from-file string             File containing parameters
   -h, --help                         help for update
-      --renew-automatic              Enable automatic renewal
-      --renew-delete-at-expiration   Delete service at expiration
-      --renew-forced                 Force renewal
-      --renew-manual-payment         Enable manual payment for renewal
-      --renew-period int             Renewal period in months
+      --renew-automatic              Renew the service automatically
+      --renew-delete-at-expiration   Delete the service when it expires
+      --renew-forced                 Force the renewal
+      --renew-manual-payment         Pay the renewal manually
+      --renew-period int             Renewal period, in months
 ```
 
 ### Options inherited from parent commands

--- a/internal/cmd/baremetal.go
+++ b/internal/cmd/baremetal.go
@@ -74,6 +74,7 @@ func init() {
 		ValidArgsFunction: completion.ServiceList("/v1/dedicated/server"),
 		Run:               baremetal.RebootBaremetal,
 	}
+	addConfirmationFlags(baremetalRebootCmd, "Print the call that would be made without making it")
 	baremetalCmd.AddCommand(baremetalRebootCmd)
 
 	// Command to reboot a baremetal in rescue mode
@@ -85,6 +86,7 @@ func init() {
 		Run:               baremetal.RebootRescueBaremetal,
 	}
 	baremetalRebootRescueCmd.Flags().BoolVar(&flags.WaitForTask, "wait", false, "Wait for reboot to be done before exiting")
+	addConfirmationFlags(baremetalRebootRescueCmd, "Print the call that would be made without making it")
 	baremetalCmd.AddCommand(baremetalRebootRescueCmd)
 
 	// Command to reinstall a baremetal
@@ -163,9 +165,7 @@ be sent without sending them.
 	reinstallBaremetalCmd.Flags().StringVar(&baremetal.Customizations.PostInstallationScriptExtension, "post-installation-script-extension", "", "Post-installation script extension (cmd, ps1)")
 	reinstallBaremetalCmd.Flags().StringVar(&baremetal.Customizations.SshKey, "ssh-key", "", "SSH public key")
 	reinstallBaremetalCmd.Flags().BoolVar(&flags.WaitForTask, "wait", false, "Wait for reinstall to be done before exiting")
-	reinstallBaremetalCmd.Flags().BoolVarP(&flags.AssumeYes, "yes", "y", false, "Skip the confirmation prompt (required for unattended runs)")
-	reinstallBaremetalCmd.Flags().BoolVar(&flags.DryRun, "dry-run", false, "Print the installation parameters without sending anything")
-	markFlagsMutuallyExclusive(reinstallBaremetalCmd, "yes", "dry-run")
+	addConfirmationFlags(reinstallBaremetalCmd, "Print the installation parameters without sending anything")
 	markFlagsMutuallyExclusive(reinstallBaremetalCmd, "from-file", "editor")
 	baremetalCmd.AddCommand(reinstallBaremetalCmd)
 
@@ -274,6 +274,7 @@ be sent without sending them.
 	}
 	baremetalVNIResetOLAAggregationCmd.Flags().StringArrayVar(&baremetal.BaremetalOLAInterfaces, "interface", nil, "Interfaces to group")
 	baremetalVNIResetOLAAggregationCmd.MarkFlagRequired("interface")
+	addConfirmationFlags(baremetalVNIResetOLAAggregationCmd, "Print the call that would be made without making it")
 	baremetalVNICmd.AddCommand(baremetalVNIResetOLAAggregationCmd)
 
 	baremetalIPMICmd := &cobra.Command{

--- a/internal/cmd/baremetal.go
+++ b/internal/cmd/baremetal.go
@@ -132,6 +132,11 @@ You can visit https://eu.api.ovh.com/console/?section=%2Fdedicated%2Fserver&bran
 to see all the available parameters and real life examples.
 
 Please note that all parameters are not compatible with all OSes.
+
+Reinstalling wipes every disk of the server, so the command asks for a
+confirmation: type the server name when prompted. Unattended runs (pipelines,
+piped input) must pass --yes, and --dry-run prints the parameters that would
+be sent without sending them.
 `,
 		Args:              cobra.MaximumNArgs(1),
 		ArgAliases:        []string{"service_name"},
@@ -155,6 +160,9 @@ Please note that all parameters are not compatible with all OSes.
 	reinstallBaremetalCmd.Flags().StringVar(&baremetal.Customizations.PostInstallationScriptExtension, "post-installation-script-extension", "", "Post-installation script extension (cmd, ps1)")
 	reinstallBaremetalCmd.Flags().StringVar(&baremetal.Customizations.SshKey, "ssh-key", "", "SSH public key")
 	reinstallBaremetalCmd.Flags().BoolVar(&flags.WaitForTask, "wait", false, "Wait for reinstall to be done before exiting")
+	reinstallBaremetalCmd.Flags().BoolVarP(&flags.AssumeYes, "yes", "y", false, "Skip the confirmation prompt (required for unattended runs)")
+	reinstallBaremetalCmd.Flags().BoolVar(&flags.DryRun, "dry-run", false, "Print the installation parameters without sending anything")
+	markFlagsMutuallyExclusive(reinstallBaremetalCmd, "yes", "dry-run")
 	markFlagsMutuallyExclusive(reinstallBaremetalCmd, "from-file", "editor")
 	baremetalCmd.AddCommand(reinstallBaremetalCmd)
 

--- a/internal/cmd/baremetal.go
+++ b/internal/cmd/baremetal.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ovh/ovhcloud-cli/internal/completion"
 	"github.com/ovh/ovhcloud-cli/internal/flags"
 	"github.com/ovh/ovhcloud-cli/internal/services/baremetal"
+	"github.com/ovh/ovhcloud-cli/internal/services/common"
 	"github.com/spf13/cobra"
 )
 
@@ -65,6 +66,66 @@ func init() {
 		Run:               baremetal.ListBaremetalTasks,
 	}
 	baremetalCmd.AddCommand(withFilterFlag(baremetalListTasksCmd))
+
+	// Service information and life cycle
+	baremetalServiceInfoCmd := &cobra.Command{
+		Use:   "service-info",
+		Short: "Manage service information of the given baremetal",
+	}
+	baremetalCmd.AddCommand(baremetalServiceInfoCmd)
+
+	baremetalServiceInfoCmd.AddCommand(&cobra.Command{
+		Use:               "get <service_name>",
+		Short:             "Get service information of the given baremetal",
+		Args:              cobra.ExactArgs(1),
+		ValidArgsFunction: completion.ServiceList("/v1/dedicated/server"),
+		Run:               baremetal.GetBaremetalServiceInfo,
+	})
+
+	baremetalServiceInfoEditCmd := &cobra.Command{
+		Use:               "edit <service_name>",
+		Short:             "Edit service information of the given baremetal",
+		Args:              cobra.ExactArgs(1),
+		ValidArgsFunction: completion.ServiceList("/v1/dedicated/server"),
+		Run:               baremetal.EditBaremetalServiceInfo,
+	}
+	common.AddServiceInfoRenewFlags(baremetalServiceInfoEditCmd)
+	addInteractiveEditorFlag(baremetalServiceInfoEditCmd)
+	baremetalServiceInfoCmd.AddCommand(baremetalServiceInfoEditCmd)
+
+	baremetalTerminateCmd := &cobra.Command{
+		Use:   "terminate <service_name>",
+		Short: "Ask for the termination of the given baremetal",
+		Long: `Ask for the termination of the given baremetal.
+
+Nothing stops when this returns: OVHcloud emails a termination token to the
+administrative contact of the service, and the server keeps running until that
+token is confirmed with "baremetal confirm-termination".`,
+		Args:              cobra.ExactArgs(1),
+		ValidArgsFunction: completion.ServiceList("/v1/dedicated/server"),
+		Run:               baremetal.TerminateBaremetal,
+	}
+	addConfirmationFlags(baremetalTerminateCmd, "Print the call that would be made without making it")
+	baremetalCmd.AddCommand(baremetalTerminateCmd)
+
+	baremetalConfirmTerminationCmd := &cobra.Command{
+		Use:   "confirm-termination <service_name> <token>",
+		Short: "Confirm the termination of the given baremetal",
+		Long: `Confirm the termination of the given baremetal, using the token emailed to
+the administrative contact by "baremetal terminate".
+
+This ends the contract: the server is returned to OVHcloud at expiry.`,
+		Args:              cobra.ExactArgs(2),
+		ValidArgsFunction: completion.ServiceList("/v1/dedicated/server"),
+		Run:               baremetal.ConfirmBaremetalTermination,
+	}
+	baremetalConfirmTerminationCmd.Flags().StringVar(&baremetal.TerminationReason, "reason", "", "Why the service is being terminated (press <tab> for the accepted values)")
+	baremetalConfirmTerminationCmd.Flags().StringVar(&baremetal.TerminationFutureUse, "future-use", "", "What comes next after this termination (press <tab> for the accepted values)")
+	baremetalConfirmTerminationCmd.Flags().StringVar(&baremetal.TerminationComment, "commentary", "", "Free-text comment attached to the termination request")
+	baremetalConfirmTerminationCmd.RegisterFlagCompletionFunc("reason", baremetal.CompleteTerminationReason)
+	baremetalConfirmTerminationCmd.RegisterFlagCompletionFunc("future-use", baremetal.CompleteTerminationFutureUse)
+	addConfirmationFlags(baremetalConfirmTerminationCmd, "Print the call that would be made without making it")
+	baremetalCmd.AddCommand(baremetalConfirmTerminationCmd)
 
 	// Command to reboot a baremetal
 	baremetalRebootCmd := &cobra.Command{

--- a/internal/cmd/baremetal.go
+++ b/internal/cmd/baremetal.go
@@ -111,7 +111,10 @@ There are three ways to define the installation parameters:
 
   Note that you can also pipe the content of the file to reinstall, like the following:
 
-	cat ./install.json | ovhcloud baremetal reinstall ns1234.ip-11.22.33.net
+	cat ./install.json | ovhcloud baremetal reinstall ns1234.ip-11.22.33.net --yes
+
+  Piped input is not a terminal, so there is nobody to answer the confirmation:
+  such a run refuses to start unless --yes is given.
 
   In both cases, you can override the parameters in the given file using command line flags, for example:
 

--- a/internal/cmd/baremetal_test.go
+++ b/internal/cmd/baremetal_test.go
@@ -166,3 +166,71 @@ func (ms *MockSuite) TestBaremetalReinstallDryRun(assert, require *td.T) {
 	assert.Cmp(httpmock.GetCallCountInfo()["POST https://eu.api.ovh.com/v1/dedicated/server/fakeBaremetal/reinstall"], 0,
 		"no reinstall call must reach the API")
 }
+
+// The point of the guardrail: an unattended run that did not say --yes must not
+// interrupt a production server, and must not reach the API at all.
+func (ms *MockSuite) TestBaremetalRebootRefusesWithoutConsent(assert, require *td.T) {
+	httpmock.RegisterResponder("POST", "https://eu.api.ovh.com/v1/dedicated/server/fakeBaremetal/reboot",
+		httpmock.NewStringResponder(200, `{}`),
+	)
+
+	_, err := cmd.Execute("baremetal", "reboot", "fakeBaremetal")
+
+	require.CmpError(err)
+	assert.Cmp(err.Error(), td.Contains("cancelled"))
+	assert.Cmp(httpmock.GetTotalCallCount(), 0, "nothing must reach the API without a confirmation")
+}
+
+// --yes is how a pipeline states its intent, and it must be enough.
+func (ms *MockSuite) TestBaremetalRebootProceedsWithYes(assert, require *td.T) {
+	httpmock.RegisterResponder("POST", "https://eu.api.ovh.com/v1/dedicated/server/fakeBaremetal/reboot",
+		httpmock.NewStringResponder(200, `{}`),
+	)
+
+	_, err := cmd.Execute("baremetal", "reboot", "fakeBaremetal", "--yes")
+
+	require.CmpNoError(err)
+	assert.Cmp(httpmock.GetCallCountInfo()["POST https://eu.api.ovh.com/v1/dedicated/server/fakeBaremetal/reboot"], 1)
+}
+
+// --dry-run shows the call and makes none, so it must never need a confirmation
+// of its own: refusing to describe what it will not do would be absurd.
+func (ms *MockSuite) TestBaremetalRebootDryRunSendsNothing(assert, require *td.T) {
+	httpmock.RegisterResponder("POST", "https://eu.api.ovh.com/v1/dedicated/server/fakeBaremetal/reboot",
+		httpmock.NewStringResponder(200, `{}`),
+	)
+
+	out, err := cmd.Execute("baremetal", "reboot", "fakeBaremetal", "--dry-run")
+
+	require.CmpNoError(err)
+	assert.Cmp(out, td.Contains("POST /v1/dedicated/server/fakeBaremetal/reboot"))
+	assert.Cmp(httpmock.GetTotalCallCount(), 0, "a dry run must send nothing")
+}
+
+// reboot-rescue leaves the server in rescue until somebody sets the boot back,
+// so it is guarded like the reboot it performs.
+func (ms *MockSuite) TestBaremetalRebootRescueRefusesWithoutConsent(assert, require *td.T) {
+	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/v1/dedicated/server/fakeBaremetal/boot?bootType=rescue",
+		httpmock.NewStringResponder(200, `[1122]`),
+	)
+
+	_, err := cmd.Execute("baremetal", "reboot-rescue", "fakeBaremetal")
+
+	require.CmpError(err)
+	assert.Cmp(err.Error(), td.Contains("cancelled"))
+	assert.Cmp(httpmock.GetTotalCallCount(), 0, "not even the boot lookup must happen")
+}
+
+// Resetting an aggregation takes the interfaces down; on a server reached over
+// that link the operator is cutting the branch they sit on.
+func (ms *MockSuite) TestBaremetalOlaResetRefusesWithoutConsent(assert, require *td.T) {
+	httpmock.RegisterResponder("POST", "https://eu.api.ovh.com/v1/dedicated/server/fakeBaremetal/ola/reset",
+		httpmock.NewStringResponder(200, `{}`),
+	)
+
+	_, err := cmd.Execute("baremetal", "vni", "ola-reset", "fakeBaremetal", "--interface", "uuid-1")
+
+	require.CmpError(err)
+	assert.Cmp(err.Error(), td.Contains("cancelled"))
+	assert.Cmp(httpmock.GetTotalCallCount(), 0, "no interface must be reset without a confirmation")
+}

--- a/internal/cmd/baremetal_test.go
+++ b/internal/cmd/baremetal_test.go
@@ -57,6 +57,9 @@ func (ms *MockSuite) TestBaremetalListCompatibleOSCmd(assert, require *td.T) {
 }
 
 // registerReinstallTask wires a reinstall whose task ends in the given state.
+//
+// These tests pass --yes: they are about what the CLI says when a task fails,
+// not about the confirmation, and without it the reinstall never starts.
 func registerReinstallTask(task string) {
 	httpmock.RegisterResponder("POST", "https://eu.api.ovh.com/v1/dedicated/server/fakeBaremetal/reinstall",
 		httpmock.NewStringResponder(200, `{"taskId": 156839472}`),
@@ -72,7 +75,7 @@ func (ms *MockSuite) TestBaremetalReinstallReportsTheFailureReason(assert, requi
 	registerReinstallTask(`{"taskId": 156839472, "function": "reinstallServer",
 		"status": "customerError", "comment": "partitioning scheme incompatible with this hardware"}`)
 
-	_, err := cmd.Execute("baremetal", "reinstall", "fakeBaremetal", "--os", "debian12_64", "--wait")
+	_, err := cmd.Execute("baremetal", "reinstall", "fakeBaremetal", "--os", "debian12_64", "--wait", "--yes")
 
 	require.CmpError(err)
 	assert.Cmp(err.Error(), td.Contains("customerError"), "the real status is named")
@@ -86,7 +89,7 @@ func (ms *MockSuite) TestBaremetalReinstallReportsTheFailureReason(assert, requi
 func (ms *MockSuite) TestBaremetalReinstallPrintsAReadableTaskID(assert, require *td.T) {
 	registerReinstallTask(`{"taskId": 156839472, "function": "reinstallServer", "status": "ovhError"}`)
 
-	_, err := cmd.Execute("baremetal", "reinstall", "fakeBaremetal", "--os", "debian12_64", "--wait")
+	_, err := cmd.Execute("baremetal", "reinstall", "fakeBaremetal", "--os", "debian12_64", "--wait", "--yes")
 
 	require.CmpError(err)
 	assert.Cmp(err.Error(), td.Contains("156839472"))
@@ -99,7 +102,7 @@ func (ms *MockSuite) TestBaremetalReinstallPrintsAReadableTaskID(assert, require
 func (ms *MockSuite) TestBaremetalReinstallReportsAnUnknownStatus(assert, require *td.T) {
 	registerReinstallTask(`{"taskId": 156839472, "function": "reinstallServer", "status": "quarantined"}`)
 
-	_, err := cmd.Execute("baremetal", "reinstall", "fakeBaremetal", "--os", "debian12_64", "--wait")
+	_, err := cmd.Execute("baremetal", "reinstall", "fakeBaremetal", "--os", "debian12_64", "--wait", "--yes")
 
 	require.CmpError(err)
 	assert.Cmp(err.Error(), td.Contains("unexpected status quarantined"))
@@ -112,9 +115,10 @@ func (ms *MockSuite) TestBaremetalReinstallSucceedsOnDoneTask(assert, require *t
 		httpmock.NewStringResponder(200, `[]`),
 	)
 
-	_, err := cmd.Execute("baremetal", "reinstall", "fakeBaremetal", "--os", "debian12_64", "--wait")
+	_, err := cmd.Execute("baremetal", "reinstall", "fakeBaremetal", "--os", "debian12_64", "--wait", "--yes")
 
 	require.CmpNoError(err)
+}
 
 // Reinstalling wipes the disks: an unattended run must not do it silently.
 func (ms *MockSuite) TestBaremetalReinstallRefusesWithoutConfirmation(assert, require *td.T) {
@@ -152,6 +156,13 @@ func (ms *MockSuite) TestBaremetalReinstallDryRun(assert, require *td.T) {
 
 	require.CmpNoError(err)
 	assert.Cmp(out, td.Contains("Dry run"))
+	// The parameters must be in the message itself: the default output prints
+	// the message alone, so a payload living only in the structured details
+	// would leave stdout with a promise and no request.
+	assert.Cmp(out, td.Contains(`"operatingSystem": "debian12_64"`),
+		"the request that would be sent is printed")
+	assert.Cmp(out, td.Contains("/v1/dedicated/server/fakeBaremetal/reinstall"),
+		"and the endpoint it would go to")
 	assert.Cmp(httpmock.GetCallCountInfo()["POST https://eu.api.ovh.com/v1/dedicated/server/fakeBaremetal/reinstall"], 0,
 		"no reinstall call must reach the API")
 }

--- a/internal/cmd/baremetal_test.go
+++ b/internal/cmd/baremetal_test.go
@@ -475,3 +475,99 @@ func (ms *MockSuite) TestBaremetalConfirmTerminationDryRunFingerprintsTheToken(a
 	assert.Cmp(out, td.Contains(fmt.Sprintf("%d characters", len(fakeTerminationToken))), "and its length")
 	assert.Cmp(out, td.Not(td.Contains(fakeTerminationToken)), "never the token itself")
 }
+
+// The guarded path, with consent given.
+//
+// Every other test of this command checks that it refuses. That leaves the
+// case it exists for untested: a guard that blocked the real operation, or
+// reordered it, would pass all of them.
+func (ms *MockSuite) TestBaremetalRebootRescueRunsTheWholeSequenceWithConsent(assert, require *td.T) {
+	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/v1/dedicated/server/fakeBaremetal/boot?bootType=rescue",
+		httpmock.NewStringResponder(200, `[1122]`))
+	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/v1/dedicated/server/fakeBaremetal/boot/1122",
+		httpmock.NewStringResponder(200, `{"bootId": 1122, "bootType": "rescue", "description": "rescue64-pro"}`))
+
+	var sentBoot map[string]any
+	httpmock.RegisterResponder("PUT", "https://eu.api.ovh.com/v1/dedicated/server/fakeBaremetal",
+		func(req *http.Request) (*http.Response, error) {
+			body, _ := io.ReadAll(req.Body)
+			_ = json.Unmarshal(body, &sentBoot)
+			return httpmock.NewStringResponse(200, `null`), nil
+		})
+	httpmock.RegisterResponder("POST", "https://eu.api.ovh.com/v1/dedicated/server/fakeBaremetal/reboot",
+		httpmock.NewStringResponder(200, `{"taskId": 1, "status": "done"}`))
+
+	_, err := cmd.Execute("baremetal", "reboot-rescue", "fakeBaremetal", "--yes")
+
+	require.CmpNoError(err)
+	assert.Cmp(sentBoot["bootId"], float64(1122), "the rescue entry the API named, not a hardcoded one")
+	assert.Cmp(httpmock.GetCallCountInfo()["POST https://eu.api.ovh.com/v1/dedicated/server/fakeBaremetal/reboot"], 1,
+		"and the machine is actually rebooted into it")
+}
+
+// One POST per interface. A loop that stopped after the first would still
+// refuse without --yes and still preview both, so only this reaches it.
+func (ms *MockSuite) TestBaremetalOlaResetPostsOncePerInterfaceWithConsent(assert, require *td.T) {
+	httpmock.RegisterResponder("POST", "https://eu.api.ovh.com/v1/dedicated/server/fakeBaremetal/ola/reset",
+		httpmock.NewStringResponder(200, `{"taskId": 1, "status": "done"}`))
+
+	_, err := cmd.Execute("baremetal", "vni", "ola-reset", "fakeBaremetal",
+		"--interface", "uuid-1", "--interface", "uuid-2", "--yes")
+
+	require.CmpNoError(err)
+	assert.Cmp(httpmock.GetCallCountInfo()["POST https://eu.api.ovh.com/v1/dedicated/server/fakeBaremetal/ola/reset"], 2)
+}
+
+func (ms *MockSuite) TestBaremetalServiceInfoGetRendersTheService(assert, require *td.T) {
+	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/v1/dedicated/server/fakeBaremetal/serviceInfos",
+		httpmock.NewStringResponder(200, `{
+			"serviceId": 1, "domain": "fakeBaremetal", "expiration": "2026-09-01",
+			"renew": {"automatic": true, "period": 1}
+		}`))
+
+	out, err := cmd.Execute("baremetal", "service-info", "get", "fakeBaremetal", "-o", "json")
+
+	require.CmpNoError(err)
+	assert.Cmp(out, td.Contains("2026-09-01"))
+}
+
+// An API failure must reach the operator. A read that reported success on a
+// 403 would be worse than one that failed loudly: the answer would be an empty
+// object rather than a refusal.
+func (ms *MockSuite) TestBaremetalServiceInfoGetReportsAnAPIFailure(assert, require *td.T) {
+	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/v1/dedicated/server/fakeBaremetal/serviceInfos",
+		httpmock.NewStringResponder(403, `{"message": "This call has not been granted"}`))
+
+	_, err := cmd.Execute("baremetal", "service-info", "get", "fakeBaremetal")
+
+	require.CmpError(err)
+	assert.Cmp(err.Error(), td.Contains("not been granted"))
+}
+
+// A failed write must not read as a successful edit. The command builds its
+// payload from a GET and sends it with a PUT; a refusal on either half leaves
+// the renewal settings unchanged, and saying otherwise would let somebody
+// believe automatic renewal is off when it is still on.
+func (ms *MockSuite) TestBaremetalServiceInfoEditReportsAFailedWrite(assert, require *td.T) {
+	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/v1/dedicated/server/fakeBaremetal/serviceInfos",
+		httpmock.NewStringResponder(200, `{"serviceId": 1, "domain": "fakeBaremetal", "renew": {"automatic": true, "period": 1}}`))
+	httpmock.RegisterResponder("PUT", "https://eu.api.ovh.com/v1/dedicated/server/fakeBaremetal/serviceInfos",
+		httpmock.NewStringResponder(400, `{"message": "Invalid renewal period"}`))
+
+	out, err := cmd.Execute("baremetal", "service-info", "edit", "fakeBaremetal", "--renew-period", "12")
+
+	require.CmpError(err)
+	assert.Cmp(err.Error(), td.Contains("Invalid renewal period"))
+	assert.Cmp(out, td.Not(td.Contains("✅")), "and nothing claims the edit went through")
+}
+
+func (ms *MockSuite) TestBaremetalServiceInfoEditReportsAFailedRead(assert, require *td.T) {
+	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/v1/dedicated/server/fakeBaremetal/serviceInfos",
+		httpmock.NewStringResponder(404, `{"message": "This service does not exist"}`))
+
+	_, err := cmd.Execute("baremetal", "service-info", "edit", "fakeBaremetal", "--renew-period", "12")
+
+	require.CmpError(err)
+	assert.Cmp(httpmock.GetCallCountInfo()["PUT https://eu.api.ovh.com/v1/dedicated/server/fakeBaremetal/serviceInfos"], 0,
+		"and nothing is written from a payload that could not be read")
+}

--- a/internal/cmd/baremetal_test.go
+++ b/internal/cmd/baremetal_test.go
@@ -115,4 +115,43 @@ func (ms *MockSuite) TestBaremetalReinstallSucceedsOnDoneTask(assert, require *t
 	_, err := cmd.Execute("baremetal", "reinstall", "fakeBaremetal", "--os", "debian12_64", "--wait")
 
 	require.CmpNoError(err)
+
+// Reinstalling wipes the disks: an unattended run must not do it silently.
+func (ms *MockSuite) TestBaremetalReinstallRefusesWithoutConfirmation(assert, require *td.T) {
+	httpmock.RegisterResponder("POST", "https://eu.api.ovh.com/v1/dedicated/server/fakeBaremetal/reinstall",
+		httpmock.NewStringResponder(200, `{"taskId": 123}`),
+	)
+
+	_, err := cmd.Execute("baremetal", "reinstall", "fakeBaremetal", "--os", "debian12_64")
+
+	require.CmpError(err)
+	assert.Cmp(err.Error(), td.Contains("cancelled"))
+	assert.Cmp(httpmock.GetCallCountInfo()["POST https://eu.api.ovh.com/v1/dedicated/server/fakeBaremetal/reinstall"], 0,
+		"no reinstall call must reach the API")
+}
+
+func (ms *MockSuite) TestBaremetalReinstallProceedsWithYes(assert, require *td.T) {
+	httpmock.RegisterResponder("POST", "https://eu.api.ovh.com/v1/dedicated/server/fakeBaremetal/reinstall",
+		httpmock.NewStringResponder(200, `{"taskId": 123}`),
+	)
+
+	out, err := cmd.Execute("baremetal", "reinstall", "fakeBaremetal", "--os", "debian12_64", "--yes")
+
+	require.CmpNoError(err)
+	assert.Cmp(out, td.Contains("Reinstallation is started"))
+	assert.Cmp(httpmock.GetCallCountInfo()["POST https://eu.api.ovh.com/v1/dedicated/server/fakeBaremetal/reinstall"], 1)
+}
+
+// --dry-run shows what would be sent and sends nothing.
+func (ms *MockSuite) TestBaremetalReinstallDryRun(assert, require *td.T) {
+	httpmock.RegisterResponder("POST", "https://eu.api.ovh.com/v1/dedicated/server/fakeBaremetal/reinstall",
+		httpmock.NewStringResponder(200, `{"taskId": 123}`),
+	)
+
+	out, err := cmd.Execute("baremetal", "reinstall", "fakeBaremetal", "--os", "debian12_64", "--dry-run")
+
+	require.CmpNoError(err)
+	assert.Cmp(out, td.Contains("Dry run"))
+	assert.Cmp(httpmock.GetCallCountInfo()["POST https://eu.api.ovh.com/v1/dedicated/server/fakeBaremetal/reinstall"], 0,
+		"no reinstall call must reach the API")
 }

--- a/internal/cmd/baremetal_test.go
+++ b/internal/cmd/baremetal_test.go
@@ -207,6 +207,51 @@ func (ms *MockSuite) TestBaremetalRebootDryRunSendsNothing(assert, require *td.T
 	assert.Cmp(httpmock.GetTotalCallCount(), 0, "a dry run must send nothing")
 }
 
+// reboot-rescue is three calls, and the middle one — writing the rescue boot to
+// the server — is the change that outlives the reboot. A preview showing the
+// reboot alone would hide exactly what the operator needs to weigh.
+func (ms *MockSuite) TestBaremetalRebootRescueDryRunShowsTheBootChange(assert, require *td.T) {
+	out, err := cmd.Execute("baremetal", "reboot-rescue", "fakeBaremetal", "--dry-run")
+
+	require.CmpNoError(err)
+	assert.Cmp(out, td.Contains("GET /v1/dedicated/server/fakeBaremetal/boot?bootType=rescue"))
+	assert.Cmp(out, td.Contains("PUT /v1/dedicated/server/fakeBaremetal"), "the boot write must be announced")
+	assert.Cmp(out, td.Contains("POST /v1/dedicated/server/fakeBaremetal/reboot"))
+	assert.Cmp(httpmock.GetTotalCallCount(), 0, "a dry run must send nothing")
+}
+
+// One call per interface: the preview must list them rather than imply a single
+// request.
+func (ms *MockSuite) TestBaremetalOlaResetDryRunListsEveryInterface(assert, require *td.T) {
+	out, err := cmd.Execute("baremetal", "vni", "ola-reset", "fakeBaremetal",
+		"--interface", "uuid-1", "--interface", "uuid-2", "--dry-run")
+
+	require.CmpNoError(err)
+	assert.Cmp(out, td.Contains("uuid-1"))
+	assert.Cmp(out, td.Contains("uuid-2"))
+	assert.Cmp(httpmock.GetTotalCallCount(), 0, "a dry run must send nothing")
+}
+
+// --yes belongs to the command it was typed on. If it survived into the next
+// command of the same process — the WASM build runs several — a confirmation
+// would be skipped that nobody granted.
+func (ms *MockSuite) TestBaremetalYesDoesNotSurviveIntoTheNextCommand(assert, require *td.T) {
+	httpmock.RegisterResponder("POST", "https://eu.api.ovh.com/v1/dedicated/server/fakeBaremetal/reboot",
+		httpmock.NewStringResponder(200, `{}`),
+	)
+
+	_, err := cmd.Execute("baremetal", "reboot", "fakeBaremetal", "--yes")
+	require.CmpNoError(err)
+
+	cmd.PostExecute()
+
+	_, err = cmd.Execute("baremetal", "reboot", "fakeBaremetal")
+	require.CmpError(err)
+	assert.Cmp(err.Error(), td.Contains("cancelled"), "the second command must ask again")
+	assert.Cmp(httpmock.GetCallCountInfo()["POST https://eu.api.ovh.com/v1/dedicated/server/fakeBaremetal/reboot"], 1,
+		"only the consented reboot must have happened")
+}
+
 // reboot-rescue leaves the server in rescue until somebody sets the boot back,
 // so it is guarded like the reboot it performs.
 func (ms *MockSuite) TestBaremetalRebootRescueRefusesWithoutConsent(assert, require *td.T) {

--- a/internal/cmd/baremetal_test.go
+++ b/internal/cmd/baremetal_test.go
@@ -6,6 +6,7 @@ package cmd_test
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 
@@ -412,4 +413,65 @@ func (ms *MockSuite) TestBaremetalServiceInfoEditSendsOnlyWhatWasAsked(assert, r
 	require.NotNil(renew)
 	assert.Cmp(renew["period"], float64(12))
 	assert.Cmp(renew["automatic"], true, "automatic renewal must survive untouched")
+}
+
+// The termination survey is held in package-level variables bound by cobra. A
+// reason typed on one command must not attach itself to the next termination
+// of the same process, which would file a survey answer nobody gave.
+func (ms *MockSuite) TestBaremetalTerminationReasonDoesNotSurvive(assert, require *td.T) {
+	var sent map[string]any
+	registerBaremetalTermination(&sent)
+
+	_, err := cmd.Execute("baremetal", "confirm-termination", "fakeBaremetal", fakeTerminationToken,
+		"--reason", "TOO_EXPENSIVE", "--yes")
+	require.CmpNoError(err)
+	require.Cmp(sent["reason"], "TOO_EXPENSIVE")
+
+	cmd.PostExecute()
+
+	_, err = cmd.Execute("baremetal", "confirm-termination", "fakeBaremetal", fakeTerminationToken, "--yes")
+	require.CmpNoError(err)
+	assert.Cmp(sent["reason"], nil, "the second termination carries no reason")
+}
+
+// cobra counts the positional arguments, it does not look at them: an empty
+// token satisfies ExactArgs(2). Sending it spends a round trip to learn what
+// the CLI already knew.
+func (ms *MockSuite) TestBaremetalConfirmTerminationRefusesAnEmptyToken(assert, require *td.T) {
+	var sent map[string]any
+	registerBaremetalTermination(&sent)
+
+	_, err := cmd.Execute("baremetal", "confirm-termination", "fakeBaremetal", "   ", "--yes")
+
+	require.CmpError(err)
+	assert.Cmp(err.Error(), td.Contains("no termination token given"))
+	assert.Cmp(httpmock.GetTotalCallCount(), 0, "nothing must reach the API")
+}
+
+// An error from the API must not be reported as a success, whatever the CLI
+// does with the response body.
+func (ms *MockSuite) TestBaremetalConfirmTerminationReportsAnApiRefusal(assert, require *td.T) {
+	httpmock.RegisterResponder("POST", "https://eu.api.ovh.com/v1/dedicated/server/fakeBaremetal/confirmTermination",
+		httpmock.NewStringResponder(400, `{"class":"Client::BadRequest","message":"This token is not valid"}`),
+	)
+
+	out, err := cmd.Execute("baremetal", "confirm-termination", "fakeBaremetal", fakeTerminationToken, "--yes")
+
+	require.CmpError(err)
+	assert.Cmp(err.Error(), td.Contains("This token is not valid"), "the reason the API gave")
+	assert.Cmp(out, td.Not(td.Contains("confirmed")), "and no claim that it worked")
+}
+
+// The preview must not hide a token the shell mangled: four characters and a
+// length answer that without reproducing the credential.
+func (ms *MockSuite) TestBaremetalConfirmTerminationDryRunFingerprintsTheToken(assert, require *td.T) {
+	var sent map[string]any
+	registerBaremetalTermination(&sent)
+
+	out, err := cmd.Execute("baremetal", "confirm-termination", "fakeBaremetal", fakeTerminationToken, "--dry-run")
+
+	require.CmpNoError(err)
+	assert.Cmp(out, td.Contains("abcd…"), "enough to recognise the token")
+	assert.Cmp(out, td.Contains(fmt.Sprintf("%d characters", len(fakeTerminationToken))), "and its length")
+	assert.Cmp(out, td.Not(td.Contains(fakeTerminationToken)), "never the token itself")
 }

--- a/internal/cmd/baremetal_test.go
+++ b/internal/cmd/baremetal_test.go
@@ -5,6 +5,10 @@
 package cmd_test
 
 import (
+	"encoding/json"
+	"io"
+	"net/http"
+
 	"github.com/jarcoal/httpmock"
 	"github.com/maxatome/go-testdeep/td"
 	"github.com/ovh/ovhcloud-cli/internal/cmd"
@@ -278,4 +282,134 @@ func (ms *MockSuite) TestBaremetalOlaResetRefusesWithoutConsent(assert, require 
 	require.CmpError(err)
 	assert.Cmp(err.Error(), td.Contains("cancelled"))
 	assert.Cmp(httpmock.GetTotalCallCount(), 0, "no interface must be reset without a confirmation")
+}
+
+const fakeTerminationToken = "abcd-1234-token"
+
+func registerBaremetalTermination(captured *map[string]any) {
+	httpmock.RegisterResponder("POST", "https://eu.api.ovh.com/v1/dedicated/server/fakeBaremetal/terminate",
+		httpmock.NewStringResponder(200, `"termination requested"`),
+	)
+	httpmock.RegisterResponder("POST", "https://eu.api.ovh.com/v1/dedicated/server/fakeBaremetal/confirmTermination",
+		func(req *http.Request) (*http.Response, error) {
+			body, err := io.ReadAll(req.Body)
+			if err != nil {
+				return nil, err
+			}
+			var sent map[string]any
+			if err := json.Unmarshal(body, &sent); err != nil {
+				return nil, err
+			}
+			*captured = sent
+			return httpmock.NewStringResponse(200, `"ok"`), nil
+		},
+	)
+}
+
+// terminate stops nothing, and the token is emailed rather than returned. An
+// operator who reads "termination started: <body>" pastes that body into the
+// confirmation and wonders why it is refused.
+func (ms *MockSuite) TestBaremetalTerminateSaysWhereTheTokenComesFrom(assert, require *td.T) {
+	var sent map[string]any
+	registerBaremetalTermination(&sent)
+
+	out, err := cmd.Execute("baremetal", "terminate", "fakeBaremetal", "--yes")
+
+	require.CmpNoError(err)
+	assert.Cmp(out, td.Contains("emailed"), "the operator must be told where the token arrives")
+	assert.Cmp(out, td.Contains("confirm-termination fakeBaremetal"), "and what to run next")
+}
+
+// The reversible half asks for a yes; the irreversible half asks for the name.
+// An unattended run gets neither, so it must reach nothing.
+func (ms *MockSuite) TestBaremetalTerminationRefusesWithoutConsent(assert, require *td.T) {
+	var sent map[string]any
+	registerBaremetalTermination(&sent)
+
+	_, err := cmd.Execute("baremetal", "terminate", "fakeBaremetal")
+	require.CmpError(err)
+
+	_, err = cmd.Execute("baremetal", "confirm-termination", "fakeBaremetal", fakeTerminationToken)
+	require.CmpError(err)
+
+	assert.Cmp(httpmock.GetTotalCallCount(), 0, "nothing must reach the API without a confirmation")
+}
+
+func (ms *MockSuite) TestBaremetalConfirmTerminationSendsTheSurveyFields(assert, require *td.T) {
+	var sent map[string]any
+	registerBaremetalTermination(&sent)
+
+	_, err := cmd.Execute("baremetal", "confirm-termination", "fakeBaremetal", fakeTerminationToken,
+		"--reason", "TOO_EXPENSIVE", "--future-use", "NOT_REPLACING_SERVICE",
+		"--commentary", "consolidating racks", "--yes")
+
+	require.CmpNoError(err)
+	assert.Cmp(sent["token"], fakeTerminationToken)
+	assert.Cmp(sent["reason"], "TOO_EXPENSIVE")
+	assert.Cmp(sent["futureUse"], "NOT_REPLACING_SERVICE")
+	assert.Cmp(sent["commentary"], "consolidating racks")
+}
+
+// A value the API would reject must be named as such here, with the accepted
+// ones listed. A 400 from the other side says "invalid value" and stops there.
+func (ms *MockSuite) TestBaremetalConfirmTerminationRejectsAnUnknownReason(assert, require *td.T) {
+	var sent map[string]any
+	registerBaremetalTermination(&sent)
+
+	_, err := cmd.Execute("baremetal", "confirm-termination", "fakeBaremetal", fakeTerminationToken,
+		"--reason", "BECAUSE", "--yes")
+
+	require.CmpError(err)
+	assert.Cmp(err.Error(), td.Contains("TOO_EXPENSIVE"), "the accepted values are listed")
+	assert.Cmp(httpmock.GetTotalCallCount(), 0, "and nothing is sent")
+}
+
+// The preview must describe the request, and withhold the one value that is a
+// single-use credential: --dry-run is run with the output on a screen or in a
+// pipeline log.
+func (ms *MockSuite) TestBaremetalConfirmTerminationDryRunWithholdsTheToken(assert, require *td.T) {
+	var sent map[string]any
+	registerBaremetalTermination(&sent)
+
+	out, err := cmd.Execute("baremetal", "confirm-termination", "fakeBaremetal", fakeTerminationToken,
+		"--reason", "TOO_EXPENSIVE", "--dry-run")
+
+	require.CmpNoError(err)
+	assert.Cmp(out, td.Contains("confirmTermination"), "the call is named")
+	assert.Cmp(out, td.Contains("reason: TOO_EXPENSIVE"), "and so are the fields")
+	assert.Cmp(out, td.Not(td.Contains(fakeTerminationToken)), "but never the token itself")
+	assert.Cmp(httpmock.GetTotalCallCount(), 0, "and nothing is sent")
+}
+
+// Editing one renewal setting must not carry the others along at their zero
+// value, on baremetal as anywhere else.
+func (ms *MockSuite) TestBaremetalServiceInfoEditSendsOnlyWhatWasAsked(assert, require *td.T) {
+	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/v1/dedicated/server/fakeBaremetal/serviceInfos",
+		httpmock.NewStringResponder(200, `{
+			"serviceId": 1,
+			"domain": "fakeBaremetal",
+			"renew": {"automatic": true, "deleteAtExpiration": false, "forced": false, "manualPayment": false, "period": 1}
+		}`),
+	)
+	var sent map[string]any
+	httpmock.RegisterResponder("PUT", "https://eu.api.ovh.com/v1/dedicated/server/fakeBaremetal/serviceInfos",
+		func(req *http.Request) (*http.Response, error) {
+			body, err := io.ReadAll(req.Body)
+			if err != nil {
+				return nil, err
+			}
+			if err := json.Unmarshal(body, &sent); err != nil {
+				return nil, err
+			}
+			return httpmock.NewStringResponse(200, `null`), nil
+		},
+	)
+
+	_, err := cmd.Execute("baremetal", "service-info", "edit", "fakeBaremetal", "--renew-period", "12")
+
+	require.CmpNoError(err)
+	renew, _ := sent["renew"].(map[string]any)
+	require.NotNil(renew)
+	assert.Cmp(renew["period"], float64(12))
+	assert.Cmp(renew["automatic"], true, "automatic renewal must survive untouched")
 }

--- a/internal/cmd/baremetal_test.go
+++ b/internal/cmd/baremetal_test.go
@@ -5,9 +5,6 @@
 package cmd_test
 
 import (
-	"bytes"
-	"log"
-
 	"github.com/jarcoal/httpmock"
 	"github.com/maxatome/go-testdeep/td"
 	"github.com/ovh/ovhcloud-cli/internal/cmd"
@@ -168,51 +165,4 @@ func (ms *MockSuite) TestBaremetalReinstallDryRun(assert, require *td.T) {
 		"and the endpoint it would go to")
 	assert.Cmp(httpmock.GetCallCountInfo()["POST https://eu.api.ovh.com/v1/dedicated/server/fakeBaremetal/reinstall"], 0,
 		"no reinstall call must reach the API")
-}
-
-// A dry run prints the payload once. It used to print it twice: the message
-// carries it, and a log.Println just above the --dry-run branch repeated the
-// same JSON behind a Go timestamp no other command in this CLI emits.
-//
-//	🔍 Dry run: nothing was sent. This would have been posted to …
-//	{ "operatingSystem": "debian12_64" }
-//	2026/08/23 23:47:22 Final parameters:
-//	{ "operatingSystem": "debian12_64" }
-//
-// The log line goes to stderr, so no assertion on stdout could ever have seen
-// it — which is why it survived every green run. This one redirects the logger.
-func (ms *MockSuite) TestBaremetalReinstallDryRunDoesNotLogTheParametersTwice(assert, require *td.T) {
-	httpmock.RegisterResponder("POST", "https://eu.api.ovh.com/v1/dedicated/server/fakeBaremetal/reinstall",
-		httpmock.NewStringResponder(200, `{"taskId": 123}`),
-	)
-	var logged bytes.Buffer
-	previous := log.Writer()
-	log.SetOutput(&logged)
-	defer log.SetOutput(previous)
-
-	out, err := cmd.Execute("baremetal", "reinstall", "fakeBaremetal", "--os", "debian12_64", "--dry-run")
-
-	require.CmpNoError(err)
-	assert.Cmp(out, td.Contains(`"operatingSystem": "debian12_64"`),
-		"the payload is still printed, once, as the message")
-	assert.Cmp(logged.String(), td.Not(td.Contains("Final parameters")),
-		"a dry run logs nothing: it sends nothing")
-}
-
-// The positive control of the test above: a REAL run still logs what it is
-// about to send. Without it, deleting the log line altogether would pass.
-func (ms *MockSuite) TestBaremetalReinstallStillLogsTheParametersItSends(assert, require *td.T) {
-	httpmock.RegisterResponder("POST", "https://eu.api.ovh.com/v1/dedicated/server/fakeBaremetal/reinstall",
-		httpmock.NewStringResponder(200, `{"taskId": 123}`),
-	)
-	var logged bytes.Buffer
-	previous := log.Writer()
-	log.SetOutput(&logged)
-	defer log.SetOutput(previous)
-
-	_, err := cmd.Execute("baremetal", "reinstall", "fakeBaremetal", "--os", "debian12_64", "--yes")
-
-	require.CmpNoError(err)
-	assert.Cmp(logged.String(), td.Contains("Final parameters"))
-	assert.Cmp(logged.String(), td.Contains(`"operatingSystem": "debian12_64"`))
 }

--- a/internal/cmd/baremetal_test.go
+++ b/internal/cmd/baremetal_test.go
@@ -5,6 +5,9 @@
 package cmd_test
 
 import (
+	"bytes"
+	"log"
+
 	"github.com/jarcoal/httpmock"
 	"github.com/maxatome/go-testdeep/td"
 	"github.com/ovh/ovhcloud-cli/internal/cmd"
@@ -165,4 +168,51 @@ func (ms *MockSuite) TestBaremetalReinstallDryRun(assert, require *td.T) {
 		"and the endpoint it would go to")
 	assert.Cmp(httpmock.GetCallCountInfo()["POST https://eu.api.ovh.com/v1/dedicated/server/fakeBaremetal/reinstall"], 0,
 		"no reinstall call must reach the API")
+}
+
+// A dry run prints the payload once. It used to print it twice: the message
+// carries it, and a log.Println just above the --dry-run branch repeated the
+// same JSON behind a Go timestamp no other command in this CLI emits.
+//
+//	🔍 Dry run: nothing was sent. This would have been posted to …
+//	{ "operatingSystem": "debian12_64" }
+//	2026/08/23 23:47:22 Final parameters:
+//	{ "operatingSystem": "debian12_64" }
+//
+// The log line goes to stderr, so no assertion on stdout could ever have seen
+// it — which is why it survived every green run. This one redirects the logger.
+func (ms *MockSuite) TestBaremetalReinstallDryRunDoesNotLogTheParametersTwice(assert, require *td.T) {
+	httpmock.RegisterResponder("POST", "https://eu.api.ovh.com/v1/dedicated/server/fakeBaremetal/reinstall",
+		httpmock.NewStringResponder(200, `{"taskId": 123}`),
+	)
+	var logged bytes.Buffer
+	previous := log.Writer()
+	log.SetOutput(&logged)
+	defer log.SetOutput(previous)
+
+	out, err := cmd.Execute("baremetal", "reinstall", "fakeBaremetal", "--os", "debian12_64", "--dry-run")
+
+	require.CmpNoError(err)
+	assert.Cmp(out, td.Contains(`"operatingSystem": "debian12_64"`),
+		"the payload is still printed, once, as the message")
+	assert.Cmp(logged.String(), td.Not(td.Contains("Final parameters")),
+		"a dry run logs nothing: it sends nothing")
+}
+
+// The positive control of the test above: a REAL run still logs what it is
+// about to send. Without it, deleting the log line altogether would pass.
+func (ms *MockSuite) TestBaremetalReinstallStillLogsTheParametersItSends(assert, require *td.T) {
+	httpmock.RegisterResponder("POST", "https://eu.api.ovh.com/v1/dedicated/server/fakeBaremetal/reinstall",
+		httpmock.NewStringResponder(200, `{"taskId": 123}`),
+	)
+	var logged bytes.Buffer
+	previous := log.Writer()
+	log.SetOutput(&logged)
+	defer log.SetOutput(previous)
+
+	_, err := cmd.Execute("baremetal", "reinstall", "fakeBaremetal", "--os", "debian12_64", "--yes")
+
+	require.CmpNoError(err)
+	assert.Cmp(logged.String(), td.Contains("Final parameters"))
+	assert.Cmp(logged.String(), td.Contains(`"operatingSystem": "debian12_64"`))
 }

--- a/internal/cmd/dry_run_log_test.go
+++ b/internal/cmd/dry_run_log_test.go
@@ -1,0 +1,68 @@
+// SPDX-FileCopyrightText: 2025 OVH SAS <opensource@ovh.net>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Ces deux tests vivent dans leur propre fichier, et non dans
+// baremetal_test.go, pour une raison mecanique : 23 branches en aval ajoutent
+// elles aussi des tests juste apres TestBaremetalReinstallDryRun et dans le
+// meme bloc d'imports. Les y placer a fait echouer les 23 merges d'un coup, sur
+// une adjacence et non sur un desaccord. Un fichier neuf ne peut entrer en
+// collision qu'avec un fichier de meme nom.
+
+package cmd_test
+
+import (
+	"bytes"
+	"log"
+
+	"github.com/jarcoal/httpmock"
+	"github.com/maxatome/go-testdeep/td"
+	"github.com/ovh/ovhcloud-cli/internal/cmd"
+)
+
+// A dry run prints the payload once. It used to print it twice: the message
+// carries it, and a log.Println just above the --dry-run branch repeated the
+// same JSON behind a Go timestamp no other command in this CLI emits.
+//
+//	🔍 Dry run: nothing was sent. This would have been posted to …
+//	{ "operatingSystem": "debian12_64" }
+//	2026/08/23 23:47:22 Final parameters:
+//	{ "operatingSystem": "debian12_64" }
+//
+// The log line goes to stderr, so no assertion on stdout could ever have seen
+// it — which is why it survived every green run. This one redirects the logger.
+func (ms *MockSuite) TestBaremetalReinstallDryRunDoesNotLogTheParametersTwice(assert, require *td.T) {
+	httpmock.RegisterResponder("POST", "https://eu.api.ovh.com/v1/dedicated/server/fakeBaremetal/reinstall",
+		httpmock.NewStringResponder(200, `{"taskId": 123}`),
+	)
+	var logged bytes.Buffer
+	previous := log.Writer()
+	log.SetOutput(&logged)
+	defer log.SetOutput(previous)
+
+	out, err := cmd.Execute("baremetal", "reinstall", "fakeBaremetal", "--os", "debian12_64", "--dry-run")
+
+	require.CmpNoError(err)
+	assert.Cmp(out, td.Contains(`"operatingSystem": "debian12_64"`),
+		"the payload is still printed, once, as the message")
+	assert.Cmp(logged.String(), td.Not(td.Contains("Final parameters")),
+		"a dry run logs nothing: it sends nothing")
+}
+
+// The positive control of the test above: a REAL run still logs what it is
+// about to send. Without it, deleting the log line altogether would pass.
+func (ms *MockSuite) TestBaremetalReinstallStillLogsTheParametersItSends(assert, require *td.T) {
+	httpmock.RegisterResponder("POST", "https://eu.api.ovh.com/v1/dedicated/server/fakeBaremetal/reinstall",
+		httpmock.NewStringResponder(200, `{"taskId": 123}`),
+	)
+	var logged bytes.Buffer
+	previous := log.Writer()
+	log.SetOutput(&logged)
+	defer log.SetOutput(previous)
+
+	_, err := cmd.Execute("baremetal", "reinstall", "fakeBaremetal", "--os", "debian12_64", "--yes")
+
+	require.CmpNoError(err)
+	assert.Cmp(logged.String(), td.Contains("Final parameters"))
+	assert.Cmp(logged.String(), td.Contains(`"operatingSystem": "debian12_64"`))
+}

--- a/internal/cmd/parameter.go
+++ b/internal/cmd/parameter.go
@@ -285,3 +285,16 @@ There are three ways to define the creation parameters:
 
 	return createCmd
 }
+
+// addConfirmationFlags gives a command the pair every guarded action needs:
+// --yes to state the intent up front, --dry-run to see the call without making
+// it. They are mutually exclusive because asking to skip a confirmation for
+// something that will not happen means one of the two was a mistake.
+//
+// preview describes what --dry-run will show, since it differs between a
+// command that has a request body to print and one that only has a path.
+func addConfirmationFlags(cmd *cobra.Command, preview string) {
+	cmd.Flags().BoolVarP(&flags.AssumeYes, "yes", "y", false, "Skip the confirmation prompt (required for unattended runs)")
+	cmd.Flags().BoolVar(&flags.DryRun, "dry-run", false, preview)
+	markFlagsMutuallyExclusive(cmd, "yes", "dry-run")
+}

--- a/internal/cmd/service_info.go
+++ b/internal/cmd/service_info.go
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: 2025 OVH SAS <opensource@ovh.net>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"github.com/ovh/ovhcloud-cli/internal/services/common"
+	"github.com/spf13/cobra"
+)
+
+// addServiceInfoRenewFlags registers the renewal flags on a `service-info edit`
+// command.
+//
+// It sits here, beside the other shared flag helpers, rather than in the
+// service package: declaring cobra flags is the command layer's job, and
+// internal/services/common was the only service package doing it. The flag
+// names still come from common.ServiceInfoRenewFlags, which is also what the
+// payload builder reads — one table, so the two halves cannot drift.
+func addServiceInfoRenewFlags(cmd *cobra.Command) {
+	for _, flag := range common.ServiceInfoRenewFlags {
+		if flag.Period {
+			cmd.Flags().Int(flag.Name, 0, flag.Usage)
+			continue
+		}
+		cmd.Flags().Bool(flag.Name, false, flag.Usage)
+	}
+}

--- a/internal/cmd/vps.go
+++ b/internal/cmd/vps.go
@@ -221,11 +221,7 @@ func init() {
 		ValidArgsFunction: completion.ServiceList("/v1/vps"),
 		Run:               vps.EditVpsServiceInfo,
 	}
-	serviceInfoEditCmd.Flags().BoolVar(&common.ServiceInfoSpec.Renew.Automatic, "renew-automatic", false, "Enable automatic renewal")
-	serviceInfoEditCmd.Flags().BoolVar(&common.ServiceInfoSpec.Renew.DeleteAtExpiration, "renew-delete-at-expiration", false, "Delete service at expiration")
-	serviceInfoEditCmd.Flags().BoolVar(&common.ServiceInfoSpec.Renew.Forced, "renew-forced", false, "Force renewal")
-	serviceInfoEditCmd.Flags().BoolVar(&common.ServiceInfoSpec.Renew.ManualPayment, "renew-manual-payment", false, "Enable manual payment for renewal")
-	serviceInfoEditCmd.Flags().IntVar(&common.ServiceInfoSpec.Renew.Period, "renew-period", 0, "Renewal period (in months)")
+	common.AddServiceInfoRenewFlags(serviceInfoEditCmd)
 	addInteractiveEditorFlag(serviceInfoEditCmd)
 	serviceInfoCmd.AddCommand(serviceInfoEditCmd)
 

--- a/internal/cmd/vps.go
+++ b/internal/cmd/vps.go
@@ -11,7 +11,6 @@ import (
 	"github.com/ovh/ovhcloud-cli/internal/assets"
 	"github.com/ovh/ovhcloud-cli/internal/completion"
 	"github.com/ovh/ovhcloud-cli/internal/flags"
-	"github.com/ovh/ovhcloud-cli/internal/services/common"
 	"github.com/ovh/ovhcloud-cli/internal/services/vps"
 	"github.com/spf13/cobra"
 )
@@ -221,7 +220,7 @@ func init() {
 		ValidArgsFunction: completion.ServiceList("/v1/vps"),
 		Run:               vps.EditVpsServiceInfo,
 	}
-	common.AddServiceInfoRenewFlags(serviceInfoEditCmd)
+	addServiceInfoRenewFlags(serviceInfoEditCmd)
 	addInteractiveEditorFlag(serviceInfoEditCmd)
 	serviceInfoCmd.AddCommand(serviceInfoEditCmd)
 

--- a/internal/cmd/vps_test.go
+++ b/internal/cmd/vps_test.go
@@ -6,6 +6,8 @@ package cmd_test
 
 import (
 	"encoding/json"
+	"io"
+	"net/http"
 
 	"github.com/jarcoal/httpmock"
 	"github.com/maxatome/go-testdeep/td"
@@ -62,4 +64,60 @@ func (ms *MockSuite) TestVpsGetCmd(assert, require *td.T) {
 			"longName": "Region OpenStack: os-gra1"
 		}
 	}`))
+}
+
+// registerVpsServiceInfos wires a service whose renewal is currently automatic,
+// and captures whatever the CLI decides to write back.
+func registerVpsServiceInfos(captured *map[string]any) {
+	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/v1/vps/fakeVps/serviceInfos",
+		httpmock.NewStringResponder(200, `{
+			"serviceId": 1,
+			"domain": "fakeVps",
+			"renew": {"automatic": true, "deleteAtExpiration": false, "forced": false, "manualPayment": false, "period": 1}
+		}`),
+	)
+	httpmock.RegisterResponder("PUT", "https://eu.api.ovh.com/v1/vps/fakeVps/serviceInfos",
+		func(req *http.Request) (*http.Response, error) {
+			body, err := io.ReadAll(req.Body)
+			if err != nil {
+				return nil, err
+			}
+			var sent map[string]any
+			if err := json.Unmarshal(body, &sent); err != nil {
+				return nil, err
+			}
+			*captured = sent
+			return httpmock.NewStringResponse(200, `null`), nil
+		},
+	)
+}
+
+// Editing the renewal period used to send every other renewal setting along
+// with it, at its zero value: a service that renewed itself automatically for
+// years stopped doing so, and nothing in the output said it had changed.
+func (ms *MockSuite) TestVpsServiceInfoEditSendsOnlyWhatWasAsked(assert, require *td.T) {
+	var sent map[string]any
+	registerVpsServiceInfos(&sent)
+
+	_, err := cmd.Execute("vps", "service-info", "edit", "fakeVps", "--renew-period", "12")
+
+	require.CmpNoError(err)
+	renew, _ := sent["renew"].(map[string]any)
+	require.NotNil(renew, "the renewal block must be written")
+	assert.Cmp(renew["period"], float64(12), "the period the operator asked for")
+	assert.Cmp(renew["automatic"], true, "automatic renewal must survive untouched")
+}
+
+// The flag being absent and the flag being set to false are different
+// intentions, and pflag can tell them apart: an explicit false must be sent.
+func (ms *MockSuite) TestVpsServiceInfoEditSendsAnExplicitFalse(assert, require *td.T) {
+	var sent map[string]any
+	registerVpsServiceInfos(&sent)
+
+	_, err := cmd.Execute("vps", "service-info", "edit", "fakeVps", "--renew-automatic=false")
+
+	require.CmpNoError(err)
+	renew, _ := sent["renew"].(map[string]any)
+	require.NotNil(renew)
+	assert.Cmp(renew["automatic"], false, "the operator asked for it, so it is sent")
 }

--- a/internal/cmd/webhosting.go
+++ b/internal/cmd/webhosting.go
@@ -605,11 +605,7 @@ func init() {
 		ValidArgsFunction: completion.ServiceList("/v1/hosting/web"),
 		Run:               webhosting.UpdateExtraSqlServiceInfo,
 	}
-	extraSQLServiceInfoUpdateCmd.Flags().BoolVar(&common.ServiceInfoSpec.Renew.Automatic, "renew-automatic", false, "Enable automatic renewal")
-	extraSQLServiceInfoUpdateCmd.Flags().BoolVar(&common.ServiceInfoSpec.Renew.DeleteAtExpiration, "renew-delete-at-expiration", false, "Delete service at expiration")
-	extraSQLServiceInfoUpdateCmd.Flags().BoolVar(&common.ServiceInfoSpec.Renew.Forced, "renew-forced", false, "Force renewal")
-	extraSQLServiceInfoUpdateCmd.Flags().BoolVar(&common.ServiceInfoSpec.Renew.ManualPayment, "renew-manual-payment", false, "Enable manual payment for renewal")
-	extraSQLServiceInfoUpdateCmd.Flags().IntVar(&common.ServiceInfoSpec.Renew.Period, "renew-period", 0, "Renewal period in months")
+	common.AddServiceInfoRenewFlags(extraSQLServiceInfoUpdateCmd)
 	addParameterFileFlags(extraSQLServiceInfoUpdateCmd, true, nil, "", "", "", nil)
 	addInteractiveEditorFlag(extraSQLServiceInfoUpdateCmd)
 	extraSQLServiceInfoCmd.AddCommand(extraSQLServiceInfoUpdateCmd)
@@ -1330,11 +1326,7 @@ func init() {
 		ValidArgsFunction: completion.ServiceList("/v1/hosting/web"),
 		Run:               webhosting.UpdateCdnServiceInfo,
 	}
-	cdnServiceInfoUpdateCmd.Flags().BoolVar(&common.ServiceInfoSpec.Renew.Automatic, "renew-automatic", false, "Enable automatic renewal")
-	cdnServiceInfoUpdateCmd.Flags().BoolVar(&common.ServiceInfoSpec.Renew.DeleteAtExpiration, "renew-delete-at-expiration", false, "Delete service at expiration")
-	cdnServiceInfoUpdateCmd.Flags().BoolVar(&common.ServiceInfoSpec.Renew.Forced, "renew-forced", false, "Force renewal")
-	cdnServiceInfoUpdateCmd.Flags().BoolVar(&common.ServiceInfoSpec.Renew.ManualPayment, "renew-manual-payment", false, "Enable manual payment for renewal")
-	cdnServiceInfoUpdateCmd.Flags().IntVar(&common.ServiceInfoSpec.Renew.Period, "renew-period", 0, "Renewal period in months")
+	common.AddServiceInfoRenewFlags(cdnServiceInfoUpdateCmd)
 	addParameterFileFlags(cdnServiceInfoUpdateCmd, true, nil, "", "", "", nil)
 	addInteractiveEditorFlag(cdnServiceInfoUpdateCmd)
 	cdnServiceInfoCmd.AddCommand(cdnServiceInfoUpdateCmd)
@@ -1468,11 +1460,7 @@ func init() {
 		ValidArgsFunction: completion.ServiceList("/v1/hosting/web"),
 		Run:               webhosting.UpdateServiceInfo,
 	}
-	serviceInfoUpdateCmd.Flags().BoolVar(&common.ServiceInfoSpec.Renew.Automatic, "renew-automatic", false, "Enable automatic renewal")
-	serviceInfoUpdateCmd.Flags().BoolVar(&common.ServiceInfoSpec.Renew.DeleteAtExpiration, "renew-delete-at-expiration", false, "Delete service at expiration")
-	serviceInfoUpdateCmd.Flags().BoolVar(&common.ServiceInfoSpec.Renew.Forced, "renew-forced", false, "Force renewal")
-	serviceInfoUpdateCmd.Flags().BoolVar(&common.ServiceInfoSpec.Renew.ManualPayment, "renew-manual-payment", false, "Enable manual payment for renewal")
-	serviceInfoUpdateCmd.Flags().IntVar(&common.ServiceInfoSpec.Renew.Period, "renew-period", 0, "Renewal period in months")
+	common.AddServiceInfoRenewFlags(serviceInfoUpdateCmd)
 	addParameterFileFlags(serviceInfoUpdateCmd, true, nil, "", "", "", nil)
 	addInteractiveEditorFlag(serviceInfoUpdateCmd)
 	serviceInfoCmd.AddCommand(serviceInfoUpdateCmd)
@@ -1583,11 +1571,7 @@ func init() {
 		ValidArgsFunction: completion.ServiceList("/v1/hosting/web"),
 		Run:               webhosting.UpdateLocalSeoLocationServiceInfo,
 	}
-	localSeoLocationServiceInfoUpdateCmd.Flags().BoolVar(&common.ServiceInfoSpec.Renew.Automatic, "renew-automatic", false, "Enable automatic renewal")
-	localSeoLocationServiceInfoUpdateCmd.Flags().BoolVar(&common.ServiceInfoSpec.Renew.DeleteAtExpiration, "renew-delete-at-expiration", false, "Delete service at expiration")
-	localSeoLocationServiceInfoUpdateCmd.Flags().BoolVar(&common.ServiceInfoSpec.Renew.Forced, "renew-forced", false, "Force renewal")
-	localSeoLocationServiceInfoUpdateCmd.Flags().BoolVar(&common.ServiceInfoSpec.Renew.ManualPayment, "renew-manual-payment", false, "Enable manual payment for renewal")
-	localSeoLocationServiceInfoUpdateCmd.Flags().IntVar(&common.ServiceInfoSpec.Renew.Period, "renew-period", 0, "Renewal period in months")
+	common.AddServiceInfoRenewFlags(localSeoLocationServiceInfoUpdateCmd)
 	addParameterFileFlags(localSeoLocationServiceInfoUpdateCmd, true, nil, "", "", "", nil)
 	addInteractiveEditorFlag(localSeoLocationServiceInfoUpdateCmd)
 	localSeoLocationServiceInfoCmd.AddCommand(localSeoLocationServiceInfoUpdateCmd)

--- a/internal/cmd/webhosting.go
+++ b/internal/cmd/webhosting.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 
 	"github.com/ovh/ovhcloud-cli/internal/completion"
-	"github.com/ovh/ovhcloud-cli/internal/services/common"
 	"github.com/ovh/ovhcloud-cli/internal/services/webhosting"
 	"github.com/spf13/cobra"
 )
@@ -605,7 +604,7 @@ func init() {
 		ValidArgsFunction: completion.ServiceList("/v1/hosting/web"),
 		Run:               webhosting.UpdateExtraSqlServiceInfo,
 	}
-	common.AddServiceInfoRenewFlags(extraSQLServiceInfoUpdateCmd)
+	addServiceInfoRenewFlags(extraSQLServiceInfoUpdateCmd)
 	addParameterFileFlags(extraSQLServiceInfoUpdateCmd, true, nil, "", "", "", nil)
 	addInteractiveEditorFlag(extraSQLServiceInfoUpdateCmd)
 	extraSQLServiceInfoCmd.AddCommand(extraSQLServiceInfoUpdateCmd)
@@ -1326,7 +1325,7 @@ func init() {
 		ValidArgsFunction: completion.ServiceList("/v1/hosting/web"),
 		Run:               webhosting.UpdateCdnServiceInfo,
 	}
-	common.AddServiceInfoRenewFlags(cdnServiceInfoUpdateCmd)
+	addServiceInfoRenewFlags(cdnServiceInfoUpdateCmd)
 	addParameterFileFlags(cdnServiceInfoUpdateCmd, true, nil, "", "", "", nil)
 	addInteractiveEditorFlag(cdnServiceInfoUpdateCmd)
 	cdnServiceInfoCmd.AddCommand(cdnServiceInfoUpdateCmd)
@@ -1460,7 +1459,7 @@ func init() {
 		ValidArgsFunction: completion.ServiceList("/v1/hosting/web"),
 		Run:               webhosting.UpdateServiceInfo,
 	}
-	common.AddServiceInfoRenewFlags(serviceInfoUpdateCmd)
+	addServiceInfoRenewFlags(serviceInfoUpdateCmd)
 	addParameterFileFlags(serviceInfoUpdateCmd, true, nil, "", "", "", nil)
 	addInteractiveEditorFlag(serviceInfoUpdateCmd)
 	serviceInfoCmd.AddCommand(serviceInfoUpdateCmd)
@@ -1571,7 +1570,7 @@ func init() {
 		ValidArgsFunction: completion.ServiceList("/v1/hosting/web"),
 		Run:               webhosting.UpdateLocalSeoLocationServiceInfo,
 	}
-	common.AddServiceInfoRenewFlags(localSeoLocationServiceInfoUpdateCmd)
+	addServiceInfoRenewFlags(localSeoLocationServiceInfoUpdateCmd)
 	addParameterFileFlags(localSeoLocationServiceInfoUpdateCmd, true, nil, "", "", "", nil)
 	addInteractiveEditorFlag(localSeoLocationServiceInfoUpdateCmd)
 	localSeoLocationServiceInfoCmd.AddCommand(localSeoLocationServiceInfoUpdateCmd)

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -39,4 +39,10 @@ var (
 
 	// Flag to indicate whether the command should use a file for input parameters
 	ParametersFile string
+
+	// Flag used by destructive commands to skip the interactive confirmation
+	AssumeYes bool
+
+	// Flag used to display what would be sent to the API without sending it
+	DryRun bool
 )

--- a/internal/openapi/openapi.go
+++ b/internal/openapi/openapi.go
@@ -158,3 +158,41 @@ func pruneUnknownFields(data map[string]any, schema *openapi3.Schema) map[string
 	}
 	return cleaned
 }
+
+// GetRequestFieldEnum returns the values a request body field accepts, in the
+// order the specification lists them.
+//
+// Enumerations are worth reading rather than copying: `reason` on a termination
+// carries fourteen values today, and a list transcribed into Go drifts the day
+// the API gains a fifteenth — silently, into a 400 the operator cannot explain.
+// The specification already ships inside the binary, so the values are free.
+//
+// It returns nil, without an error, for a field that exists but enumerates
+// nothing: a caller asking for a free-text field wants an empty list, not a
+// failure.
+func GetRequestFieldEnum(spec []byte, path, method, field string) ([]string, error) {
+	content, err := getRequestBodyFromSpec(spec, path, method)
+	if err != nil {
+		return nil, err
+	}
+
+	if content.Schema == nil || content.Schema.Value == nil {
+		return nil, fmt.Errorf("no request schema for %s %s", method, path)
+	}
+
+	property, found := content.Schema.Value.Properties[field]
+	if !found || property.Value == nil {
+		return nil, fmt.Errorf("field %q not found in the body of %s %s", field, method, path)
+	}
+
+	values := make([]string, 0, len(property.Value.Enum))
+	for _, value := range property.Value.Enum {
+		text, ok := value.(string)
+		if !ok {
+			return nil, fmt.Errorf("field %q enumerates a %T, expected a string", field, value)
+		}
+		values = append(values, text)
+	}
+
+	return values, nil
+}

--- a/internal/services/baremetal/baremetal.go
+++ b/internal/services/baremetal/baremetal.go
@@ -23,7 +23,6 @@ import (
 	"github.com/ovh/ovhcloud-cli/internal/flags"
 	httpLib "github.com/ovh/ovhcloud-cli/internal/http"
 	"github.com/ovh/ovhcloud-cli/internal/services/common"
-	"github.com/ovh/ovhcloud-cli/internal/utils"
 	"github.com/spf13/cobra"
 )
 
@@ -142,6 +141,16 @@ func EditBaremetal(cmd *cobra.Command, args []string) {
 func RebootBaremetal(_ *cobra.Command, args []string) {
 	url := fmt.Sprintf("/v1/dedicated/server/%s/reboot", url.PathEscape(args[0]))
 
+	if !common.ConfirmAction(common.Disruptive, args[0],
+		fmt.Sprintf("Rebooting %s interrupts everything running on it.", args[0])) {
+		display.OutputError(&flags.OutputFormatConfig, "reboot of %s cancelled", args[0])
+		return
+	}
+
+	if common.ReportDryRun("POST", url) {
+		return
+	}
+
 	if err := httpLib.Client.Post(url, nil, nil); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "error rebooting server %s: %s", args[0], err)
 		return
@@ -151,6 +160,17 @@ func RebootBaremetal(_ *cobra.Command, args []string) {
 }
 
 func RebootRescueBaremetal(cmd *cobra.Command, args []string) {
+	if !common.ConfirmAction(common.Disruptive, args[0], fmt.Sprintf(
+		"Rebooting %s into rescue mode interrupts everything running on it, and it stays in rescue until the boot is set back to disk.",
+		args[0])) {
+		display.OutputError(&flags.OutputFormatConfig, "reboot of %s into rescue mode cancelled", args[0])
+		return
+	}
+
+	if common.ReportDryRun("POST", fmt.Sprintf("/v1/dedicated/server/%s/reboot", url.PathEscape(args[0]))) {
+		return
+	}
+
 	endpoint := fmt.Sprintf("/v1/dedicated/server/%s/boot?bootType=rescue", url.PathEscape(args[0]))
 
 	var boots []int
@@ -482,6 +502,19 @@ func CreateBaremetalOLAAggregation(_ *cobra.Command, args []string) {
 func ResetBaremetalOLAAggregation(_ *cobra.Command, args []string) {
 	url := fmt.Sprintf("/v1/dedicated/server/%s/ola/reset", url.PathEscape(args[0]))
 
+	// Resetting an aggregation takes the interfaces down and back up: on a
+	// server reached over that link, the operator is cutting the branch.
+	if !common.ConfirmAction(common.Disruptive, args[0], fmt.Sprintf(
+		"Resetting %d interface(s) of %s to their default configuration interrupts the network of the server.",
+		len(BaremetalOLAInterfaces), args[0])) {
+		display.OutputError(&flags.OutputFormatConfig, "interface reset on %s cancelled", args[0])
+		return
+	}
+
+	if common.ReportDryRun("POST", url) {
+		return
+	}
+
 	for _, itf := range BaremetalOLAInterfaces {
 		if err := httpLib.Client.Post(url, map[string]string{
 			"virtualNetworkInterface": itf,
@@ -503,18 +536,16 @@ func ReinstallBaremetal(cmd *cobra.Command, args []string) {
 		return
 	}
 
-	// Reinstalling wipes every disk of the server. Nothing else in this CLI
-	// destroys customer data, so this is the one place that asks before acting.
-	if !flags.AssumeYes && !flags.DryRun {
-		warning := fmt.Sprintf("Reinstalling %s wipes every disk of the server. This cannot be undone.", args[0])
-		if OperatingSystem != "" {
-			warning += fmt.Sprintf("\n   Operating system to install: %s", OperatingSystem)
-		}
+	// Reinstalling wipes every disk of the server, so this one asks for the
+	// server's name rather than a yes.
+	warning := fmt.Sprintf("Reinstalling %s wipes every disk of the server. This cannot be undone.", args[0])
+	if OperatingSystem != "" {
+		warning += fmt.Sprintf("\n   Operating system to install: %s", OperatingSystem)
+	}
 
-		if !utils.ConfirmByName(args[0], warning) {
-			display.OutputError(&flags.OutputFormatConfig, "reinstallation of %s cancelled", args[0])
-			return
-		}
+	if !common.ConfirmAction(common.Destructive, args[0], warning) {
+		display.OutputError(&flags.OutputFormatConfig, "reinstallation of %s cancelled", args[0])
+		return
 	}
 
 	endpoint := fmt.Sprintf("/v1/dedicated/server/%s/reinstall", url.PathEscape(args[0]))

--- a/internal/services/baremetal/baremetal.go
+++ b/internal/services/baremetal/baremetal.go
@@ -23,6 +23,7 @@ import (
 	"github.com/ovh/ovhcloud-cli/internal/flags"
 	httpLib "github.com/ovh/ovhcloud-cli/internal/http"
 	"github.com/ovh/ovhcloud-cli/internal/services/common"
+	"github.com/ovh/ovhcloud-cli/internal/utils"
 	"github.com/spf13/cobra"
 )
 
@@ -502,6 +503,20 @@ func ReinstallBaremetal(cmd *cobra.Command, args []string) {
 		return
 	}
 
+	// Reinstalling wipes every disk of the server. Nothing else in this CLI
+	// destroys customer data, so this is the one place that asks before acting.
+	if !flags.AssumeYes && !flags.DryRun {
+		warning := fmt.Sprintf("Reinstalling %s wipes every disk of the server. This cannot be undone.", args[0])
+		if OperatingSystem != "" {
+			warning += fmt.Sprintf("\n   Operating system to install: %s", OperatingSystem)
+		}
+
+		if !utils.ConfirmByName(args[0], warning) {
+			display.OutputError(&flags.OutputFormatConfig, "reinstallation of %s cancelled", args[0])
+			return
+		}
+	}
+
 	endpoint := fmt.Sprintf("/v1/dedicated/server/%s/reinstall", url.PathEscape(args[0]))
 	task, err := common.CreateResource(
 		cmd,
@@ -519,6 +534,11 @@ func ReinstallBaremetal(cmd *cobra.Command, args []string) {
 		[]string{"operatingSystem"})
 	if err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "error reinstalling server: %s", err)
+		return
+	}
+
+	// Nothing was sent in dry-run mode, so there is no task to follow.
+	if flags.DryRun {
 		return
 	}
 

--- a/internal/services/baremetal/baremetal.go
+++ b/internal/services/baremetal/baremetal.go
@@ -147,7 +147,7 @@ func RebootBaremetal(_ *cobra.Command, args []string) {
 		return
 	}
 
-	if common.ReportDryRun("POST", url) {
+	if common.ReportDryRun(common.Call{Method: "POST", Endpoint: url}) {
 		return
 	}
 
@@ -167,7 +167,14 @@ func RebootRescueBaremetal(cmd *cobra.Command, args []string) {
 		return
 	}
 
-	if common.ReportDryRun("POST", fmt.Sprintf("/v1/dedicated/server/%s/reboot", url.PathEscape(args[0]))) {
+	// Three calls, not one: the boot is read, written to the server, and only
+	// then is the server rebooted. The write is what outlives the reboot.
+	server := fmt.Sprintf("/v1/dedicated/server/%s", url.PathEscape(args[0]))
+	if common.ReportDryRun(
+		common.Call{Method: "GET", Endpoint: server + "/boot?bootType=rescue"},
+		common.Call{Method: "PUT", Endpoint: server + "  (bootId of the rescue entry)"},
+		common.Call{Method: "POST", Endpoint: server + "/reboot"},
+	) {
 		return
 	}
 
@@ -511,7 +518,13 @@ func ResetBaremetalOLAAggregation(_ *cobra.Command, args []string) {
 		return
 	}
 
-	if common.ReportDryRun("POST", url) {
+	// One call per interface, so the preview lists them rather than implying a
+	// single request.
+	calls := make([]common.Call, 0, len(BaremetalOLAInterfaces))
+	for _, itf := range BaremetalOLAInterfaces {
+		calls = append(calls, common.Call{Method: "POST", Endpoint: url + "  (virtualNetworkInterface " + itf + ")"})
+	}
+	if common.ReportDryRun(calls...) {
 		return
 	}
 

--- a/internal/services/baremetal/lifecycle.go
+++ b/internal/services/baremetal/lifecycle.go
@@ -1,0 +1,229 @@
+// SPDX-FileCopyrightText: 2025 OVH SAS <opensource@ovh.net>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package baremetal
+
+import (
+	"fmt"
+	"net/url"
+	"slices"
+	"strings"
+	"sync"
+
+	"github.com/ovh/ovhcloud-cli/internal/assets"
+	"github.com/ovh/ovhcloud-cli/internal/display"
+	"github.com/ovh/ovhcloud-cli/internal/flags"
+	httpLib "github.com/ovh/ovhcloud-cli/internal/http"
+	"github.com/ovh/ovhcloud-cli/internal/openapi"
+	"github.com/ovh/ovhcloud-cli/internal/services/common"
+	"github.com/spf13/cobra"
+)
+
+const confirmTerminationPath = "/dedicated/server/{serviceName}/confirmTermination"
+
+// Flags of `confirm-termination`. The reason and the intent are what the
+// termination survey asks for on the web side; sending them from the CLI is the
+// difference between ending a contract and ending it with a reason attached.
+var (
+	TerminationReason    string
+	TerminationFutureUse string
+	TerminationComment   string
+)
+
+// The accepted values live in the specification embedded in this binary, so
+// they are read rather than transcribed: `reason` carries fourteen values
+// today, and a list copied into Go drifts the day the API gains a fifteenth —
+// silently, into a 400 nobody can explain.
+//
+// Reading it costs about 50 ms, because the whole specification is loaded and
+// validated. That is why it is behind a sync.OnceValues and never called while
+// flags are being registered: every invocation of the CLI registers them, and
+// only a completion or an actual termination needs the values.
+var (
+	terminationReasons = sync.OnceValues(func() ([]string, error) {
+		return openapi.GetRequestFieldEnum(assets.BaremetalOpenapiSchema, confirmTerminationPath, "post", "reason")
+	})
+	terminationFutureUses = sync.OnceValues(func() ([]string, error) {
+		return openapi.GetRequestFieldEnum(assets.BaremetalOpenapiSchema, confirmTerminationPath, "post", "futureUse")
+	})
+)
+
+// CompleteTerminationReason and CompleteTerminationFutureUse offer the accepted
+// values on <tab>. They are the discoverable half of the pair: the flag help
+// cannot list fourteen values without becoming unreadable, and it must not read
+// the specification to find them.
+func CompleteTerminationReason(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+	return completeEnum(terminationReasons)
+}
+
+func CompleteTerminationFutureUse(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+	return completeEnum(terminationFutureUses)
+}
+
+func completeEnum(read func() ([]string, error)) ([]string, cobra.ShellCompDirective) {
+	values, err := read()
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveError
+	}
+	return values, cobra.ShellCompDirectiveNoFileComp
+}
+
+// checkEnumFlag rejects a value the API would reject, and names the ones it
+// would accept. A 400 from the other side of the network says "invalid value"
+// and stops there.
+func checkEnumFlag(name, value string, read func() ([]string, error)) error {
+	if value == "" {
+		return nil
+	}
+
+	accepted, err := read()
+	if err != nil {
+		return fmt.Errorf("failed to read the values accepted for --%s: %w", name, err)
+	}
+
+	if slices.Contains(accepted, value) {
+		return nil
+	}
+
+	return fmt.Errorf("--%s does not accept %q; accepted values are: %s",
+		name, value, strings.Join(accepted, ", "))
+}
+
+func GetBaremetalServiceInfo(_ *cobra.Command, args []string) {
+	endpoint := fmt.Sprintf("/v1/dedicated/server/%s/serviceInfos", url.PathEscape(args[0]))
+
+	var object map[string]any
+	if err := httpLib.Client.Get(endpoint, &object); err != nil {
+		display.OutputError(&flags.OutputFormatConfig, "error fetching service information for %s: %s", args[0], err)
+		return
+	}
+
+	display.OutputObject(object, args[0], common.ServiceInfoTemplate, &flags.OutputFormatConfig)
+}
+
+func EditBaremetalServiceInfo(cmd *cobra.Command, args []string) {
+	renewPayload := common.ServiceInfoRenewPayload(cmd)
+
+	if err := common.EditResource(
+		cmd,
+		"/dedicated/server/{serviceName}/serviceInfos",
+		fmt.Sprintf("/v1/dedicated/server/%s/serviceInfos", url.PathEscape(args[0])),
+		renewPayload,
+		assets.BaremetalOpenapiSchema,
+	); err != nil {
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
+		return
+	}
+}
+
+// TerminateBaremetal asks for the termination of a server. It stops nothing:
+// the API sends a token to the administrative contact by email, and the server
+// keeps running until that token is confirmed.
+//
+// The guard is therefore the interrupting kind rather than the destroying kind.
+// Making the operator type the server name here would spend the strong
+// confirmation on the reversible half of the pair, and teach them to reach for
+// --yes before the half that is not reversible.
+func TerminateBaremetal(_ *cobra.Command, args []string) {
+	endpoint := fmt.Sprintf("/v1/dedicated/server/%s/terminate", url.PathEscape(args[0]))
+
+	if !common.ConfirmAction(common.Disruptive, args[0], fmt.Sprintf(
+		"This asks for the termination of %s. Nothing stops now: a termination token is emailed to the administrative contact, and the server runs until that token is confirmed.",
+		args[0])) {
+		display.OutputError(&flags.OutputFormatConfig, "termination request for %s cancelled", args[0])
+		return
+	}
+
+	if common.ReportDryRun(common.Call{Method: "POST", Endpoint: endpoint}) {
+		return
+	}
+
+	// The response is a free-form string, and the token is not in it — the API
+	// mails it. Printing the body as though it were the token is how an
+	// operator ends up pasting a sentence into --token.
+	var response string
+	if err := httpLib.Client.Post(endpoint, nil, &response); err != nil {
+		display.OutputError(&flags.OutputFormatConfig, "error requesting termination of %s: %s", args[0], err)
+		return
+	}
+
+	message := fmt.Sprintf("⚡️ Termination of %s requested. A token has been emailed to the administrative contact; confirm with:\n  ovhcloud baremetal confirm-termination %s <token>", args[0], args[0])
+	if response != "" {
+		message += fmt.Sprintf("\nThe API answered: %s", response)
+	}
+
+	display.OutputInfo(&flags.OutputFormatConfig, map[string]any{"service": args[0], "response": response}, "%s", message)
+}
+
+// ConfirmBaremetalTermination is the irreversible half: it ends the contract and
+// the server goes back to OVHcloud at expiry. Hence the strongest guard the CLI
+// has, the server's own name typed by hand.
+//
+// The token is not that guard. It proves the request reached the administrative
+// contact's mailbox, which says nothing about whether this is the server they
+// meant.
+func ConfirmBaremetalTermination(_ *cobra.Command, args []string) {
+	if err := checkEnumFlag("reason", TerminationReason, terminationReasons); err != nil {
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
+		return
+	}
+	if err := checkEnumFlag("future-use", TerminationFutureUse, terminationFutureUses); err != nil {
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
+		return
+	}
+
+	endpoint := fmt.Sprintf("/v1/dedicated/server/%s/confirmTermination", url.PathEscape(args[0]))
+
+	if !common.ConfirmAction(common.Destructive, args[0], fmt.Sprintf(
+		"This confirms the termination of %s. The contract ends and the server is returned to OVHcloud at expiry; there is no undoing it from here.",
+		args[0])) {
+		display.OutputError(&flags.OutputFormatConfig, "termination of %s not confirmed", args[0])
+		return
+	}
+
+	body := map[string]any{"token": args[1]}
+	if TerminationReason != "" {
+		body["reason"] = TerminationReason
+	}
+	if TerminationFutureUse != "" {
+		body["futureUse"] = TerminationFutureUse
+	}
+	if TerminationComment != "" {
+		body["commentary"] = TerminationComment
+	}
+
+	// The preview names every field it would send and withholds one value: the
+	// token is a single-use credential, and a --dry-run is the one command an
+	// operator runs with the output on screen or in a pipeline log.
+	if common.ReportDryRun(common.Call{
+		Method:   "POST",
+		Endpoint: fmt.Sprintf("%s  (%s)", endpoint, describeTerminationBody(body)),
+	}) {
+		return
+	}
+
+	if err := httpLib.Client.Post(endpoint, body, nil); err != nil {
+		display.OutputError(&flags.OutputFormatConfig, "error confirming termination of %s: %s", args[0], err)
+		return
+	}
+
+	display.OutputInfo(&flags.OutputFormatConfig, map[string]any{"service": args[0]},
+		"✅ Termination of %s confirmed", args[0])
+}
+
+func describeTerminationBody(body map[string]any) string {
+	fields := make([]string, 0, len(body))
+	for _, name := range []string{"token", "reason", "futureUse", "commentary"} {
+		value, set := body[name]
+		if !set {
+			continue
+		}
+		if name == "token" {
+			fields = append(fields, "token: (withheld)")
+			continue
+		}
+		fields = append(fields, fmt.Sprintf("%s: %v", name, value))
+	}
+	return strings.Join(fields, ", ")
+}

--- a/internal/services/baremetal/lifecycle.go
+++ b/internal/services/baremetal/lifecycle.go
@@ -40,6 +40,11 @@ var (
 // validated. That is why it is behind a sync.OnceValues and never called while
 // flags are being registered: every invocation of the CLI registers them, and
 // only a completion or an actual termination needs the values.
+//
+// sync.OnceValues caches a failure as firmly as a success, which is what we
+// want: the input is compiled into the binary by //go:embed and cannot change
+// while the process runs, so a second attempt would read the same bytes and
+// fail the same way.
 var (
 	terminationReasons = sync.OnceValues(func() ([]string, error) {
 		return openapi.GetRequestFieldEnum(assets.BaremetalOpenapiSchema, confirmTerminationPath, "post", "reason")
@@ -148,12 +153,10 @@ func TerminateBaremetal(_ *cobra.Command, args []string) {
 		return
 	}
 
-	message := fmt.Sprintf("⚡️ Termination of %s requested. A token has been emailed to the administrative contact; confirm with:\n  ovhcloud baremetal confirm-termination %s <token>", args[0], args[0])
-	if response != "" {
-		message += fmt.Sprintf("\nThe API answered: %s", response)
-	}
-
-	display.OutputInfo(&flags.OutputFormatConfig, map[string]any{"service": args[0], "response": response}, "%s", message)
+	display.OutputInfo(&flags.OutputFormatConfig,
+		map[string]any{"service": args[0], "response": response},
+		"⚡️ Termination of %s requested. A token has been emailed to the administrative contact; confirm with:\n  ovhcloud baremetal confirm-termination %s <token>",
+		args[0], args[0])
 }
 
 // ConfirmBaremetalTermination is the irreversible half: it ends the contract and
@@ -173,6 +176,15 @@ func ConfirmBaremetalTermination(_ *cobra.Command, args []string) {
 		return
 	}
 
+	// cobra counts the arguments, it does not look at them: an empty second
+	// argument satisfies ExactArgs(2) and would travel all the way to a 400.
+	token := strings.TrimSpace(args[1])
+	if token == "" {
+		display.OutputError(&flags.OutputFormatConfig,
+			"no termination token given; it is the token emailed to the administrative contact by `baremetal terminate %s`", args[0])
+		return
+	}
+
 	endpoint := fmt.Sprintf("/v1/dedicated/server/%s/confirmTermination", url.PathEscape(args[0]))
 
 	if !common.ConfirmAction(common.Destructive, args[0], fmt.Sprintf(
@@ -182,7 +194,7 @@ func ConfirmBaremetalTermination(_ *cobra.Command, args []string) {
 		return
 	}
 
-	body := map[string]any{"token": args[1]}
+	body := map[string]any{"token": token}
 	if TerminationReason != "" {
 		body["reason"] = TerminationReason
 	}
@@ -212,6 +224,18 @@ func ConfirmBaremetalTermination(_ *cobra.Command, args []string) {
 		"✅ Termination of %s confirmed", args[0])
 }
 
+// fingerprint identifies a token without reproducing it. Withholding it
+// entirely was the first answer, and it costs the one thing an operator
+// legitimately checks in a preview: that the shell handed over the token they
+// pasted, rather than one it truncated or expanded. Four characters and a
+// length settle that question and reconstruct nothing.
+func fingerprint(token string) string {
+	if len(token) < 8 {
+		return fmt.Sprintf("(%d characters, too short to show)", len(token))
+	}
+	return fmt.Sprintf("%s… (%d characters)", token[:4], len(token))
+}
+
 func describeTerminationBody(body map[string]any) string {
 	fields := make([]string, 0, len(body))
 	for _, name := range []string{"token", "reason", "futureUse", "commentary"} {
@@ -220,7 +244,7 @@ func describeTerminationBody(body map[string]any) string {
 			continue
 		}
 		if name == "token" {
-			fields = append(fields, "token: (withheld)")
+			fields = append(fields, fmt.Sprintf("token: %s", fingerprint(fmt.Sprint(value))))
 			continue
 		}
 		fields = append(fields, fmt.Sprintf("%s: %v", name, value))

--- a/internal/services/common/common.go
+++ b/internal/services/common/common.go
@@ -24,20 +24,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var (
-	//go:embed templates/service_info.tmpl
-	ServiceInfoTemplate string
-
-	ServiceInfoSpec struct {
-		Renew struct {
-			Automatic          bool `json:"automatic"`
-			DeleteAtExpiration bool `json:"deleteAtExpiration"`
-			Forced             bool `json:"forced"`
-			ManualPayment      bool `json:"manualPayment"`
-			Period             int  `json:"period"`
-		} `json:"renew"`
-	}
-)
+//go:embed templates/service_info.tmpl
+var ServiceInfoTemplate string
 
 func ManageListRequest(path, idField string, columnsToDisplay, filters []string) {
 	body, err := httpLib.FetchExpandedArray(path, idField)

--- a/internal/services/common/common.go
+++ b/internal/services/common/common.go
@@ -183,10 +183,18 @@ func CreateResource(cmd *cobra.Command, path, endpoint, defaultExample string,
 	// --dry-run stops here: the caller sees exactly what would have been sent,
 	// and nothing reaches the API.
 	if flags.DryRun {
+		// The payload goes in the message, not only in the details: the
+		// default output prints the message alone, so a --dry-run whose body
+		// lived in the details printed a promise and no request.
+		payload, err := json.MarshalIndent(parameters, "", "  ")
+		if err != nil {
+			return nil, fmt.Errorf("failed to render the parameters: %w", err)
+		}
+
 		display.OutputInfo(&flags.OutputFormatConfig, map[string]any{
 			"endpoint":   endpoint,
 			"parameters": parameters,
-		}, "🔍 Dry run: nothing was sent. The request above would have been posted to %s", endpoint)
+		}, "🔍 Dry run: nothing was sent. This would have been posted to %s:\n%s", endpoint, payload)
 		return nil, nil
 	}
 

--- a/internal/services/common/common.go
+++ b/internal/services/common/common.go
@@ -180,6 +180,16 @@ func CreateResource(cmd *cobra.Command, path, endpoint, defaultExample string,
 
 	log.Println("Final parameters: \n" + string(out))
 
+	// --dry-run stops here: the caller sees exactly what would have been sent,
+	// and nothing reaches the API.
+	if flags.DryRun {
+		display.OutputInfo(&flags.OutputFormatConfig, map[string]any{
+			"endpoint":   endpoint,
+			"parameters": parameters,
+		}, "🔍 Dry run: nothing was sent. The request above would have been posted to %s", endpoint)
+		return nil, nil
+	}
+
 	var createdResource map[string]any
 	if err := httpLib.Client.Post(endpoint, parameters, &createdResource); err != nil {
 		return nil, fmt.Errorf("error creating resource: %w", err)

--- a/internal/services/common/common.go
+++ b/internal/services/common/common.go
@@ -178,8 +178,6 @@ func CreateResource(cmd *cobra.Command, path, endpoint, defaultExample string,
 		return nil, fmt.Errorf("parameters cannot be marshalled: %w", err)
 	}
 
-	log.Println("Final parameters: \n" + string(out))
-
 	// --dry-run stops here: the caller sees exactly what would have been sent,
 	// and nothing reaches the API.
 	if flags.DryRun {
@@ -197,6 +195,19 @@ func CreateResource(cmd *cobra.Command, path, endpoint, defaultExample string,
 		}, "🔍 Dry run: nothing was sent. This would have been posted to %s:\n%s", endpoint, payload)
 		return nil, nil
 	}
+
+	// Logged only once the dry run is ruled out. A --dry-run already prints the
+	// payload as its message, so logging it here printed the same JSON twice,
+	// the second time behind a Go timestamp no other command in this CLI emits:
+	//
+	//	🔍 Dry run: nothing was sent. This would have been posted to …
+	//	{ "operatingSystem": "debian12_64" }
+	//	2026/08/23 23:47:22 Final parameters:
+	//	{ "operatingSystem": "debian12_64" }
+	//
+	// A real run still logs what it is about to send, which is what this line
+	// was for.
+	log.Println("Final parameters: \n" + string(out))
 
 	var createdResource map[string]any
 	if err := httpLib.Client.Post(endpoint, parameters, &createdResource); err != nil {

--- a/internal/services/common/guard.go
+++ b/internal/services/common/guard.go
@@ -1,0 +1,68 @@
+// SPDX-FileCopyrightText: 2025 OVH SAS <opensource@ovh.net>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package common
+
+import (
+	"github.com/ovh/ovhcloud-cli/internal/display"
+	"github.com/ovh/ovhcloud-cli/internal/flags"
+	"github.com/ovh/ovhcloud-cli/internal/utils"
+)
+
+// Severity says how much an action costs when it was not the one intended.
+// The two levels exist because proportionality is what makes a guardrail
+// survive daily use: asking an operator to type a server name before every
+// reboot teaches them to reach for --yes, and a habit of --yes protects
+// nothing on the day it matters.
+type Severity int
+
+const (
+	// Disruptive interrupts a running service. Nothing is lost, but somebody
+	// notices.
+	Disruptive Severity = iota
+
+	// Destructive loses data, or the resource itself. There is no retry.
+	Destructive
+)
+
+// ConfirmAction gates an action behind a confirmation and reports whether the
+// caller may proceed.
+//
+// It answers true without asking anything in two cases: --yes, which is how a
+// pipeline states its intent, and --dry-run, where the caller is about to
+// print the request instead of sending it. A dry run that still demanded a
+// confirmation would refuse to describe what it will not do.
+//
+// When it answers false it has already told the operator why, so the caller
+// only has to stop.
+func ConfirmAction(severity Severity, resource, warning string) bool {
+	if flags.AssumeYes || flags.DryRun {
+		return true
+	}
+
+	switch severity {
+	case Destructive:
+		return utils.ConfirmByName(resource, warning)
+	default:
+		return utils.ConfirmYesNo(warning)
+	}
+}
+
+// ReportDryRun prints the call a command would have made, and reports true so
+// the caller can stop on the same line it tested the flag.
+//
+// The endpoint is shown in full because these commands have no other preview:
+// the whole point of --dry-run here is to let somebody read the path before it
+// is acted on.
+func ReportDryRun(method, endpoint string) bool {
+	if !flags.DryRun {
+		return false
+	}
+
+	display.OutputInfo(&flags.OutputFormatConfig,
+		map[string]any{"method": method, "endpoint": endpoint},
+		"🔍 Dry run: nothing was sent. This would have been called:\n  %s %s", method, endpoint)
+
+	return true
+}

--- a/internal/services/common/guard.go
+++ b/internal/services/common/guard.go
@@ -5,6 +5,8 @@
 package common
 
 import (
+	"fmt"
+
 	"github.com/ovh/ovhcloud-cli/internal/display"
 	"github.com/ovh/ovhcloud-cli/internal/flags"
 	"github.com/ovh/ovhcloud-cli/internal/utils"
@@ -18,12 +20,16 @@ import (
 type Severity int
 
 const (
+	// Destructive loses data, or the resource itself. There is no retry.
+	//
+	// It is deliberately the zero value: a caller that forgets to state a
+	// severity gets the strictest guard rather than the weakest one, and finds
+	// out immediately instead of on the day it mattered.
+	Destructive Severity = iota
+
 	// Disruptive interrupts a running service. Nothing is lost, but somebody
 	// notices.
-	Disruptive Severity = iota
-
-	// Destructive loses data, or the resource itself. There is no retry.
-	Destructive
+	Disruptive
 )
 
 // ConfirmAction gates an action behind a confirmation and reports whether the
@@ -42,27 +48,43 @@ func ConfirmAction(severity Severity, resource, warning string) bool {
 	}
 
 	switch severity {
-	case Destructive:
-		return utils.ConfirmByName(resource, warning)
-	default:
+	case Disruptive:
 		return utils.ConfirmYesNo(warning)
+	default:
+		return utils.ConfirmByName(resource, warning)
 	}
 }
 
-// ReportDryRun prints the call a command would have made, and reports true so
+// Call is one request a command would send.
+type Call struct {
+	Method   string
+	Endpoint string
+}
+
+// ReportDryRun prints every call a command would have made, and reports true so
 // the caller can stop on the same line it tested the flag.
 //
-// The endpoint is shown in full because these commands have no other preview:
-// the whole point of --dry-run here is to let somebody read the path before it
-// is acted on.
-func ReportDryRun(method, endpoint string) bool {
+// It takes the whole sequence rather than one call because several of these
+// commands are not one request. `reboot-rescue` reads the rescue boot, writes
+// it to the server and only then reboots — and the write is the part that
+// outlives the reboot. A preview that showed the reboot alone would hide
+// exactly the change an operator needs to see before agreeing to it.
+//
+// Endpoints are shown in full: these commands have no other preview, and the
+// point is to let somebody read the paths before they are acted on.
+func ReportDryRun(calls ...Call) bool {
 	if !flags.DryRun {
 		return false
 	}
 
-	display.OutputInfo(&flags.OutputFormatConfig,
-		map[string]any{"method": method, "endpoint": endpoint},
-		"🔍 Dry run: nothing was sent. This would have been called:\n  %s %s", method, endpoint)
+	details := make([]map[string]any, 0, len(calls))
+	message := "🔍 Dry run: nothing was sent. This would have been called:"
+	for _, c := range calls {
+		details = append(details, map[string]any{"method": c.Method, "endpoint": c.Endpoint})
+		message += fmt.Sprintf("\n  %s %s", c.Method, c.Endpoint)
+	}
+
+	display.OutputInfo(&flags.OutputFormatConfig, map[string]any{"calls": details}, "%s", message)
 
 	return true
 }

--- a/internal/services/common/guard_test.go
+++ b/internal/services/common/guard_test.go
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: 2025 OVH SAS <opensource@ovh.net>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package common
+
+import (
+	"testing"
+
+	"github.com/maxatome/go-testdeep/td"
+	"github.com/ovh/ovhcloud-cli/internal/flags"
+)
+
+// A caller that forgets to state a severity must get the strictest guard.
+// Written as an assertion on the constant rather than on behaviour, because
+// the failure this prevents is somebody reordering the block: the zero value
+// would quietly become the weak confirmation and every call site that relied
+// on the default would be downgraded without a single test noticing.
+func TestSeverity_ZeroValueIsTheStrictestGuard(t *testing.T) {
+	var unset Severity
+
+	td.Cmp(t, unset, Destructive,
+		"the zero value must be Destructive: an omitted severity is a bug, and it must fail safe")
+}
+
+// --yes is how a pipeline states its intent, for either severity.
+func TestConfirmAction_AssumeYesSkipsBothLevels(t *testing.T) {
+	orig := flags.AssumeYes
+	defer func() { flags.AssumeYes = orig }()
+	flags.AssumeYes = true
+
+	td.Cmp(t, ConfirmAction(Destructive, "srv", "wipes the disks"), true)
+	td.Cmp(t, ConfirmAction(Disruptive, "srv", "interrupts the service"), true)
+}
+
+// A dry run prints instead of acting, so it must never be gated by a
+// confirmation: refusing to describe a call it will not make is absurd.
+func TestConfirmAction_DryRunNeverPrompts(t *testing.T) {
+	orig := flags.DryRun
+	defer func() { flags.DryRun = orig }()
+	flags.DryRun = true
+
+	td.Cmp(t, ConfirmAction(Destructive, "srv", "wipes the disks"), true)
+}
+
+// ReportDryRun is inert unless --dry-run was given: it must not print over the
+// output of a command that is really running.
+func TestReportDryRun_IsInertWithoutTheFlag(t *testing.T) {
+	orig := flags.DryRun
+	defer func() { flags.DryRun = orig }()
+	flags.DryRun = false
+
+	td.Cmp(t, ReportDryRun(Call{Method: "POST", Endpoint: "/v1/whatever"}), false)
+}

--- a/internal/services/common/service_info.go
+++ b/internal/services/common/service_info.go
@@ -1,0 +1,82 @@
+// SPDX-FileCopyrightText: 2025 OVH SAS <opensource@ovh.net>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package common
+
+import "github.com/spf13/cobra"
+
+// The renewal flags shared by every `service-info edit` command, paired with
+// the field each one sets in the API object.
+//
+// The registration and the payload builder live side by side on purpose: the
+// flag name is the only thing that ties them together, so a rename that
+// touches one and not the other would silently stop sending a setting rather
+// than fail to compile.
+var serviceInfoRenewFlags = []struct {
+	name  string
+	field string
+	usage string
+}{
+	{"renew-automatic", "automatic", "Renew the service automatically"},
+	{"renew-delete-at-expiration", "deleteAtExpiration", "Delete the service when it expires"},
+	{"renew-forced", "forced", "Force the renewal"},
+	{"renew-manual-payment", "manualPayment", "Pay the renewal manually"},
+	{"renew-period", "period", "Renewal period, in months"},
+}
+
+// AddServiceInfoRenewFlags registers the renewal flags on a `service-info
+// edit` command.
+func AddServiceInfoRenewFlags(cmd *cobra.Command) {
+	for _, flag := range serviceInfoRenewFlags {
+		if flag.field == "period" {
+			cmd.Flags().Int(flag.name, 0, flag.usage)
+			continue
+		}
+		cmd.Flags().Bool(flag.name, false, flag.usage)
+	}
+}
+
+// ServiceInfoRenewPayload returns the renewal settings the operator actually
+// asked to change, and nothing else.
+//
+// The distinction matters more than it looks. These settings are booleans
+// bound to a struct with no `omitempty`, so building the payload from that
+// struct sends every one of them on every call — and a merge that lets the
+// command line win then turns `--renew-period 12` into "set the period to 12
+// AND switch automatic renewal off". The service kept renewing itself for
+// years; one unrelated edit stopped it, and nothing said so.
+//
+// Reading `Changed` rather than the values also keeps `--renew-automatic=false`
+// working: pflag records a flag as changed whatever value it was given, so an
+// explicit false is sent while an absent flag stays absent.
+func ServiceInfoRenewPayload(cmd *cobra.Command) map[string]any {
+	renew := map[string]any{}
+
+	for _, flag := range serviceInfoRenewFlags {
+		if !cmd.Flags().Changed(flag.name) {
+			continue
+		}
+
+		if flag.field == "period" {
+			period, err := cmd.Flags().GetInt(flag.name)
+			if err != nil {
+				continue
+			}
+			renew[flag.field] = period
+			continue
+		}
+
+		value, err := cmd.Flags().GetBool(flag.name)
+		if err != nil {
+			continue
+		}
+		renew[flag.field] = value
+	}
+
+	if len(renew) == 0 {
+		return map[string]any{}
+	}
+
+	return map[string]any{"renew": renew}
+}

--- a/internal/services/common/service_info.go
+++ b/internal/services/common/service_info.go
@@ -6,35 +6,31 @@ package common
 
 import "github.com/spf13/cobra"
 
-// The renewal flags shared by every `service-info edit` command, paired with
-// the field each one sets in the API object.
-//
-// The registration and the payload builder live side by side on purpose: the
-// flag name is the only thing that ties them together, so a rename that
-// touches one and not the other would silently stop sending a setting rather
-// than fail to compile.
-var serviceInfoRenewFlags = []struct {
-	name  string
-	field string
-	usage string
-}{
-	{"renew-automatic", "automatic", "Renew the service automatically"},
-	{"renew-delete-at-expiration", "deleteAtExpiration", "Delete the service when it expires"},
-	{"renew-forced", "forced", "Force the renewal"},
-	{"renew-manual-payment", "manualPayment", "Pay the renewal manually"},
-	{"renew-period", "period", "Renewal period, in months"},
+// ServiceInfoRenewFlag describes one renewal flag: what it is called on the
+// command line, and which field of the API object it sets.
+type ServiceInfoRenewFlag struct {
+	Name  string
+	Field string
+	Usage string
+
+	// Period is the one flag that carries a number rather than a yes or no.
+	Period bool
 }
 
-// AddServiceInfoRenewFlags registers the renewal flags on a `service-info
-// edit` command.
-func AddServiceInfoRenewFlags(cmd *cobra.Command) {
-	for _, flag := range serviceInfoRenewFlags {
-		if flag.field == "period" {
-			cmd.Flags().Int(flag.name, 0, flag.usage)
-			continue
-		}
-		cmd.Flags().Bool(flag.name, false, flag.usage)
-	}
+// ServiceInfoRenewFlags is the single description of the renewal flags shared
+// by every `service-info edit` command.
+//
+// It is exported rather than kept private because the command layer registers
+// the flags and this layer reads them back: the flag name is the only thing
+// tying the two halves together, so they must not each hold their own copy of
+// it. One table, read twice — a rename in it changes both sides at once, and a
+// rename anywhere else does not compile.
+var ServiceInfoRenewFlags = []ServiceInfoRenewFlag{
+	{Name: "renew-automatic", Field: "automatic", Usage: "Renew the service automatically"},
+	{Name: "renew-delete-at-expiration", Field: "deleteAtExpiration", Usage: "Delete the service when it expires"},
+	{Name: "renew-forced", Field: "forced", Usage: "Force the renewal"},
+	{Name: "renew-manual-payment", Field: "manualPayment", Usage: "Pay the renewal manually"},
+	{Name: "renew-period", Field: "period", Usage: "Renewal period, in months", Period: true},
 }
 
 // ServiceInfoRenewPayload returns the renewal settings the operator actually
@@ -53,25 +49,25 @@ func AddServiceInfoRenewFlags(cmd *cobra.Command) {
 func ServiceInfoRenewPayload(cmd *cobra.Command) map[string]any {
 	renew := map[string]any{}
 
-	for _, flag := range serviceInfoRenewFlags {
-		if !cmd.Flags().Changed(flag.name) {
+	for _, flag := range ServiceInfoRenewFlags {
+		if !cmd.Flags().Changed(flag.Name) {
 			continue
 		}
 
-		if flag.field == "period" {
-			period, err := cmd.Flags().GetInt(flag.name)
+		if flag.Period {
+			period, err := cmd.Flags().GetInt(flag.Name)
 			if err != nil {
 				continue
 			}
-			renew[flag.field] = period
+			renew[flag.Field] = period
 			continue
 		}
 
-		value, err := cmd.Flags().GetBool(flag.name)
+		value, err := cmd.Flags().GetBool(flag.Name)
 		if err != nil {
 			continue
 		}
-		renew[flag.field] = value
+		renew[flag.Field] = value
 	}
 
 	if len(renew) == 0 {

--- a/internal/services/vps/vps.go
+++ b/internal/services/vps/vps.go
@@ -310,11 +310,13 @@ func GetVpsServiceInfo(_ *cobra.Command, args []string) {
 }
 
 func EditVpsServiceInfo(cmd *cobra.Command, args []string) {
+	renewPayload := common.ServiceInfoRenewPayload(cmd)
+
 	if err := common.EditResource(
 		cmd,
 		"/vps/{serviceName}/serviceInfos",
 		fmt.Sprintf("/v1/vps/%s/serviceInfos", url.PathEscape(args[0])),
-		common.ServiceInfoSpec,
+		renewPayload,
 		assets.VpsOpenapiSchema,
 	); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "%s", err)

--- a/internal/services/webhosting/webhosting.go
+++ b/internal/services/webhosting/webhosting.go
@@ -940,7 +940,7 @@ func GetExtraSqlServiceInfo(_ *cobra.Command, args []string) {
 }
 
 func UpdateExtraSqlServiceInfo(cmd *cobra.Command, args []string) {
-	payload := buildServiceInfoRenewPayload(cmd)
+	payload := common.ServiceInfoRenewPayload(cmd)
 	if len(payload) == 0 && !flags.ParametersViaEditor && flags.ParametersFile == "" {
 		display.OutputInfo(&flags.OutputFormatConfig, nil, "🟠 No parameters given, nothing to edit")
 		return
@@ -2532,7 +2532,7 @@ func GetCdnServiceInfo(_ *cobra.Command, args []string) {
 }
 
 func UpdateCdnServiceInfo(cmd *cobra.Command, args []string) {
-	payload := buildServiceInfoRenewPayload(cmd)
+	payload := common.ServiceInfoRenewPayload(cmd)
 	if len(payload) == 0 && !flags.ParametersViaEditor && flags.ParametersFile == "" {
 		display.OutputInfo(&flags.OutputFormatConfig, nil, "🟠 No parameters given, nothing to edit")
 		return
@@ -2733,31 +2733,6 @@ func buildCdnOptionConfig(cmd *cobra.Command) map[string]any {
 	}
 
 	return config
-}
-
-func buildServiceInfoRenewPayload(cmd *cobra.Command) map[string]any {
-	renew := map[string]any{}
-	if cmd.Flags().Changed("renew-automatic") {
-		renew["automatic"] = common.ServiceInfoSpec.Renew.Automatic
-	}
-	if cmd.Flags().Changed("renew-delete-at-expiration") {
-		renew["deleteAtExpiration"] = common.ServiceInfoSpec.Renew.DeleteAtExpiration
-	}
-	if cmd.Flags().Changed("renew-forced") {
-		renew["forced"] = common.ServiceInfoSpec.Renew.Forced
-	}
-	if cmd.Flags().Changed("renew-manual-payment") {
-		renew["manualPayment"] = common.ServiceInfoSpec.Renew.ManualPayment
-	}
-	if cmd.Flags().Changed("renew-period") {
-		renew["period"] = common.ServiceInfoSpec.Renew.Period
-	}
-
-	if len(renew) == 0 {
-		return map[string]any{}
-	}
-
-	return map[string]any{"renew": renew}
 }
 
 func formatQuota(value any) (string, bool) {
@@ -2980,7 +2955,7 @@ func GetServiceInfo(_ *cobra.Command, args []string) {
 }
 
 func UpdateServiceInfo(cmd *cobra.Command, args []string) {
-	payload := buildServiceInfoRenewPayload(cmd)
+	payload := common.ServiceInfoRenewPayload(cmd)
 	if len(payload) == 0 && !flags.ParametersViaEditor && flags.ParametersFile == "" && !utils.IsInputFromPipe() {
 		display.OutputInfo(&flags.OutputFormatConfig, nil, "🟠 No parameters given, nothing to edit")
 		return
@@ -3240,7 +3215,7 @@ func GetLocalSeoLocationServiceInfo(_ *cobra.Command, args []string) {
 }
 
 func UpdateLocalSeoLocationServiceInfo(cmd *cobra.Command, args []string) {
-	payload := buildServiceInfoRenewPayload(cmd)
+	payload := common.ServiceInfoRenewPayload(cmd)
 	if len(payload) == 0 && !flags.ParametersViaEditor && flags.ParametersFile == "" {
 		display.OutputInfo(&flags.OutputFormatConfig, nil, "🟠 No parameters given, nothing to edit")
 		return

--- a/internal/utils/confirm_test.go
+++ b/internal/utils/confirm_test.go
@@ -75,3 +75,37 @@ func TestConfirmByName_RefusesWhenNotInteractive(t *testing.T) {
 
 	td.Cmp(t, ConfirmByName("ns3168421.ip-51-77-12.eu", "this wipes both disks"), false)
 }
+
+// A reboot asks for a yes, not for the server's name: the friction has to match
+// the risk or it gets bypassed by habit.
+func TestConfirmYesNo_AcceptsYes(t *testing.T) {
+	for _, answer := range []string{"y\n", "Y\n", "yes\n", "  YES  \n"} {
+		var confirmed bool
+		withInteractiveInput(t, answer, func() {
+			confirmed = ConfirmYesNo("this reboots the server")
+		})
+		td.Cmp(t, confirmed, true, "answer %q must confirm", answer)
+	}
+}
+
+// Everything else declines, including the empty answer that a hurried Enter
+// produces — the prompt reads [y/N] and must mean it.
+func TestConfirmYesNo_RefusesAnythingElse(t *testing.T) {
+	for _, answer := range []string{"\n", "n\n", "no\n", "ya\n", "sure\n", "yes please\n"} {
+		var confirmed bool
+		withInteractiveInput(t, answer, func() {
+			confirmed = ConfirmYesNo("this reboots the server")
+		})
+		td.Cmp(t, confirmed, false, "answer %q must decline", answer)
+	}
+}
+
+// Non-interactive means a pipeline, and a pipeline that did not say --yes did
+// not consent.
+func TestConfirmYesNo_RefusesWhenNotInteractive(t *testing.T) {
+	origInteractive := confirmInteractive
+	confirmInteractive = func() bool { return false }
+	defer func() { confirmInteractive = origInteractive }()
+
+	td.Cmp(t, ConfirmYesNo("this reboots the server"), false)
+}

--- a/internal/utils/confirm_test.go
+++ b/internal/utils/confirm_test.go
@@ -1,0 +1,77 @@
+// SPDX-FileCopyrightText: 2025 OVH SAS <opensource@ovh.net>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !(js && wasm)
+
+package utils
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/maxatome/go-testdeep/td"
+)
+
+// withInteractiveInput runs f as if the operator were typing answer at an
+// interactive terminal.
+func withInteractiveInput(t *testing.T, answer string, f func()) {
+	t.Helper()
+
+	origInput, origInteractive := confirmInput, confirmInteractive
+	confirmInput = strings.NewReader(answer)
+	confirmInteractive = func() bool { return true }
+	defer func() { confirmInput, confirmInteractive = origInput, origInteractive }()
+
+	f()
+}
+
+// The exact name is the guard between a typo and an erased disk, so the
+// accepting path has to be exercised, not only the refusals around it.
+func TestConfirmByName_AcceptsTheExactName(t *testing.T) {
+	var confirmed bool
+	withInteractiveInput(t, "ns3168421.ip-51-77-12.eu\n", func() {
+		confirmed = ConfirmByName("ns3168421.ip-51-77-12.eu", "this wipes both disks")
+	})
+
+	td.Cmp(t, confirmed, true)
+}
+
+// Surrounding whitespace is the operator's, not the server's.
+func TestConfirmByName_AcceptsTheNameWithSurroundingSpaces(t *testing.T) {
+	var confirmed bool
+	withInteractiveInput(t, "  ns3168421.ip-51-77-12.eu  \n", func() {
+		confirmed = ConfirmByName("ns3168421.ip-51-77-12.eu", "this wipes both disks")
+	})
+
+	td.Cmp(t, confirmed, true)
+}
+
+// Anything else is a refusal: a near miss must not pass.
+func TestConfirmByName_RejectsAnythingElse(t *testing.T) {
+	for _, answer := range []string{
+		"ns3168421.ip-51-77-12.e\n",  // one character short
+		"ns3168422.ip-51-77-12.eu\n", // the neighbouring server
+		"yes\n",
+		"\n",
+		"", // stream closed before any answer
+	} {
+		var confirmed bool
+		withInteractiveInput(t, answer, func() {
+			confirmed = ConfirmByName("ns3168421.ip-51-77-12.eu", "this wipes both disks")
+		})
+
+		td.Cmp(t, confirmed, false, "answer %q must not confirm", answer)
+	}
+}
+
+// Without a terminal there is no prompt at all: an unattended run has to opt
+// in with --yes rather than be asked a question nobody will read.
+func TestConfirmByName_RefusesWhenNotInteractive(t *testing.T) {
+	origInput, origInteractive := confirmInput, confirmInteractive
+	confirmInput = strings.NewReader("ns3168421.ip-51-77-12.eu\n")
+	confirmInteractive = func() bool { return false }
+	defer func() { confirmInput, confirmInteractive = origInput, origInteractive }()
+
+	td.Cmp(t, ConfirmByName("ns3168421.ip-51-77-12.eu", "this wipes both disks"), false)
+}

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -7,6 +7,7 @@ package utils
 import (
 	"bufio"
 	"fmt"
+	"io"
 	"os"
 	"runtime"
 	"strings"
@@ -39,8 +40,18 @@ func IsInputFromPipe() bool {
 //
 // The prompt is written to stderr so that a redirected stdout keeps holding
 // data only.
+// Both indirections exist so that the confirmation path itself can be
+// exercised by a test: it is the guard standing between a typo and an erased
+// disk, and a guard nobody executes is a guard nobody has checked.
+var (
+	confirmInput       io.Reader = os.Stdin
+	confirmInteractive           = func() bool {
+		return !IsInputFromPipe() && term.IsTerminal(os.Stdin.Fd())
+	}
+)
+
 func ConfirmByName(expected, warning string) bool {
-	if IsInputFromPipe() || !term.IsTerminal(os.Stdin.Fd()) {
+	if !confirmInteractive() {
 		fmt.Fprintf(os.Stderr,
 			"🛑 %s\n   Refusing to continue without a confirmation. Re-run with --yes to confirm, or --dry-run to preview.\n",
 			warning)
@@ -49,7 +60,7 @@ func ConfirmByName(expected, warning string) bool {
 
 	fmt.Fprintf(os.Stderr, "⚠️  %s\n   Type %q to confirm › ", warning, expected)
 
-	reader := bufio.NewReader(os.Stdin)
+	reader := bufio.NewReader(confirmInput)
 	answer, err := reader.ReadString('\n')
 	if err != nil {
 		return false

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -50,6 +50,38 @@ var (
 	}
 )
 
+// ConfirmYesNo asks for a plain yes before an action that interrupts a running
+// service without losing anything. Typing the resource name, as ConfirmByName
+// requires, is the right friction for an irreversible act and the wrong one for
+// a reboot: a guardrail that is tiresome out of proportion to its risk is a
+// guardrail people learn to bypass.
+//
+// Anything other than "y" or "yes" declines, and a non-interactive session
+// declines rather than guessing.
+func ConfirmYesNo(warning string) bool {
+	if !confirmInteractive() {
+		fmt.Fprintf(os.Stderr,
+			"🛑 %s\n   Refusing to continue without a confirmation. Re-run with --yes to confirm, or --dry-run to preview.\n",
+			warning)
+		return false
+	}
+
+	fmt.Fprintf(os.Stderr, "⚠️  %s\n   Continue? [y/N] › ", warning)
+
+	reader := bufio.NewReader(confirmInput)
+	answer, err := reader.ReadString('\n')
+	if err != nil {
+		return false
+	}
+
+	switch strings.ToLower(strings.TrimSpace(answer)) {
+	case "y", "yes":
+		return true
+	default:
+		return false
+	}
+}
+
 func ConfirmByName(expected, warning string) bool {
 	if !confirmInteractive() {
 		fmt.Fprintf(os.Stderr,

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -29,7 +29,15 @@ func IsInputFromPipe() bool {
 		return false
 	}
 
-	fileInfo, _ := os.Stdin.Stat()
+	// A closed or otherwise unstatable stdin returns a nil FileInfo, and every
+	// guarded command asks this before it may prompt: dereferencing it crashed
+	// the command instead of letting it decline. Treated as "not a terminal",
+	// which is the safe reading — an input nobody can describe is not one an
+	// operator is typing into.
+	fileInfo, err := os.Stdin.Stat()
+	if err != nil {
+		return true
+	}
 	return fileInfo.Mode()&os.ModeCharDevice == 0
 }
 

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -5,11 +5,14 @@
 package utils
 
 import (
+	"bufio"
 	"fmt"
 	"os"
 	"runtime"
+	"strings"
 
 	"dario.cat/mergo"
+	"github.com/charmbracelet/x/term"
 )
 
 func MergeMaps(left, right map[string]any) error {
@@ -27,4 +30,30 @@ func IsInputFromPipe() bool {
 
 	fileInfo, _ := os.Stdin.Stat()
 	return fileInfo.Mode()&os.ModeCharDevice == 0
+}
+
+// ConfirmByName asks the operator to type the given name before a destructive
+// action is carried out. It returns false — without prompting — when the input
+// is not an interactive terminal, so an unattended run never destroys anything
+// by default: such runs must opt in explicitly.
+//
+// The prompt is written to stderr so that a redirected stdout keeps holding
+// data only.
+func ConfirmByName(expected, warning string) bool {
+	if IsInputFromPipe() || !term.IsTerminal(os.Stdin.Fd()) {
+		fmt.Fprintf(os.Stderr,
+			"🛑 %s\n   Refusing to continue without a confirmation. Re-run with --yes to confirm, or --dry-run to preview.\n",
+			warning)
+		return false
+	}
+
+	fmt.Fprintf(os.Stderr, "⚠️  %s\n   Type %q to confirm › ", warning, expected)
+
+	reader := bufio.NewReader(os.Stdin)
+	answer, err := reader.ReadString('\n')
+	if err != nil {
+		return false
+	}
+
+	return strings.TrimSpace(answer) == expected
 }

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -5,6 +5,7 @@
 package utils
 
 import (
+	"os"
 	"testing"
 
 	"github.com/maxatome/go-testdeep/td"
@@ -69,4 +70,39 @@ func TestMergeMaps_WrongType(t *testing.T) {
 	err := MergeMaps(left, right)
 	td.CmpNoError(t, err)
 	td.Cmp(t, left, expected)
+}
+
+// A guard that panics has stopped being a guard.
+//
+// Since #242 every disruptive command asks IsInputFromPipe whether it may
+// prompt, so this runs before any confirmation can refuse. os.Stdin.Stat()
+// fails on a closed descriptor and returns a nil FileInfo; dereferencing it
+// crashes the command with a nil pointer instead of declining the action.
+//
+// Closing os.Stdin is what the test is about, so it is restored afterwards
+// rather than left broken for the rest of the package.
+func TestIsInputFromPipeDoesNotPanicOnAClosedStdin(t *testing.T) {
+	original := os.Stdin
+	t.Cleanup(func() { os.Stdin = original })
+
+	read, write, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("failed to create a pipe: %s", err)
+	}
+	write.Close()
+	read.Close()
+	os.Stdin = read
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("IsInputFromPipe panicked on a closed stdin: %v", r)
+		}
+	}()
+
+	// The value does not matter; not crashing does. A descriptor that cannot be
+	// stated is not a terminal, so the guarded command must refuse rather than
+	// prompt.
+	if IsInputFromPipe() != true {
+		t.Error("an unstatable stdin is not an interactive terminal")
+	}
 }


### PR DESCRIPTION
# Description

`baremetal` could reinstall a server, reboot it and read its tasks, but not see
when it expires, change how it renews, or hand it back. Four commands close
that:

```
ovhcloud baremetal service-info get <server>
ovhcloud baremetal service-info edit <server> [--renew-automatic ...]
ovhcloud baremetal terminate <server>
ovhcloud baremetal confirm-termination <server> <token> [--reason ...]
```

## The two halves of a termination are not the same act

`terminate` stops nothing. OVHcloud emails a token to the administrative
contact and the server keeps running. It asks for a yes, and its message says
where the token arrives and what to run next — the response body is *not* the
token, and reporting it as one is how an operator ends up pasting a sentence
into the confirmation.

`confirm-termination` ends the contract, so it asks for the server's own name.
Spending the strong confirmation on the reversible half would only teach the
operator to reach for `--yes` before the half that is not reversible.

Both honour `--yes` and `--dry-run`, and both refuse an unattended run that
said neither.

## The enumerations are read, not copied

`confirm-termination` carries the survey the web form asks for: `--reason`,
`--future-use`, `--commentary`. The accepted values come from the OpenAPI
specification already embedded in the binary. `reason` has fourteen today, and
a list transcribed into Go drifts the day the API gains a fifteenth — silently,
into a 400 nobody can explain. They are offered on `<tab>` and checked before
anything is sent, so a wrong value is named here, with the accepted ones.

Reading the specification costs about 50 ms, measured, so it happens on
completion or on the call itself and never while flags are registered — every
invocation of the CLI registers them.

## What the review passes changed

Two external models reviewed the first commit. Four things came back and are
fixed in the second:

- an empty token satisfied `ExactArgs(2)` and travelled to the API to be told
  what the CLI already knew;
- the preview withheld the token entirely, which also hid an empty one. It now
  prints four characters and a length — enough to spot a token the shell
  mangled, not enough to be a credential in a log;
- `terminate` echoed the API's free-form answer into the sentence meant for the
  operator; it stays in the structured details, where a script can still read it;
- `sync.OnceValues` caches a failure as firmly as a success, which is correct
  here and now says why: the specification is compiled in by `//go:embed`.

Two claims from that review were checked and did not hold: an API refusal is
already reported as an error rather than a success (verified against a 400), and
the survey flags do not leak between two commands in one process (verified by
removing `PostExecute` and watching the test fail).

## Tests

Ten, each checked against the failure it exists to catch: removing the guard,
dropping a field, disabling the enum check, printing the token, accepting an
empty one, and skipping the flag reset each fail exactly the test written for it.

## Depends on

- #242 for `common.ConfirmAction` / `common.ReportDryRun`
- #243 for `common.ServiceInfoRenewPayload`

Both are shown in the commit list until they merge.

# Type of change

- [X] New feature (non-breaking change which adds functionality)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have commented my code
- [X] I ran `go mod tidy`
- [X] I have added tests that prove my feature works
