### PR TITLE
fix(filters): --filter was accepted, documented, and ignored on 20 commands

### DIFF
--- a/doc/ovhcloud_cloud_loadbalancer_log_list-kinds.md
+++ b/doc/ovhcloud_cloud_loadbalancer_log_list-kinds.md
@@ -9,14 +9,7 @@ ovhcloud cloud loadbalancer log list-kinds <region> [flags]
 ### Options
 
 ```
-      --filter stringArray   Filter results by any property using https://github.com/PaesslerAG/gval syntax
-                             Examples:
-                               --filter 'state=="running"'
-                               --filter 'name=~"^my.*"'
-                               --filter 'nested.property.subproperty>10'
-                               --filter 'startDate>="2023-12-01"'
-                               --filter 'name=~"something" && nbField>10'
-  -h, --help                 help for list-kinds
+  -h, --help   help for list-kinds
 ```
 
 ### Options inherited from parent commands

--- a/doc/ovhcloud_cloud_storage_object_quota_get.md
+++ b/doc/ovhcloud_cloud_storage_object_quota_get.md
@@ -9,14 +9,7 @@ ovhcloud cloud storage object quota get <region> [flags]
 ### Options
 
 ```
-      --filter stringArray   Filter results by any property using https://github.com/PaesslerAG/gval syntax
-                             Examples:
-                               --filter 'state=="running"'
-                               --filter 'name=~"^my.*"'
-                               --filter 'nested.property.subproperty>10'
-                               --filter 'startDate>="2023-12-01"'
-                               --filter 'name=~"something" && nbField>10'
-  -h, --help                 help for get
+  -h, --help   help for get
 ```
 
 ### Options inherited from parent commands

--- a/internal/cmd/cloud_loadbalancer.go
+++ b/internal/cmd/cloud_loadbalancer.go
@@ -610,12 +610,15 @@ func initLogSubCommands(loadbalancerCmd *cobra.Command) {
 	}
 	loadbalancerCmd.AddCommand(logCmd)
 
-	logCmd.AddCommand(withFilterFlag(&cobra.Command{
+	// No --filter here: the API answers a list of plain strings, and --filter
+	// selects on the properties of a row. There is nothing for it to select on,
+	// so registering it only had docgen document it and cobra accept it.
+	logCmd.AddCommand(&cobra.Command{
 		Use:   "list-kinds <region>",
 		Short: "List available log kinds",
 		Run:   cloud.ListCloudLoadbalancerLogKinds,
 		Args:  cobra.ExactArgs(1),
-	}))
+	})
 
 	logCmd.AddCommand(&cobra.Command{
 		Use:   "get-kind <region> <kind_name>",

--- a/internal/cmd/cloud_storage_object.go
+++ b/internal/cmd/cloud_storage_object.go
@@ -288,12 +288,14 @@ func initCloudStorageS3Command(cloudCmd *cobra.Command) {
 	}
 	storageS3Cmd.AddCommand(quotaCmd)
 
-	quotaCmd.AddCommand(withFilterFlag(&cobra.Command{
+	// No --filter here: this reads the quota of one region and renders one
+	// object. There are no rows to filter.
+	quotaCmd.AddCommand(&cobra.Command{
 		Use:   "get <region>",
 		Short: "Get storage quota for the given region",
 		Run:   cloud.GetStorageS3Quota,
 		Args:  cobra.ExactArgs(1),
-	}))
+	})
 
 	quotaEditCmd := &cobra.Command{
 		Use:   "edit <region>",

--- a/internal/cmd/filter_flag_test.go
+++ b/internal/cmd/filter_flag_test.go
@@ -1,0 +1,107 @@
+// SPDX-FileCopyrightText: 2026 OVH SAS <opensource@ovh.net>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd_test
+
+import (
+	"github.com/jarcoal/httpmock"
+	"github.com/maxatome/go-testdeep/td"
+	"github.com/ovh/ovhcloud-cli/internal/cmd"
+)
+
+// withFilterFlag only binds --filter to flags.GenericFilters; the filtering
+// itself happens in ManageListRequest and ManageListRequestNoExpand. A command
+// that assembles its own rows and calls display.RenderTable therefore accepts
+// the flag, documents it, offers completion for it, and ignores it.
+//
+// Every assertion below is on the row the filter is supposed to REMOVE.
+// Asserting the kept row is present would pass just as well with no filtering
+// at all, which is how twenty of these went unnoticed.
+
+func (ms *MockSuite) TestVpsRestorePointsAreFiltered(assert, require *td.T) {
+	httpmock.RegisterResponder("GET",
+		"https://eu.api.ovh.com/v1/vps/vps-12345/automatedBackup/restorePoints?state=available",
+		httpmock.NewStringResponder(200, `["2026-08-01T00:00:00Z","2026-08-20T00:00:00Z"]`))
+
+	out, err := cmd.Execute("vps", "automated-backup", "list-restore-points", "vps-12345",
+		"--filter", `restorePoint=~"2026-08-20"`)
+
+	require.CmpNoError(err)
+	assert.Cmp(out, td.Not(td.Contains("2026-08-01")), "the excluded restore point must be gone")
+	assert.Cmp(out, td.Contains("2026-08-20"))
+}
+
+func (ms *MockSuite) TestKubeIPRestrictionsAreFiltered(assert, require *td.T) {
+	httpmock.RegisterResponder("GET",
+		"https://eu.api.ovh.com/v1/cloud/project/fakeProjectID/kube/kube-12345/ipRestrictions",
+		httpmock.NewStringResponder(200, `["203.0.113.0/24","198.51.100.7/32"]`))
+
+	out, err := cmd.Execute("cloud", "managed-kubernetes", "ip-restrictions", "list", "kube-12345",
+		"--cloud-project", "fakeProjectID", "--filter", `ip=~"^203\\."`)
+
+	require.CmpNoError(err)
+	assert.Cmp(out, td.Not(td.Contains("198.51.100.7")), "the excluded restriction must be gone")
+	assert.Cmp(out, td.Contains("203.0.113.0"))
+}
+
+func (ms *MockSuite) TestWebhostingModuleCatalogIsFiltered(assert, require *td.T) {
+	httpmock.RegisterResponder("GET",
+		"https://eu.api.ovh.com/v1/hosting/web/moduleList",
+		httpmock.NewStringResponder(200, `[1,2]`))
+	httpmock.RegisterResponder("GET",
+		"https://eu.api.ovh.com/v1/hosting/web/moduleList/1",
+		httpmock.NewStringResponder(200, `{"id":1,"name":"wordpress","branch":"6","version":"6.5","active":true,"latest":true}`))
+	httpmock.RegisterResponder("GET",
+		"https://eu.api.ovh.com/v1/hosting/web/moduleList/2",
+		httpmock.NewStringResponder(200, `{"id":2,"name":"joomla","branch":"5","version":"5.1","active":true,"latest":true}`))
+
+	out, err := cmd.Execute("webhosting", "module", "catalog", "list", "--filter", `name=="wordpress"`)
+
+	require.CmpNoError(err)
+	assert.Cmp(out, td.Not(td.Contains("joomla")), "the excluded module must be gone")
+	assert.Cmp(out, td.Contains("wordpress"))
+}
+
+// This one does not render a table: it wraps its list in an object and hands it
+// to a template, so the filter has to run BEFORE the wrapping — once the list is
+// inside an object there are no rows left to select from.
+func (ms *MockSuite) TestWebhostingOvhConfigCapabilitiesAreFiltered(assert, require *td.T) {
+	httpmock.RegisterResponder("GET",
+		"https://eu.api.ovh.com/v1/hosting/web/site.example/ovhConfigCapabilities",
+		httpmock.NewStringResponder(200,
+			`[{"version":"8.3","container":"jessie.i386"},{"version":"7.4","container":"stretch.i386"}]`))
+
+	out, err := cmd.Execute("webhosting", "ovh-config", "capabilities", "site.example",
+		"--filter", `version=="8.3"`)
+
+	require.CmpNoError(err)
+	assert.Cmp(out, td.Not(td.Contains("7.4")), "the excluded capability must be gone")
+	assert.Cmp(out, td.Contains("8.3"))
+}
+
+// The other half of the fix: two commands render one object, so there was never
+// anything for --filter to select. Removing the flag is the honest correction —
+// applying it there would only have made the lie harder to see.
+func (ms *MockSuite) TestCommandsRenderingOneObjectDoNotOfferFilter(assert, require *td.T) {
+	// Asserted by running the command, not by looking the flag up on a FlagSet:
+	// withFilterFlag registers on PersistentFlags, so Flags().Lookup("filter")
+	// answers nil whether the flag is there or not — an assertion that passes
+	// either way. Found by sabotage; the FlagSet version stayed green with the
+	// flag put back.
+	for _, path := range [][]string{
+		{"cloud", "loadbalancer", "log", "list-kinds"},
+		{"cloud", "storage", "object", "quota", "get"},
+	} {
+		found, _, err := cmd.GetRootCommand().Find(path)
+		require.CmpNoError(err, "%v must resolve", path)
+		require.Cmp(found.Name(), path[len(path)-1], "%v must resolve to its leaf", path)
+
+		cmd.PostExecute()
+		_, err = cmd.Execute(append(append([]string{}, path...), "GRA11", "--filter", `x=="y"`)...)
+
+		require.CmpError(err, "%v", path)
+		assert.Cmp(err.Error(), td.Contains("unknown flag: --filter"),
+			"%v renders one object, so --filter must not be accepted at all", path)
+	}
+}

--- a/internal/services/cloud/cloud_managed_analytics.go
+++ b/internal/services/cloud/cloud_managed_analytics.go
@@ -788,7 +788,7 @@ func ListManagedAnalyticsPermissions(_ *cobra.Command, args []string) {
 		rows[i] = map[string]any{"name": name}
 	}
 
-	display.RenderTable(rows, cloudprojectManagedAnalyticsPermissionColumnsToDisplay, &flags.OutputFormatConfig)
+	common.RenderFilteredTable(rows, cloudprojectManagedAnalyticsPermissionColumnsToDisplay)
 }
 
 func ListManagedAnalyticsPatterns(_ *cobra.Command, args []string) {

--- a/internal/services/cloud/cloud_managed_kubernetes.go
+++ b/internal/services/cloud/cloud_managed_kubernetes.go
@@ -374,7 +374,7 @@ func ListKubeIPRestrictions(_ *cobra.Command, args []string) {
 		})
 	}
 
-	display.RenderTable(objects, []string{"ip"}, &flags.OutputFormatConfig)
+	common.RenderFilteredTable(objects, []string{"ip"})
 }
 
 func EditKubeIPRestrictions(cmd *cobra.Command, args []string) {

--- a/internal/services/cloud/cloud_savings_plan.go
+++ b/internal/services/cloud/cloud_savings_plan.go
@@ -208,7 +208,7 @@ func ListSavingsPlanOffers(cmd *cobra.Command, _ []string) {
 		}
 	}
 
-	display.RenderTable(offerList, []string{"offerId"}, &flags.OutputFormatConfig)
+	common.RenderFilteredTable(offerList, []string{"offerId"})
 }
 
 // findMatchingOffer finds the appropriate offer ID based on flavor and deployment type

--- a/internal/services/common/common.go
+++ b/internal/services/common/common.go
@@ -55,6 +55,40 @@ func ManageListRequest(path, idField string, columnsToDisplay, filters []string)
 	display.RenderTable(body, columnsToDisplay, &flags.OutputFormatConfig)
 }
 
+// RenderFilteredTable prints rows through --filter.
+//
+// withFilterFlag only binds the flag to flags.GenericFilters; display.RenderTable
+// does not filter. ManageListRequest and ManageListRequestNoExpand call
+// FilterLines for their callers, so a command that assembles its own rows and
+// renders them itself has to do it explicitly — and twenty of them did not, so
+// --filter was accepted, documented, completed, and ignored. This is that call,
+// in one place, so the next command to assemble its own rows has something to
+// reach for.
+func RenderFilteredTable(rows []map[string]any, columnsToDisplay []string) {
+	filtered, ok := FilteredRows(rows)
+	if !ok {
+		return
+	}
+
+	display.RenderTable(filtered, columnsToDisplay, &flags.OutputFormatConfig)
+}
+
+// FilteredRows applies --filter and reports whether the caller may carry on.
+//
+// Separate from RenderFilteredTable for the commands that do not render a table:
+// a few wrap their list in an object and hand it to a template, and there the
+// filter has to run before the wrapping. Returning false means the failure has
+// already been reported.
+func FilteredRows(rows []map[string]any) ([]map[string]any, bool) {
+	filtered, err := filtersLib.FilterLines(rows, flags.GenericFilters)
+	if err != nil {
+		display.OutputError(&flags.OutputFormatConfig, "failed to filter results: %s", err)
+		return nil, false
+	}
+
+	return filtered, true
+}
+
 func ManageListRequestNoExpand(path string, columnsToDisplay, filters []string) {
 	body, err := httpLib.FetchArray(path, "")
 	if err != nil {

--- a/internal/services/vps/vps.go
+++ b/internal/services/vps/vps.go
@@ -278,7 +278,7 @@ func ListVpsAutomatedBackupRestorePoints(_ *cobra.Command, args []string) {
 		})
 	}
 
-	display.RenderTable(pointsMaps, []string{"restorePoint"}, &flags.OutputFormatConfig)
+	common.RenderFilteredTable(pointsMaps, []string{"restorePoint"})
 }
 
 func ListVpsAvailableUpgrades(_ *cobra.Command, args []string) {

--- a/internal/services/webhosting/webhosting.go
+++ b/internal/services/webhosting/webhosting.go
@@ -435,7 +435,7 @@ func ListHostingIncidents(_ *cobra.Command, _ []string) {
 	for _, incident := range incidents {
 		rows = append(rows, map[string]any{"incident": incident})
 	}
-	display.RenderTable(rows, []string{"incident"}, &flags.OutputFormatConfig)
+	common.RenderFilteredTable(rows, []string{"incident"})
 }
 
 func GetAttachedDomain(cmd *cobra.Command, args []string) {
@@ -705,7 +705,7 @@ func ListDatabaseAvailableTypes(_ *cobra.Command, args []string) {
 		rows = append(rows, map[string]any{"type": t})
 	}
 
-	display.RenderTable(rows, []string{"type"}, &flags.OutputFormatConfig)
+	common.RenderFilteredTable(rows, []string{"type"})
 }
 
 func ListDatabaseAvailableVersions(_ *cobra.Command, args []string) {
@@ -746,7 +746,7 @@ func ListDatabaseCreationCapabilities(_ *cobra.Command, args []string) {
 		}
 	}
 
-	display.RenderTable(capabilities, []string{"type", "isolation", "available", "quotaDisplay quota", "enginesDisplay engines"}, &flags.OutputFormatConfig)
+	common.RenderFilteredTable(capabilities, []string{"type", "isolation", "available", "quotaDisplay quota", "enginesDisplay engines"})
 }
 
 func GetDatabase(_ *cobra.Command, args []string) {
@@ -851,7 +851,7 @@ func ListEmailVolumes(_ *cobra.Command, args []string) {
 		}
 	}
 
-	display.RenderTable(volumes, []string{"date", "volume"}, &flags.OutputFormatConfig)
+	common.RenderFilteredTable(volumes, []string{"date", "volume"})
 }
 
 func ListEmailOptions(_ *cobra.Command, args []string) {
@@ -867,7 +867,7 @@ func ListEmailOptions(_ *cobra.Command, args []string) {
 		rows = append(rows, map[string]any{"id": fmt.Sprintf("%v", id)})
 	}
 
-	display.RenderTable(rows, []string{"id"}, &flags.OutputFormatConfig)
+	common.RenderFilteredTable(rows, []string{"id"})
 }
 
 func GetEmailOption(_ *cobra.Command, args []string) {
@@ -906,7 +906,7 @@ func ListExtraSqlOptions(_ *cobra.Command, args []string) {
 		rows = append(rows, map[string]any{"id": fmt.Sprintf("%v", value)})
 	}
 
-	display.RenderTable(rows, []string{"id"}, &flags.OutputFormatConfig)
+	common.RenderFilteredTable(rows, []string{"id"})
 }
 
 func GetExtraSqlOption(_ *cobra.Command, args []string) {
@@ -926,7 +926,7 @@ func ListExtraSqlDatabases(_ *cobra.Command, args []string) {
 		rows = append(rows, map[string]any{"database": fmt.Sprintf("%v", value)})
 	}
 
-	display.RenderTable(rows, []string{"database"}, &flags.OutputFormatConfig)
+	common.RenderFilteredTable(rows, []string{"database"})
 }
 
 func GetExtraSqlServiceInfo(_ *cobra.Command, args []string) {
@@ -1198,7 +1198,7 @@ func GetDatabaseStatistics(cmd *cobra.Command, args []string) {
 		rows = append(rows, row)
 	}
 
-	display.RenderTable(rows, []string{"timestamp", "value"}, &flags.OutputFormatConfig)
+	common.RenderFilteredTable(rows, []string{"timestamp", "value"})
 }
 
 func RequestDatabaseDump(cmd *cobra.Command, args []string) {
@@ -1517,7 +1517,7 @@ func ListModuleCatalog(_ *cobra.Command, _ []string) {
 		return
 	}
 
-	display.RenderTable(modules, []string{"id", "name", "branch", "version", "active", "latest"}, &flags.OutputFormatConfig)
+	common.RenderFilteredTable(modules, []string{"id", "name", "branch", "version", "active", "latest"})
 }
 
 func GetModuleCatalog(_ *cobra.Command, args []string) {
@@ -1554,7 +1554,7 @@ func ListSupportedVcs(_ *cobra.Command, _ []string) {
 		display.OutputInfo(&flags.OutputFormatConfig, nil, "ℹ️ No VCS platform returned")
 		return
 	}
-	display.RenderTable(rows, []string{"platform"}, &flags.OutputFormatConfig)
+	common.RenderFilteredTable(rows, []string{"platform"})
 }
 
 func GetAbuseState(_ *cobra.Command, args []string) {
@@ -1874,7 +1874,15 @@ func GetOvhConfigCapabilities(_ *cobra.Command, args []string) {
 		return
 	}
 
-	payload := map[string]any{"entries": capabilities}
+	// Filtered before the wrapping, not after: what --filter selects is an
+	// entry, and once the list is inside an object there are no rows left to
+	// select from.
+	filtered, ok := common.FilteredRows(capabilities)
+	if !ok {
+		return
+	}
+
+	payload := map[string]any{"entries": filtered}
 	display.OutputObject(payload, args[0], ovhConfigCapabilitiesTemplate, &flags.OutputFormatConfig)
 }
 
@@ -2405,7 +2413,12 @@ func ListSSLAttachedDomains(_ *cobra.Command, args []string) {
 		display.OutputError(&flags.OutputFormatConfig, "failed to fetch SSL certificates: %s", err)
 		return
 	}
-	payload := map[string]any{"certificates": certificates}
+	filtered, ok := common.FilteredRows(certificates)
+	if !ok {
+		return
+	}
+
+	payload := map[string]any{"certificates": filtered}
 	display.OutputObject(payload, args[0], sslResourceCertificatesTemplate, &flags.OutputFormatConfig)
 }
 
@@ -3192,7 +3205,7 @@ func ListLocalSeoAccounts(_ *cobra.Command, args []string) {
 		rows = append(rows, map[string]any{"id": fmt.Sprintf("%v", id)})
 	}
 
-	display.RenderTable(rows, []string{"id"}, &flags.OutputFormatConfig)
+	common.RenderFilteredTable(rows, []string{"id"})
 }
 
 func GetLocalSeoAccount(_ *cobra.Command, args []string) {
@@ -3222,7 +3235,7 @@ func ListLocalSeoLocations(_ *cobra.Command, args []string) {
 		rows = append(rows, map[string]any{"id": fmt.Sprintf("%v", id)})
 	}
 
-	display.RenderTable(rows, []string{"id"}, &flags.OutputFormatConfig)
+	common.RenderFilteredTable(rows, []string{"id"})
 }
 
 func GetLocalSeoLocation(_ *cobra.Command, args []string) {


### PR DESCRIPTION
`withFilterFlag` only binds the flag to `flags.GenericFilters`. The filtering itself happens inside `common.ManageListRequest` and `common.ManageListRequestNoExpand`, so a command that assembles its own rows and calls `display.RenderTable` gets the flag, its documentation page, its shell completion — and no filtering at all.

**Twenty commands were in that state**, across `cloud`, `vps` and `webhosting`.

## What changes

**Eighteen list rows and now filter them**, through one helper rather than the same three lines copied eighteen times.

**Two do not list anything, and lose the flag instead.** `cloud loadbalancer log list-kinds` answers a list of plain strings, which has no properties to select on; `cloud storage object quota get` reads the quota of one region and renders one object. Applying `--filter` there would only have made the lie harder to see.

**Two of the eighteen filter before wrapping.** They hand their list to a template inside a wrapper object, and once the list is inside an object there are no rows left to select from. That is what `common.FilteredRows` is for.

## Verification

Five tests, **each asserting the row the filter must remove**. Asserting that the kept row is present would pass just as well with no filtering at all — which is how these twenty went unnoticed.

Three sabotages, three red: the helper made inert while still compiling, the flag put back on one of the two object commands, and `display.RenderTable` restored on one of the eighteen.

Gate: `go build`, `go vet`, `make wasm`, `go test ./...`, `make doc` — all green, doc pages regenerated for the two flag removals.

## Two things the instruments got wrong, and how they were caught

Both by a control, not by a reading — recorded here because the numbers in this PR depend on it.

- **The first census said 27, not 20.** Seven of those were correct: they delegate to a package-local helper — `listNetworksByVisibility`, `listLoadbalancingResources` — which does filter, and the analyser did not follow one level of indirection. Verified by reading both helpers, then by a positive control that breaks one and watches its two callers reappear in the census.
- **The flag-removal test first used `Flags().Lookup("filter")`.** `withFilterFlag` registers on `PersistentFlags`, so that answers `nil` whether the flag is there or not: the assertion passed with the flag put back. It runs the command now, because what matters is what cobra accepts on the command line.

## Scope

Based on `main`, independent of the BareMetal series. The same defect existed on twenty-one commands of that series and is fixed there separately; the helper added here is the same one, with the same name and body, so if both land the merge is trivial.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
