### PR TITLE
feat(cli): fixed bug ssh key

### DIFF
--- a/internal/cmd/vps_test.go
+++ b/internal/cmd/vps_test.go
@@ -6,6 +6,7 @@ package cmd_test
 
 import (
 	"encoding/json"
+	"net/http"
 
 	"github.com/jarcoal/httpmock"
 	"github.com/maxatome/go-testdeep/td"
@@ -62,4 +63,45 @@ func (ms *MockSuite) TestVpsGetCmd(assert, require *td.T) {
 			"longName": "Region OpenStack: os-gra1"
 		}
 	}`))
+}
+
+// TestVpsReinstallResolvesSSHKeyCmd checks that "--ssh-key <name>" is resolved
+// against /me/sshKey and sent as publicSshKey (not as the name), so the key
+// actually populates authorized_keys (issue #260).
+func (ms *MockSuite) TestVpsReinstallResolvesSSHKeyCmd(assert, require *td.T) {
+	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/v1/me/sshKey",
+		httpmock.NewStringResponder(200, `["mykey"]`))
+	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/v1/me/sshKey/mykey",
+		httpmock.NewStringResponder(200, `{"keyName": "mykey", "key": "ssh-ed25519 AAAATEST test@host"}`))
+
+	var body map[string]any
+	httpmock.RegisterResponder("POST", "https://eu.api.ovh.com/v1/vps/vps-67890/rebuild",
+		func(req *http.Request) (*http.Response, error) {
+			_ = json.NewDecoder(req.Body).Decode(&body)
+			return httpmock.NewStringResponse(200, `{"id": 123}`), nil
+		})
+
+	_, err := cmd.Execute("vps", "reinstall", "vps-67890",
+		"--image-id", "img-1", "--ssh-key", "mykey", "--do-not-send-password")
+
+	require.CmpNoError(err)
+	assert.Cmp(body["publicSshKey"], "ssh-ed25519 AAAATEST test@host")
+	assert.Cmp(body["sshKey"], nil) // the name must not be sent as-is
+	assert.Cmp(body["imageId"], "img-1")
+	assert.Cmp(body["doNotSendPassword"], true)
+}
+
+// TestVpsReinstallUnknownSSHKeyCmd checks that an unknown "--ssh-key" name fails
+// fast with a clear error instead of silently leaving authorized_keys empty (#260).
+func (ms *MockSuite) TestVpsReinstallUnknownSSHKeyCmd(assert, require *td.T) {
+	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/v1/me/sshKey",
+		httpmock.NewStringResponder(200, `["other"]`))
+	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/v1/me/sshKey/other",
+		httpmock.NewStringResponder(200, `{"keyName": "other", "key": "ssh-ed25519 AAAAOTHER"}`))
+
+	_, err := cmd.Execute("vps", "reinstall", "vps-67890",
+		"--image-id", "img-1", "--ssh-key", "missing")
+
+	require.CmpError(err)
+	assert.Cmp(err.Error(), td.Contains("not found"))
 }

--- a/internal/services/vps/utils.go
+++ b/internal/services/vps/utils.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"log"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/ovh/ovhcloud-cli/internal/display"
@@ -113,4 +114,32 @@ func runSSHKeySelector() (string, string, error) {
 	}
 
 	return display.RunGenericChoicePicker("Please select an SSH key", keyChoices, 10)
+}
+
+// getAccountSSHKeyByName returns the public key content of the account SSH key
+// (/me/sshKey) matching the given name. If no key matches, it returns an error
+// listing the available key names, so the user does not silently end up with an
+// empty authorized_keys file after a reinstall (see issue #260).
+func getAccountSSHKeyByName(name string) (string, error) {
+	keys, err := httpLib.FetchExpandedArray("/v1/me/sshKey", "")
+	if err != nil {
+		return "", fmt.Errorf("failed to fetch account ssh keys: %w", err)
+	}
+
+	var available []string
+	for _, key := range keys {
+		keyName, _ := key["keyName"].(string)
+		if keyName == name {
+			publicKey, _ := key["key"].(string)
+			return publicKey, nil
+		}
+		if keyName != "" {
+			available = append(available, keyName)
+		}
+	}
+
+	if len(available) == 0 {
+		return "", fmt.Errorf("SSH key %q not found: your account has no SSH key registered in /me/sshKey", name)
+	}
+	return "", fmt.Errorf("SSH key %q not found in your account; available keys: %s", name, strings.Join(available, ", "))
 }

--- a/internal/services/vps/vps.go
+++ b/internal/services/vps/vps.go
@@ -541,12 +541,33 @@ func ReinstallVps(cmd *cobra.Command, args []string) {
 	}
 
 	if VpsSSHKeyViaInteractiveSelector {
-		keyName, _, err := runSSHKeySelector()
+		_, publicKey, err := runSSHKeySelector()
 		if err != nil {
 			display.OutputError(&flags.OutputFormatConfig, "error selecting SSH key: %s", err)
 			return
 		}
-		VpsReinstallSpec.SshKey = keyName
+		// Send the public key directly (publicSshKey) rather than the key name:
+		// this reliably populates authorized_keys, matching the web behavior.
+		VpsReinstallSpec.SshKey = ""
+		VpsReinstallSpec.PublicSshKey = publicKey
+	} else if VpsReinstallSpec.SshKey != "" {
+		// The --ssh-key flag takes the name of an account SSH key (/me/sshKey).
+		// Resolve it to its public key and send it as publicSshKey, so a wrong
+		// name fails fast instead of silently leaving authorized_keys empty (#260).
+		publicKey, err := getAccountSSHKeyByName(VpsReinstallSpec.SshKey)
+		if err != nil {
+			display.OutputError(&flags.OutputFormatConfig, "%s", err)
+			return
+		}
+		VpsReinstallSpec.SshKey = ""
+		VpsReinstallSpec.PublicSshKey = publicKey
+	}
+
+	// Guard against locking yourself out: --do-not-send-password only makes
+	// sense if an SSH key is provided, otherwise there is no way to log in.
+	if VpsReinstallSpec.DoNotSendPassword && VpsReinstallSpec.PublicSshKey == "" {
+		display.OutputError(&flags.OutputFormatConfig, "--do-not-send-password requires an SSH key (use --ssh-key <name>, --public-ssh-key <key> or --ssh-key-selector), otherwise you would have no way to log in")
+		return
 	}
 
 	response, err := common.CreateResource(


### PR DESCRIPTION
# Description

`vps reinstall --ssh-key <name>` could leave `authorized_keys` empty. The `sshKey`
field of `POST /vps/{serviceName}/rebuild` expects the **name** of an account SSH
key (`/me/sshKey`); when it didn't match, the API accepted the request but
installed no key — and with `--do-not-send-password` this locked the user out
(no key, no password).

Changes:
- `--ssh-key <name>` is now resolved against `/me/sshKey` and sent as
  `publicSshKey` (the raw key), reliably populating `authorized_keys` (like the
  web UI) instead of relying on backend name resolution.
- An unknown name fails fast with a clear error listing the available keys.
- The interactive selector (`--ssh-key-selector`) sends the resolved public key too.
- Guard: `--do-not-send-password` without any SSH key is refused, to avoid lockout.

Fixes #260 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have commented my code
- [x] I ran `go mod tidy`
- [x] I have added tests that prove my fix is effective or that my feature works

# Tests

### Unit tests
```
$ go test ./internal/cmd/ -run "MockSuite/TestVpsReinstall" -v
--- PASS: TestMockSuite/TestVpsReinstallResolvesSSHKeyCmd
--- PASS: TestMockSuite/TestVpsReinstallUnknownSSHKeyCmd
PASS
```
`TestVpsReinstallResolvesSSHKeyCmd` asserts the request body carries the resolved
`publicSshKey` (and not the raw `sshKey` name).

### Unknown SSH key name → clear error (no reinstall performed)
```
$ ovhcloud vps reinstall <vps> --image-id x --ssh-key doesnotexist
🛑 SSH key "doesnotexist" not found: your account has no SSH key registered in /me/sshKey
```
(with keys present, the message lists the available key names)

### Lockout guard
```
$ ovhcloud vps reinstall <vps> --image-id x --do-not-send-password
🛑 --do-not-send-password requires an SSH key (use --ssh-key <name>, --public-ssh-key <key> or --ssh-key-selector), otherwise you would have no way to log in
```
