### PR TITLE
feat(baremetal): os details

### DIFF
--- a/doc/ovhcloud_baremetal.md
+++ b/doc/ovhcloud_baremetal.md
@@ -38,6 +38,7 @@ Retrieve information and manage your Bare Metal services
 * [ovhcloud baremetal list-compatible-os](ovhcloud_baremetal_list-compatible-os.md)	 - Retrieve OSes that can be installed on this baremetal
 * [ovhcloud baremetal list-interventions](ovhcloud_baremetal_list-interventions.md)	 - List past and planned interventions for the given baremetal
 * [ovhcloud baremetal list-ips](ovhcloud_baremetal_list-ips.md)	 - List all IPs that are routed to the given baremetal
+* [ovhcloud baremetal list-os](ovhcloud_baremetal_list-os.md)	 - List all OSes available at OVHcloud
 * [ovhcloud baremetal list-secrets](ovhcloud_baremetal_list-secrets.md)	 - Retrieve secrets to connect to the server
 * [ovhcloud baremetal list-tasks](ovhcloud_baremetal_list-tasks.md)	 - Retrieve tasks of the given baremetal
 * [ovhcloud baremetal reboot](ovhcloud_baremetal_reboot.md)	 - Reboot the given baremetal

--- a/doc/ovhcloud_baremetal_list-os.md
+++ b/doc/ovhcloud_baremetal_list-os.md
@@ -1,0 +1,44 @@
+## ovhcloud baremetal list-os
+
+List all OSes available at OVHcloud
+
+```
+ovhcloud baremetal list-os [flags]
+```
+
+### Options
+
+```
+      --filter stringArray   Filter results by any property using https://github.com/PaesslerAG/gval syntax
+                             Examples:
+                               --filter 'state=="running"'
+                               --filter 'name=~"^my.*"'
+                               --filter 'nested.property.subproperty>10'
+                               --filter 'startDate>="2023-12-01"'
+                               --filter 'name=~"something" && nbField>10'
+  -h, --help                 help for list-os
+```
+
+### Options inherited from parent commands
+
+```
+  -d, --debug            Activate debug mode (will log all HTTP requests details)
+  -e, --ignore-errors    Ignore errors in API calls when it is not fatal to the execution
+  -o, --output string    Output format: json, yaml, interactive, or a custom format expression (using https://github.com/PaesslerAG/gval syntax)
+                         Examples:
+                           --output json
+                           --output yaml
+                           --output interactive
+                           --output 'id' (to extract a single field)
+                           --output 'nested.field.subfield' (to extract a nested field)
+                           --output '[id, "name"]' (to extract multiple fields as an array)
+                           --output '{"newKey": oldKey, "otherKey": nested.field}' (to extract and rename fields in an object)
+                           --output 'name+","+type' (to extract and concatenate fields in a string)
+                           --output '(nbFieldA + nbFieldB) * 10' (to compute values from numeric fields)
+      --profile string   Use a specific profile from the configuration file
+```
+
+### SEE ALSO
+
+* [ovhcloud baremetal](ovhcloud_baremetal.md)	 - Retrieve information and manage your Bare Metal services
+

--- a/doc/ovhcloud_logout.md
+++ b/doc/ovhcloud_logout.md
@@ -1,0 +1,46 @@
+## ovhcloud logout
+
+Revoke your API credentials and remove them from the configuration
+
+```
+ovhcloud logout [flags]
+```
+
+### Examples
+
+```
+ovhcloud logout
+ovhcloud logout --yes
+ovhcloud logout --profile work
+```
+
+### Options
+
+```
+  -h, --help   help for logout
+  -y, --yes    Do not ask for confirmation
+```
+
+### Options inherited from parent commands
+
+```
+  -d, --debug            Activate debug mode (will log all HTTP requests details)
+  -e, --ignore-errors    Ignore errors in API calls when it is not fatal to the execution
+  -o, --output string    Output format: json, yaml, interactive, or a custom format expression (using https://github.com/PaesslerAG/gval syntax)
+                         Examples:
+                           --output json
+                           --output yaml
+                           --output interactive
+                           --output 'id' (to extract a single field)
+                           --output 'nested.field.subfield' (to extract a nested field)
+                           --output '[id, "name"]' (to extract multiple fields as an array)
+                           --output '{"newKey": oldKey, "otherKey": nested.field}' (to extract and rename fields in an object)
+                           --output 'name+","+type' (to extract and concatenate fields in a string)
+                           --output '(nbFieldA + nbFieldB) * 10' (to compute values from numeric fields)
+      --profile string   Use a specific profile from the configuration file
+```
+
+### SEE ALSO
+
+* [ovhcloud](ovhcloud.md)	 - CLI to manage your OVHcloud services
+

--- a/internal/cmd/baremetal.go
+++ b/internal/cmd/baremetal.go
@@ -227,6 +227,13 @@ Please note that all parameters are not compatible with all OSes.
 		Run:               baremetal.GetBaremetalCompatibleOses,
 	}))
 
+	baremetalCmd.AddCommand(withFilterFlag(&cobra.Command{
+		Use:   "list-os",
+		Short: "List all OSes available at OVHcloud",
+		Args:  cobra.NoArgs,
+		Run:   baremetal.ListBaremetalOses,
+	}))
+
 	// Commands to manage virtual network interfaces
 	baremetalVNICmd := &cobra.Command{
 		Use:   "vni",

--- a/internal/cmd/baremetal_test.go
+++ b/internal/cmd/baremetal_test.go
@@ -21,39 +21,162 @@ func (ms *MockSuite) TestBaremetalIPMIResetSessionsCmd(assert, require *td.T) {
 	assert.Contains(out, "IPMI sessions reset")
 }
 
-func (ms *MockSuite) TestBaremetalListCompatibleOSCmd(assert, require *td.T) {
+// compatibleOSNames lists the OS names the fake compatibleTemplates responder
+// declares available for "fakeBaremetal", shared across the compatible-OS tests.
+var compatibleOSNames = []string{
+	"alma8-cpanel-latest_64",
+	"alma8-plesk18_64",
+	"alma8_64",
+	"alma9-cpanel-latest_64",
+	"alma9-plesk18_64",
+	"alma9_64",
+	"byoi_64",
+	"byolinux_64",
+}
+
+// templateInfosFixture is a GET /dedicated/installationTemplate/templateInfos
+// response covering every name in compatibleOSNames, plus one extra template
+// ("debian12_64") that is NOT compatible, to prove it gets filtered out.
+const templateInfosFixture = `[
+	{"templateName": "alma8-cpanel-latest_64", "description": "cPanel (AlmaLinux 8)", "category": "management", "family": "linux", "subfamily": "alma", "endOfInstall": "2029-03-06"},
+	{"templateName": "alma8-plesk18_64", "description": "Linux Plesk Obsidian (AlmaLinux 8)", "category": "management", "family": "linux", "subfamily": "alma", "endOfInstall": "2029-03-06"},
+	{"templateName": "alma8_64", "description": "AlmaLinux 8", "category": "basic", "family": "linux", "subfamily": "alma", "endOfInstall": "2029-03-06"},
+	{"templateName": "alma9-cpanel-latest_64", "description": "cPanel (AlmaLinux 9)", "category": "management", "family": "linux", "subfamily": "alma", "endOfInstall": "2032-06-01"},
+	{"templateName": "alma9-plesk18_64", "description": "Linux Plesk Obsidian (AlmaLinux 9)", "category": "management", "family": "linux", "subfamily": "alma", "endOfInstall": "2032-06-01"},
+	{"templateName": "alma9_64", "description": "AlmaLinux 9", "category": "basic", "family": "linux", "subfamily": "alma", "endOfInstall": "2032-06-01"},
+	{"templateName": "byoi_64", "description": "Bring Your Own Image", "category": "customer", "family": "custom", "subfamily": "byoi", "endOfInstall": "2999-12-31"},
+	{"templateName": "byolinux_64", "description": "Bring Your Own Linux", "category": "customer", "family": "custom", "subfamily": "byolinux", "endOfInstall": "2999-12-31"},
+	{"templateName": "debian12_64", "description": "Debian 12 (Bookworm)", "category": "basic", "family": "linux", "subfamily": "debian", "endOfInstall": "2028-07-04"}
+]`
+
+// registerCompatibleTemplatesResponder wires GET .../install/compatibleTemplates
+// for "fakeBaremetal" to return compatibleOSNames under the "ovh" key.
+func registerCompatibleTemplatesResponder() {
+	names := `"` + compatibleOSNames[0] + `"`
+	for _, name := range compatibleOSNames[1:] {
+		names += `, "` + name + `"`
+	}
 	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/v1/dedicated/server/fakeBaremetal/install/compatibleTemplates",
-		httpmock.NewStringResponder(200, `{
-			"ovh": [
-				"alma8-cpanel-latest_64",
-				"alma8-plesk18_64",
-				"alma8_64",
-				"alma9-cpanel-latest_64",
-				"alma9-plesk18_64",
-				"alma9_64",
-				"byoi_64",
-				"byolinux_64"
-			]
-		}`),
+		httpmock.NewStringResponder(200, `{"ovh": [`+names+`]}`),
+	)
+}
+
+func (ms *MockSuite) TestBaremetalListCompatibleOSCmd(assert, require *td.T) {
+	registerCompatibleTemplatesResponder()
+	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/v1/dedicated/installationTemplate/templateInfos",
+		httpmock.NewStringResponder(200, templateInfosFixture),
 	)
 
 	out, err := cmd.Execute("baremetal", "list-compatible-os", "fakeBaremetal")
 
 	require.CmpNoError(err)
 	assert.String(out, `
-┌────────┬────────────────────────┐
-│ source │          name          │
-├────────┼────────────────────────┤
-│ ovh    │ alma8-cpanel-latest_64 │
-│ ovh    │ alma8-plesk18_64       │
-│ ovh    │ alma8_64               │
-│ ovh    │ alma9-cpanel-latest_64 │
-│ ovh    │ alma9-plesk18_64       │
-│ ovh    │ alma9_64               │
-│ ovh    │ byoi_64                │
-│ ovh    │ byolinux_64            │
-└────────┴────────────────────────┘
+┌────────────────────────┬────────────────────────────────────┬────────────┬────────┬───────────┬──────────────┐
+│          name          │            description             │  category  │ family │ subfamily │ endOfInstall │
+├────────────────────────┼────────────────────────────────────┼────────────┼────────┼───────────┼──────────────┤
+│ alma8-cpanel-latest_64 │ cPanel (AlmaLinux 8)               │ management │ linux  │ alma      │ 2029-03-06   │
+│ alma8-plesk18_64       │ Linux Plesk Obsidian (AlmaLinux 8) │ management │ linux  │ alma      │ 2029-03-06   │
+│ alma8_64               │ AlmaLinux 8                        │ basic      │ linux  │ alma      │ 2029-03-06   │
+│ alma9-cpanel-latest_64 │ cPanel (AlmaLinux 9)               │ management │ linux  │ alma      │ 2032-06-01   │
+│ alma9-plesk18_64       │ Linux Plesk Obsidian (AlmaLinux 9) │ management │ linux  │ alma      │ 2032-06-01   │
+│ alma9_64               │ AlmaLinux 9                        │ basic      │ linux  │ alma      │ 2032-06-01   │
+│ byoi_64                │ Bring Your Own Image               │ customer   │ custom │ byoi      │ 2999-12-31   │
+│ byolinux_64            │ Bring Your Own Linux               │ customer   │ custom │ byolinux  │ 2999-12-31   │
+└────────────────────────┴────────────────────────────────────┴────────────┴────────┴───────────┴──────────────┘
 💡 Use option -o json or -o yaml to get the raw output with all information`[1:])
+}
+
+// -o name only needs the OS names: it must not trigger the extra
+// installationTemplate/templateInfos call. No responder is registered for it,
+// so the test would fail with "no responder found" if that call happened.
+func (ms *MockSuite) TestBaremetalListCompatibleOSCmdNameOnlySkipsDetails(assert, require *td.T) {
+	registerCompatibleTemplatesResponder()
+
+	out, err := cmd.Execute("baremetal", "list-compatible-os", "fakeBaremetal", "-o", "name")
+
+	require.CmpNoError(err)
+	assert.String(out, `"alma8-cpanel-latest_64"
+"alma8-plesk18_64"
+"alma8_64"
+"alma9-cpanel-latest_64"
+"alma9-plesk18_64"
+"alma9_64"
+"byoi_64"
+"byolinux_64"
+`)
+}
+
+// A filter referencing a detail-only field (here "category") must still
+// trigger the templateInfos call even when the output format is name-only.
+func (ms *MockSuite) TestBaremetalListCompatibleOSCmdFilterOnDetailFieldFetchesDetails(assert, require *td.T) {
+	registerCompatibleTemplatesResponder()
+	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/v1/dedicated/installationTemplate/templateInfos",
+		httpmock.NewStringResponder(200, templateInfosFixture),
+	)
+
+	out, err := cmd.Execute("baremetal", "list-compatible-os", "fakeBaremetal", "-o", "name", "--filter", `category=="customer"`)
+
+	require.CmpNoError(err)
+	assert.String(out, `"byoi_64"
+"byolinux_64"
+`)
+}
+
+func (ms *MockSuite) TestBaremetalListOsCmd(assert, require *td.T) {
+	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/v1/dedicated/installationTemplate/templateInfos",
+		httpmock.NewStringResponder(200, templateInfosFixture),
+	)
+
+	out, err := cmd.Execute("baremetal", "list-os")
+
+	require.CmpNoError(err)
+	assert.String(out, `
+┌────────────────────────┬────────────────────────────────────┬────────────┬────────┬───────────┬──────────────┐
+│          name          │            description             │  category  │ family │ subfamily │ endOfInstall │
+├────────────────────────┼────────────────────────────────────┼────────────┼────────┼───────────┼──────────────┤
+│ alma8-cpanel-latest_64 │ cPanel (AlmaLinux 8)               │ management │ linux  │ alma      │ 2029-03-06   │
+│ alma8-plesk18_64       │ Linux Plesk Obsidian (AlmaLinux 8) │ management │ linux  │ alma      │ 2029-03-06   │
+│ alma8_64               │ AlmaLinux 8                        │ basic      │ linux  │ alma      │ 2029-03-06   │
+│ alma9-cpanel-latest_64 │ cPanel (AlmaLinux 9)               │ management │ linux  │ alma      │ 2032-06-01   │
+│ alma9-plesk18_64       │ Linux Plesk Obsidian (AlmaLinux 9) │ management │ linux  │ alma      │ 2032-06-01   │
+│ alma9_64               │ AlmaLinux 9                        │ basic      │ linux  │ alma      │ 2032-06-01   │
+│ byoi_64                │ Bring Your Own Image               │ customer   │ custom │ byoi      │ 2999-12-31   │
+│ byolinux_64            │ Bring Your Own Linux               │ customer   │ custom │ byolinux  │ 2999-12-31   │
+│ debian12_64            │ Debian 12 (Bookworm)               │ basic      │ linux  │ debian    │ 2028-07-04   │
+└────────────────────────┴────────────────────────────────────┴────────────┴────────┴───────────┴──────────────┘
+💡 Use option -o json or -o yaml to get the raw output with all information`[1:])
+}
+
+// -o name only needs the OS names: it must use the cheap
+// GET /dedicated/installationTemplate (plain name list) rather than
+// templateInfos. No responder is registered for templateInfos, so the test
+// would fail with "no responder found" if that call happened.
+func (ms *MockSuite) TestBaremetalListOsCmdNameOnlySkipsDetails(assert, require *td.T) {
+	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/v1/dedicated/installationTemplate",
+		httpmock.NewStringResponder(200, `["alma8_64", "debian12_64"]`),
+	)
+
+	out, err := cmd.Execute("baremetal", "list-os", "-o", "name")
+
+	require.CmpNoError(err)
+	assert.String(out, `"alma8_64"
+"debian12_64"
+`)
+}
+
+// A filter referencing a detail-only field must still trigger the
+// templateInfos call even when the output format is name-only.
+func (ms *MockSuite) TestBaremetalListOsCmdFilterOnDetailFieldFetchesDetails(assert, require *td.T) {
+	httpmock.RegisterResponder("GET", "https://eu.api.ovh.com/v1/dedicated/installationTemplate/templateInfos",
+		httpmock.NewStringResponder(200, templateInfosFixture),
+	)
+
+	out, err := cmd.Execute("baremetal", "list-os", "-o", "name", "--filter", `category=="customer"`)
+
+	require.CmpNoError(err)
+	assert.String(out, `"byoi_64"
+"byolinux_64"
+`)
 }
 
 // registerReinstallTask wires a reinstall whose task ends in the given state.

--- a/internal/display/display.go
+++ b/internal/display/display.go
@@ -31,7 +31,7 @@ import (
 )
 
 const (
-	maxCellWidth = 50
+	maxCellWidth = 75
 )
 
 var (

--- a/internal/services/baremetal/baremetal.go
+++ b/internal/services/baremetal/baremetal.go
@@ -12,6 +12,7 @@ import (
 	"maps"
 	"net/url"
 	"os"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -595,29 +596,94 @@ func GetBaremetalAuthenticationSecrets(_ *cobra.Command, args []string) {
 	display.RenderTable(allSecrets, []string{"type", "url", "user", "secret", "expiration"}, &flags.OutputFormatConfig)
 }
 
-func GetBaremetalCompatibleOses(_ *cobra.Command, args []string) {
-	path := fmt.Sprintf("/v1/dedicated/server/%s/install/compatibleTemplates", url.PathEscape(args[0]))
+type templateOsInfo struct {
+	TemplateName string `json:"templateName"`
+	Description  string `json:"description"`
+	Category     string `json:"category"`
+	Family       string `json:"family"`
+	Subfamily    string `json:"subfamily"`
+	EndOfInstall string `json:"endOfInstall,omitempty"`
+}
 
-	var oses map[string]any
-	if err := httpLib.Client.Get(path, &oses); err != nil {
-		display.OutputError(&flags.OutputFormatConfig, "failed to fetch compatible OSes: %s", err)
-		return
+// osTemplateColumns are the columns displayed for OS template rows, in order.
+var osTemplateColumns = []string{"name", "description", "category", "family", "subfamily", "endOfInstall"}
+
+// osTemplateDetailFields are the columns only available by calling
+// installationTemplate/templateInfos, on top of the plain OS names returned by
+// installationTemplate (or install/compatibleTemplates).
+var osTemplateDetailFields = []string{"description", "category", "family", "subfamily", "endOfInstall"}
+
+// osTemplateDetailsNeeded reports whether the requested output format or any
+// active filter references a detail field, so the more expensive templateInfos
+// call can be skipped when only OS names are needed (e.g. `-o name`).
+func osTemplateDetailsNeeded() bool {
+	if flags.OutputFormatConfig.IsJson() || flags.OutputFormatConfig.IsYaml() || flags.OutputFormatConfig.IsInteractive() {
+		return true
+	}
+
+	custom := flags.OutputFormatConfig.CustomFormat()
+	if custom == "" {
+		// Default table rendering always shows every detail column.
+		return true
+	}
+
+	haystacks := append([]string{custom}, flags.GenericFilters...)
+	for _, field := range osTemplateDetailFields {
+		re := regexp.MustCompile(`\b` + field + `\b`)
+		for _, h := range haystacks {
+			if re.MatchString(h) {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+// fetchOsTemplatesInfo calls installationTemplate/templateInfos and returns one
+// row per template, keeping only those for which keep(templateName) is true.
+func fetchOsTemplatesInfo(keep func(templateName string) bool) ([]map[string]any, error) {
+	var templatesInfo []templateOsInfo
+	if err := httpLib.Client.Get("/v1/dedicated/installationTemplate/templateInfos", &templatesInfo); err != nil {
+		return nil, err
 	}
 
 	var formattedValues []map[string]any
-	for _, os := range oses["ovh"].([]any) {
+	for _, info := range templatesInfo {
+		if keep != nil && !keep(info.TemplateName) {
+			continue
+		}
 		formattedValues = append(formattedValues, map[string]any{
-			"source": "ovh",
-			"name":   os,
+			"name":         info.TemplateName,
+			"description":  info.Description,
+			"category":     info.Category,
+			"family":       info.Family,
+			"subfamily":    info.Subfamily,
+			"endOfInstall": info.EndOfInstall,
 		})
 	}
 
-	if personalOSes, ok := oses["personal"]; ok {
-		for _, os := range personalOSes.([]any) {
-			formattedValues = append(formattedValues, map[string]any{
-				"source": "personal",
-				"name":   os,
-			})
+	return formattedValues, nil
+}
+
+func ListBaremetalOses(_ *cobra.Command, _ []string) {
+	var formattedValues []map[string]any
+
+	if osTemplateDetailsNeeded() {
+		var err error
+		formattedValues, err = fetchOsTemplatesInfo(nil)
+		if err != nil {
+			display.OutputError(&flags.OutputFormatConfig, "failed to fetch OS details: %s", err)
+			return
+		}
+	} else {
+		var names []string
+		if err := httpLib.Client.Get("/v1/dedicated/installationTemplate", &names); err != nil {
+			display.OutputError(&flags.OutputFormatConfig, "failed to fetch OSes: %s", err)
+			return
+		}
+		for _, name := range names {
+			formattedValues = append(formattedValues, map[string]any{"name": name})
 		}
 	}
 
@@ -627,5 +693,50 @@ func GetBaremetalCompatibleOses(_ *cobra.Command, args []string) {
 		return
 	}
 
-	display.RenderTable(formattedValues, []string{"source", "name"}, &flags.OutputFormatConfig)
+	display.RenderTable(formattedValues, osTemplateColumns, &flags.OutputFormatConfig)
+}
+
+func GetBaremetalCompatibleOses(_ *cobra.Command, args []string) {
+	path := fmt.Sprintf("/v1/dedicated/server/%s/install/compatibleTemplates", url.PathEscape(args[0]))
+
+	var oses map[string]any
+	if err := httpLib.Client.Get(path, &oses); err != nil {
+		display.OutputError(&flags.OutputFormatConfig, "failed to fetch compatible OSes: %s", err)
+		return
+	}
+
+	var names []string
+	seenNames := make(map[string]bool)
+	addNames := func(list []any) {
+		for _, os := range list {
+			name := os.(string)
+			if !seenNames[name] {
+				seenNames[name] = true
+				names = append(names, name)
+			}
+		}
+	}
+	addNames(oses["ovh"].([]any))
+
+	var formattedValues []map[string]any
+	if osTemplateDetailsNeeded() {
+		var err error
+		formattedValues, err = fetchOsTemplatesInfo(func(templateName string) bool { return seenNames[templateName] })
+		if err != nil {
+			display.OutputError(&flags.OutputFormatConfig, "failed to fetch OS details: %s", err)
+			return
+		}
+	} else {
+		for _, name := range names {
+			formattedValues = append(formattedValues, map[string]any{"name": name})
+		}
+	}
+
+	formattedValues, err := filtersLib.FilterLines(formattedValues, flags.GenericFilters)
+	if err != nil {
+		display.OutputError(&flags.OutputFormatConfig, "failed to filter results: %s", err)
+		return
+	}
+
+	display.RenderTable(formattedValues, osTemplateColumns, &flags.OutputFormatConfig)
 }


### PR DESCRIPTION
# Description

This PR is about:
- adding OS details on existing `baremetal list-compatible-os` command
- add `baremetal list-os` command to list all available OSes, with their details, exactly as  `baremetal list-compatible-os` command

### Summary

* feat(doc): update accordingly
* feat(display): increase max cell width
* feat(baremetal): os details

Fixes #272

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have commented my code
- [x] I ran `go mod tidy`
- [x] I have added tests that prove my fix is effective or that my feature works
