### PR TITLE
fix(baremetal): fix English typos in the reinstall wizard

### DIFF
--- a/internal/services/baremetal/reinstall_wizard_api.go
+++ b/internal/services/baremetal/reinstall_wizard_api.go
@@ -367,7 +367,7 @@ func hardwareRaidWarning(group diskGroup) string {
 	}
 
 	return fmt.Sprintf(
-		"Disk group %d has a hardware RAID controller (%s), which the OVHcloud CLI does not support configuring — it will be installed in JBOD mode instead",
+		"Disk group %d has a hardware RAID controller (%s), which the OVHcloud CLI cannot configure, so it will be installed in JBOD mode instead",
 		group.DiskGroupID, group.RaidController)
 }
 

--- a/internal/services/baremetal/reinstall_wizard_confirm.go
+++ b/internal/services/baremetal/reinstall_wizard_confirm.go
@@ -234,7 +234,7 @@ func (m *reinstallWizardModel) renderConfirmStep() string {
 		}
 
 		if labels := m.erasedDiskGroupLabels(); len(labels) > 1 {
-			content.WriteString(wizardErrorStyle.Render("⚠  All data of following groups will be erased ⚠") + "\n")
+			content.WriteString(wizardErrorStyle.Render("⚠  All data on the following disk groups will be erased ⚠") + "\n")
 			for _, label := range labels {
 				content.WriteString(wizardErrorStyle.Render("- "+label) + "\n")
 			}
@@ -242,7 +242,7 @@ func (m *reinstallWizardModel) renderConfirmStep() string {
 			content.WriteString(wizardErrorStyle.Render(fmt.Sprintf(
 				"⚠  All data on %s of server %s will be erased  ⚠", labels[0], m.serviceName)) + "\n")
 		}
-		content.WriteString(wizardErrorStyle.Render("Are you sure to continue ?") + "\n\n")
+		content.WriteString(wizardErrorStyle.Render("Are you sure you want to continue?") + "\n\n")
 	}
 
 	content.WriteString(lipgloss.JoinHorizontal(lipgloss.Center,


### PR DESCRIPTION
# Description

Reword messages of the baremetal reinstall wizard that read like French translated word for word.

## Type of change

- [x] Improvement (improvement of existing commands)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have commented my code
- [x] I ran `go mod tidy`
- [ ] I have added tests that prove my fix is effective or that my feature works
