### PR TITLE
feat(managed-database): add network update support to edit command

### DIFF
--- a/doc/ovhcloud_cloud_managed-database_edit.md
+++ b/doc/ovhcloud_cloud_managed-database_edit.md
@@ -20,6 +20,21 @@ There are two ways to define the edition parameters:
 
 	ovhcloud cloud managed-database edit <service_id> --editor --description "My database cluster"
 
+Network update:
+
+  You can switch a database service between public and private networks without recreating it.
+
+  To switch from public to private network:
+
+	ovhcloud cloud managed-database edit <service_id> --network-id <private-network-uuid> --subnet-id <subnet-uuid>
+
+  To switch from private to public network:
+
+	ovhcloud cloud managed-database edit <service_id> --network-id none --subnet-id none
+
+  Note: Changing the network triggers a service rebuild. The service will be temporarily unavailable
+  during the transition.
+
 
 ```
 ovhcloud cloud managed-database edit <service_id> [flags]
@@ -38,7 +53,9 @@ ovhcloud cloud managed-database edit <service_id> [flags]
   -h, --help                      help for edit
       --ip-restrictions strings   IP blocks authorized to access the cluster (CIDR format)
       --maintenance-time string   Time on which maintenances can start every day
+      --network-id string         Private network ID (use "none" to switch to public network)
       --plan string               Plan of the cluster
+      --subnet-id string          Private subnet ID (use "none" to switch to public network)
       --version string            Version of the engine deployed on the cluster
 ```
 

--- a/internal/cmd/cloud_managed_database.go
+++ b/internal/cmd/cloud_managed_database.go
@@ -317,6 +317,21 @@ There are two ways to define the edition parameters:
   Note that it is also possible to override values in the presented examples using command line flags like the following:
 
 	ovhcloud cloud managed-database edit <service_id> --editor --description "My database cluster"
+
+Network update:
+
+  You can switch a database service between public and private networks without recreating it.
+
+  To switch from public to private network:
+
+	ovhcloud cloud managed-database edit <service_id> --network-id <private-network-uuid> --subnet-id <subnet-uuid>
+
+  To switch from private to public network:
+
+	ovhcloud cloud managed-database edit <service_id> --network-id none --subnet-id none
+
+  Note: Changing the network triggers a service rebuild. The service will be temporarily unavailable
+  during the transition.
 `,
 		ValidArgsFunction: completion.CloudResources("/v1/cloud/project/%s/database"),
 		Run:               cloud.EditManagedDatabase,
@@ -336,6 +351,8 @@ There are two ways to define the edition parameters:
 
 	// Network configuration
 	managedDatabaseEditCmd.Flags().StringSliceVar(&cloud.ManagedDatabaseSpec.CLIIPRestrictions, "ip-restrictions", nil, "IP blocks authorized to access the cluster (CIDR format)")
+	managedDatabaseEditCmd.Flags().StringVar(&cloud.ManagedDatabaseSpec.CLINetworkID, "network-id", "", `Private network ID (use "none" to switch to public network)`)
+	managedDatabaseEditCmd.Flags().StringVar(&cloud.ManagedDatabaseSpec.CLISubnetID, "subnet-id", "", `Private subnet ID (use "none" to switch to public network)`)
 
 	// Common flags for other mean to define parameters
 	addInteractiveEditorFlag(managedDatabaseEditCmd)

--- a/internal/services/cloud/cloud_managed_database.go
+++ b/internal/services/cloud/cloud_managed_database.go
@@ -87,6 +87,8 @@ var (
 		Engine            string   `json:"-"`
 		CLIIPRestrictions []string `json:"-"`
 		CLINodesList      []string `json:"-"`
+		CLINetworkID      string   `json:"-"`
+		CLISubnetID       string   `json:"-"`
 	}
 
 	ManagedDatabaseDatabaseSpec struct {
@@ -236,16 +238,44 @@ func EditManagedDatabase(cmd *cobra.Command, args []string) {
 		ManagedDatabaseSpec.IPRestrictions = append(ManagedDatabaseSpec.IPRestrictions, managedDatabaseIPRestriction{IP: restriction})
 	}
 
-	// Edit resource
-	if err := common.EditResource(
-		cmd,
-		fmt.Sprintf("/cloud/project/{serviceName}/database/%s/{clusterId}", url.PathEscape(databaseService["engine"].(string))),
-		fmt.Sprintf("/v1/cloud/project/%s/database/%s/%s", projectID, url.PathEscape(databaseService["engine"].(string)), url.PathEscape(args[0])),
-		ManagedDatabaseSpec,
-		assets.CloudOpenapiSchema,
-	); err != nil {
-		display.OutputError(&flags.OutputFormatConfig, "%s", err)
-		return
+	// Handle network update separately since networkId/subnetId are filtered
+	// out by the OpenAPI spec filter in EditResource
+	networkChanged := ManagedDatabaseSpec.CLINetworkID != "" || ManagedDatabaseSpec.CLISubnetID != ""
+
+	endpoint := fmt.Sprintf("/v1/cloud/project/%s/database/%s/%s", projectID, url.PathEscape(databaseService["engine"].(string)), url.PathEscape(args[0]))
+
+	// Edit non-network fields through the standard flow
+	if cmd.Flags().NFlag() > 0 && (!networkChanged || cmd.Flags().NFlag() > countNetworkFlags(cmd)) {
+		if err := common.EditResource(
+			cmd,
+			fmt.Sprintf("/cloud/project/{serviceName}/database/%s/{clusterId}", url.PathEscape(databaseService["engine"].(string))),
+			endpoint,
+			ManagedDatabaseSpec,
+			assets.CloudOpenapiSchema,
+		); err != nil {
+			display.OutputError(&flags.OutputFormatConfig, "%s", err)
+			return
+		}
+	}
+
+	// Send network update as a direct PUT
+	if networkChanged {
+		networkBody := map[string]any{}
+		if ManagedDatabaseSpec.CLINetworkID == "none" {
+			networkBody["networkId"] = nil
+		} else if ManagedDatabaseSpec.CLINetworkID != "" {
+			networkBody["networkId"] = ManagedDatabaseSpec.CLINetworkID
+		}
+		if ManagedDatabaseSpec.CLISubnetID == "none" {
+			networkBody["subnetId"] = nil
+		} else if ManagedDatabaseSpec.CLISubnetID != "" {
+			networkBody["subnetId"] = ManagedDatabaseSpec.CLISubnetID
+		}
+		if err := httpLib.Client.Put(endpoint, networkBody, nil); err != nil {
+			display.OutputError(&flags.OutputFormatConfig, "failed to update network: %s", err)
+			return
+		}
+		display.OutputInfo(&flags.OutputFormatConfig, nil, "✅ Network update triggered successfully")
 	}
 }
 
@@ -276,6 +306,17 @@ func DeleteManagedDatabase(_ *cobra.Command, args []string) {
 	}
 
 	display.OutputInfo(&flags.OutputFormatConfig, nil, "✅ Managed database deleted successfully")
+}
+
+func countNetworkFlags(cmd *cobra.Command) int {
+	count := 0
+	if cmd.Flags().Changed("network-id") {
+		count++
+	}
+	if cmd.Flags().Changed("subnet-id") {
+		count++
+	}
+	return count
 }
 
 func ListManagedDatabaseDatabases(_ *cobra.Command, args []string) {


### PR DESCRIPTION
feat(managed-database): add network update support to edit command

# Description

Add `--network-id` and `--subnet-id` flags to the `managed-database edit` command, enabling in-place network switching between public and private networks.

Usage:
- Switch to private: `--network-id <uuid> --subnet-id <uuid>`
- Switch to public: `--network-id none --subnet-id none`

Network updates are sent as a separate PUT request to properly handle null values for the public network switch, since the OpenAPI spec filter in `EditResource` strips network fields.

Changes:
- Added `--network-id` and `--subnet-id` flags to the edit command
- Added network update logic with direct PUT for proper null handling
- Updated auto-generated documentation with network update examples
- Added usage examples in the command's help text

# How Has This Been Tested?

Manually tested against a live PostgreSQL production cluster on OVH EU:

- [x] Public to private network switch (`--network-id <uuid> --subnet-id <uuid>`) — cluster switched to private successfully
- [x] Private to public network switch (`--network-id none --subnet-id none`) — cluster switched to public successfully
- [x] Edit without network flags while on public (`--description "..."`) — no network change triggered, cluster stayed READY
- [x] Edit without network flags while on private (`--description "..."`) — no network change triggered, cluster stayed READY

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have commented my code
- [x] I ran `go mod tidy`
- [ ] I have added tests that prove my fix is effective or that my feature works
