### PR TITLE
Migrate snapshot file storage v2

### DIFF
--- a/doc/ovhcloud_cloud_storage_file.md
+++ b/doc/ovhcloud_cloud_storage_file.md
@@ -7,7 +7,6 @@ Manage file storage shares in the given cloud project
 ```
       --cloud-project string   Cloud project ID
   -h, --help                   help for file
-      --region string          Region (skip region discovery if set)
 ```
 
 ### Options inherited from parent commands

--- a/doc/ovhcloud_cloud_storage_file_network.md
+++ b/doc/ovhcloud_cloud_storage_file_network.md
@@ -26,7 +26,6 @@ Manage file storage share networks
                                  --output 'name+","+type' (to extract and concatenate fields in a string)
                                  --output '(nbFieldA + nbFieldB) * 10' (to compute values from numeric fields)
       --profile string         Use a specific profile from the configuration file
-      --region string          Region (skip region discovery if set)
 ```
 
 ### SEE ALSO

--- a/doc/ovhcloud_cloud_storage_file_network_create.md
+++ b/doc/ovhcloud_cloud_storage_file_network_create.md
@@ -39,7 +39,6 @@ ovhcloud cloud storage file network create <region> [flags]
                                  --output 'name+","+type' (to extract and concatenate fields in a string)
                                  --output '(nbFieldA + nbFieldB) * 10' (to compute values from numeric fields)
       --profile string         Use a specific profile from the configuration file
-      --region string          Region (skip region discovery if set)
 ```
 
 ### SEE ALSO

--- a/doc/ovhcloud_cloud_storage_file_network_delete.md
+++ b/doc/ovhcloud_cloud_storage_file_network_delete.md
@@ -30,7 +30,6 @@ ovhcloud cloud storage file network delete <share_network_id> [flags]
                                  --output 'name+","+type' (to extract and concatenate fields in a string)
                                  --output '(nbFieldA + nbFieldB) * 10' (to compute values from numeric fields)
       --profile string         Use a specific profile from the configuration file
-      --region string          Region (skip region discovery if set)
 ```
 
 ### SEE ALSO

--- a/doc/ovhcloud_cloud_storage_file_network_get.md
+++ b/doc/ovhcloud_cloud_storage_file_network_get.md
@@ -30,7 +30,6 @@ ovhcloud cloud storage file network get <share_network_id> [flags]
                                  --output 'name+","+type' (to extract and concatenate fields in a string)
                                  --output '(nbFieldA + nbFieldB) * 10' (to compute values from numeric fields)
       --profile string         Use a specific profile from the configuration file
-      --region string          Region (skip region discovery if set)
 ```
 
 ### SEE ALSO

--- a/doc/ovhcloud_cloud_storage_file_network_list.md
+++ b/doc/ovhcloud_cloud_storage_file_network_list.md
@@ -37,7 +37,6 @@ ovhcloud cloud storage file network list [flags]
                                  --output 'name+","+type' (to extract and concatenate fields in a string)
                                  --output '(nbFieldA + nbFieldB) * 10' (to compute values from numeric fields)
       --profile string         Use a specific profile from the configuration file
-      --region string          Region (skip region discovery if set)
 ```
 
 ### SEE ALSO

--- a/doc/ovhcloud_cloud_storage_file_share.md
+++ b/doc/ovhcloud_cloud_storage_file_share.md
@@ -26,7 +26,6 @@ Manage file storage shares
                                  --output 'name+","+type' (to extract and concatenate fields in a string)
                                  --output '(nbFieldA + nbFieldB) * 10' (to compute values from numeric fields)
       --profile string         Use a specific profile from the configuration file
-      --region string          Region (skip region discovery if set)
 ```
 
 ### SEE ALSO

--- a/doc/ovhcloud_cloud_storage_file_share_acl.md
+++ b/doc/ovhcloud_cloud_storage_file_share_acl.md
@@ -26,7 +26,6 @@ Manage share access control lists
                                  --output 'name+","+type' (to extract and concatenate fields in a string)
                                  --output '(nbFieldA + nbFieldB) * 10' (to compute values from numeric fields)
       --profile string         Use a specific profile from the configuration file
-      --region string          Region (skip region discovery if set)
 ```
 
 ### SEE ALSO

--- a/doc/ovhcloud_cloud_storage_file_share_acl_create.md
+++ b/doc/ovhcloud_cloud_storage_file_share_acl_create.md
@@ -32,7 +32,6 @@ ovhcloud cloud storage file share acl create <share_id> [flags]
                                  --output 'name+","+type' (to extract and concatenate fields in a string)
                                  --output '(nbFieldA + nbFieldB) * 10' (to compute values from numeric fields)
       --profile string         Use a specific profile from the configuration file
-      --region string          Region (skip region discovery if set)
 ```
 
 ### SEE ALSO

--- a/doc/ovhcloud_cloud_storage_file_share_acl_delete.md
+++ b/doc/ovhcloud_cloud_storage_file_share_acl_delete.md
@@ -30,7 +30,6 @@ ovhcloud cloud storage file share acl delete <share_id> <acl_id> [flags]
                                  --output 'name+","+type' (to extract and concatenate fields in a string)
                                  --output '(nbFieldA + nbFieldB) * 10' (to compute values from numeric fields)
       --profile string         Use a specific profile from the configuration file
-      --region string          Region (skip region discovery if set)
 ```
 
 ### SEE ALSO

--- a/doc/ovhcloud_cloud_storage_file_share_acl_get.md
+++ b/doc/ovhcloud_cloud_storage_file_share_acl_get.md
@@ -30,7 +30,6 @@ ovhcloud cloud storage file share acl get <share_id> <acl_id> [flags]
                                  --output 'name+","+type' (to extract and concatenate fields in a string)
                                  --output '(nbFieldA + nbFieldB) * 10' (to compute values from numeric fields)
       --profile string         Use a specific profile from the configuration file
-      --region string          Region (skip region discovery if set)
 ```
 
 ### SEE ALSO

--- a/doc/ovhcloud_cloud_storage_file_share_acl_list.md
+++ b/doc/ovhcloud_cloud_storage_file_share_acl_list.md
@@ -37,7 +37,6 @@ ovhcloud cloud storage file share acl list <share_id> [flags]
                                  --output 'name+","+type' (to extract and concatenate fields in a string)
                                  --output '(nbFieldA + nbFieldB) * 10' (to compute values from numeric fields)
       --profile string         Use a specific profile from the configuration file
-      --region string          Region (skip region discovery if set)
 ```
 
 ### SEE ALSO

--- a/doc/ovhcloud_cloud_storage_file_share_create.md
+++ b/doc/ovhcloud_cloud_storage_file_share_create.md
@@ -41,7 +41,6 @@ ovhcloud cloud storage file share create <region> [flags]
                                  --output 'name+","+type' (to extract and concatenate fields in a string)
                                  --output '(nbFieldA + nbFieldB) * 10' (to compute values from numeric fields)
       --profile string         Use a specific profile from the configuration file
-      --region string          Region (skip region discovery if set)
 ```
 
 ### SEE ALSO

--- a/doc/ovhcloud_cloud_storage_file_share_edit.md
+++ b/doc/ovhcloud_cloud_storage_file_share_edit.md
@@ -34,7 +34,6 @@ ovhcloud cloud storage file share edit <share_id> [flags]
                                  --output 'name+","+type' (to extract and concatenate fields in a string)
                                  --output '(nbFieldA + nbFieldB) * 10' (to compute values from numeric fields)
       --profile string         Use a specific profile from the configuration file
-      --region string          Region (skip region discovery if set)
 ```
 
 ### SEE ALSO

--- a/doc/ovhcloud_cloud_storage_file_share_get.md
+++ b/doc/ovhcloud_cloud_storage_file_share_get.md
@@ -30,7 +30,6 @@ ovhcloud cloud storage file share get <share_id> [flags]
                                  --output 'name+","+type' (to extract and concatenate fields in a string)
                                  --output '(nbFieldA + nbFieldB) * 10' (to compute values from numeric fields)
       --profile string         Use a specific profile from the configuration file
-      --region string          Region (skip region discovery if set)
 ```
 
 ### SEE ALSO

--- a/doc/ovhcloud_cloud_storage_file_share_list.md
+++ b/doc/ovhcloud_cloud_storage_file_share_list.md
@@ -37,7 +37,6 @@ ovhcloud cloud storage file share list [flags]
                                  --output 'name+","+type' (to extract and concatenate fields in a string)
                                  --output '(nbFieldA + nbFieldB) * 10' (to compute values from numeric fields)
       --profile string         Use a specific profile from the configuration file
-      --region string          Region (skip region discovery if set)
 ```
 
 ### SEE ALSO

--- a/doc/ovhcloud_cloud_storage_file_share_snapshot.md
+++ b/doc/ovhcloud_cloud_storage_file_share_snapshot.md
@@ -26,7 +26,6 @@ Manage share snapshots
                                  --output 'name+","+type' (to extract and concatenate fields in a string)
                                  --output '(nbFieldA + nbFieldB) * 10' (to compute values from numeric fields)
       --profile string         Use a specific profile from the configuration file
-      --region string          Region (skip region discovery if set)
 ```
 
 ### SEE ALSO
@@ -34,6 +33,7 @@ Manage share snapshots
 * [ovhcloud cloud storage file share](ovhcloud_cloud_storage_file_share.md)	 - Manage file storage shares
 * [ovhcloud cloud storage file share snapshot create](ovhcloud_cloud_storage_file_share_snapshot_create.md)	 - Create a snapshot of the given share
 * [ovhcloud cloud storage file share snapshot delete](ovhcloud_cloud_storage_file_share_snapshot_delete.md)	 - Delete a snapshot from the given share
+* [ovhcloud cloud storage file share snapshot edit](ovhcloud_cloud_storage_file_share_snapshot_edit.md)	 - Edit a snapshot of the given share
 * [ovhcloud cloud storage file share snapshot get](ovhcloud_cloud_storage_file_share_snapshot_get.md)	 - Get a specific snapshot for the given share
 * [ovhcloud cloud storage file share snapshot list](ovhcloud_cloud_storage_file_share_snapshot_list.md)	 - List snapshots for the given share
 

--- a/doc/ovhcloud_cloud_storage_file_share_snapshot_create.md
+++ b/doc/ovhcloud_cloud_storage_file_share_snapshot_create.md
@@ -10,8 +10,13 @@ ovhcloud cloud storage file share snapshot create <share_id> [flags]
 
 ```
       --description string   Snapshot description
+      --editor               Use a text editor to define parameters
+      --from-file string     File containing parameters
   -h, --help                 help for create
+      --init-file string     Create a file with example parameters
       --name string          Snapshot name
+      --replace              Replace parameters file if it already exists
+      --wait                 Wait for the snapshot to be ready before exiting
 ```
 
 ### Options inherited from parent commands
@@ -32,7 +37,6 @@ ovhcloud cloud storage file share snapshot create <share_id> [flags]
                                  --output 'name+","+type' (to extract and concatenate fields in a string)
                                  --output '(nbFieldA + nbFieldB) * 10' (to compute values from numeric fields)
       --profile string         Use a specific profile from the configuration file
-      --region string          Region (skip region discovery if set)
 ```
 
 ### SEE ALSO

--- a/doc/ovhcloud_cloud_storage_file_share_snapshot_delete.md
+++ b/doc/ovhcloud_cloud_storage_file_share_snapshot_delete.md
@@ -30,7 +30,6 @@ ovhcloud cloud storage file share snapshot delete <share_id> <snapshot_id> [flag
                                  --output 'name+","+type' (to extract and concatenate fields in a string)
                                  --output '(nbFieldA + nbFieldB) * 10' (to compute values from numeric fields)
       --profile string         Use a specific profile from the configuration file
-      --region string          Region (skip region discovery if set)
 ```
 
 ### SEE ALSO

--- a/doc/ovhcloud_cloud_storage_file_share_snapshot_edit.md
+++ b/doc/ovhcloud_cloud_storage_file_share_snapshot_edit.md
@@ -1,15 +1,19 @@
-## ovhcloud cloud storage file share delete
+## ovhcloud cloud storage file share snapshot edit
 
-Delete the given share
+Edit a snapshot of the given share
 
 ```
-ovhcloud cloud storage file share delete <share_id> [flags]
+ovhcloud cloud storage file share snapshot edit <share_id> <snapshot_id> [flags]
 ```
 
 ### Options
 
 ```
-  -h, --help   help for delete
+      --description string   Snapshot description
+      --editor               Use a text editor to define parameters
+  -h, --help                 help for edit
+      --name string          Snapshot name
+      --wait                 Wait for the snapshot to be ready before exiting
 ```
 
 ### Options inherited from parent commands
@@ -34,5 +38,5 @@ ovhcloud cloud storage file share delete <share_id> [flags]
 
 ### SEE ALSO
 
-* [ovhcloud cloud storage file share](ovhcloud_cloud_storage_file_share.md)	 - Manage file storage shares
+* [ovhcloud cloud storage file share snapshot](ovhcloud_cloud_storage_file_share_snapshot.md)	 - Manage share snapshots
 

--- a/doc/ovhcloud_cloud_storage_file_share_snapshot_get.md
+++ b/doc/ovhcloud_cloud_storage_file_share_snapshot_get.md
@@ -30,7 +30,6 @@ ovhcloud cloud storage file share snapshot get <share_id> <snapshot_id> [flags]
                                  --output 'name+","+type' (to extract and concatenate fields in a string)
                                  --output '(nbFieldA + nbFieldB) * 10' (to compute values from numeric fields)
       --profile string         Use a specific profile from the configuration file
-      --region string          Region (skip region discovery if set)
 ```
 
 ### SEE ALSO

--- a/doc/ovhcloud_cloud_storage_file_share_snapshot_list.md
+++ b/doc/ovhcloud_cloud_storage_file_share_snapshot_list.md
@@ -37,7 +37,6 @@ ovhcloud cloud storage file share snapshot list <share_id> [flags]
                                  --output 'name+","+type' (to extract and concatenate fields in a string)
                                  --output '(nbFieldA + nbFieldB) * 10' (to compute values from numeric fields)
       --profile string         Use a specific profile from the configuration file
-      --region string          Region (skip region discovery if set)
 ```
 
 ### SEE ALSO

--- a/internal/assets/api-schemas/cloud_v2.json
+++ b/internal/assets/api-schemas/cloud_v2.json
@@ -9526,10 +9526,17 @@
             "nullable": true,
             "readOnly": true
           },
-          "shareId": {
-            "type": "string",
-            "description": "ID of the parent file storage share",
-            "format": "uuid",
+          "share": {
+            "type": "object",
+            "description": "Parent file storage share",
+            "properties": {
+              "id": {
+                "type": "string",
+                "description": "ID of the parent file storage share",
+                "format": "uuid",
+                "readOnly": true
+              }
+            },
             "readOnly": true
           },
           "shareProto": {
@@ -9546,7 +9553,7 @@
             "description": "Size of the parent share in GB at the time of the snapshot",
             "readOnly": true
           },
-          "snapshotSize": {
+          "size": {
             "type": "integer",
             "description": "Size of the snapshot in GB",
             "readOnly": true
@@ -9575,15 +9582,24 @@
             "description": "Desired snapshot name",
             "nullable": true
           },
-          "shareId": {
-            "type": "string",
-            "description": "ID of the parent file storage share",
-            "format": "uuid"
+          "share": {
+            "type": "object",
+            "description": "Parent file storage share",
+            "properties": {
+              "id": {
+                "type": "string",
+                "description": "ID of the parent file storage share",
+                "format": "uuid"
+              }
+            },
+            "required": [
+              "id"
+            ]
           }
         },
         "required": [
           "location",
-          "shareId"
+          "share"
         ]
       },
       "publicCloud.storage.file.FileStorageSnapshotUpdate": {
@@ -27243,7 +27259,9 @@
                         "region": "GRA1"
                       },
                       "name": "my-share-snapshot",
-                      "shareId": "d1e2f3a4-b5c6-7890-abcd-ef1234567890"
+                      "share": {
+                        "id": "d1e2f3a4-b5c6-7890-abcd-ef1234567890"
+                      }
                     }
                   },
                   "summary": "Create a snapshot of a file storage"
@@ -27544,10 +27562,12 @@
                           "region": "GRA1"
                         },
                         "name": "my-share-snapshot",
-                        "shareId": "d1e2f3a4-b5c6-7890-abcd-ef1234567890",
+                        "share": {
+                          "id": "d1e2f3a4-b5c6-7890-abcd-ef1234567890"
+                        },
                         "shareProto": "NFS",
                         "shareSize": 100,
-                        "snapshotSize": 1
+                        "size": 1
                       },
                       "currentTasks": null,
                       "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
@@ -27558,7 +27578,9 @@
                           "region": "GRA1"
                         },
                         "name": "my-share-snapshot",
-                        "shareId": "d1e2f3a4-b5c6-7890-abcd-ef1234567890"
+                        "share": {
+                          "id": "d1e2f3a4-b5c6-7890-abcd-ef1234567890"
+                        }
                       },
                       "updatedAt": "2026-02-10T15:05:00Z"
                     },

--- a/internal/assets/api-schemas/cloud_v2.json
+++ b/internal/assets/api-schemas/cloud_v2.json
@@ -9539,20 +9539,6 @@
             },
             "readOnly": true
           },
-          "shareProto": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/publicCloud.storage.file.FileStorageProtocolEnum"
-              }
-            ],
-            "description": "File sharing protocol of the parent share",
-            "readOnly": true
-          },
-          "shareSize": {
-            "type": "integer",
-            "description": "Size of the parent share in GB at the time of the snapshot",
-            "readOnly": true
-          },
           "size": {
             "type": "integer",
             "description": "Size of the snapshot in GB",
@@ -9568,14 +9554,6 @@
             "type": "string",
             "description": "Description of the snapshot",
             "nullable": true
-          },
-          "location": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/publicCloud.common.Location"
-              }
-            ],
-            "description": "Location of the snapshot"
           },
           "name": {
             "type": "string",
@@ -9598,7 +9576,6 @@
           }
         },
         "required": [
-          "location",
           "share"
         ]
       },
@@ -27255,9 +27232,6 @@
                   "value": {
                     "targetSpec": {
                       "description": "Daily backup snapshot",
-                      "location": {
-                        "region": "GRA1"
-                      },
                       "name": "my-share-snapshot",
                       "share": {
                         "id": "d1e2f3a4-b5c6-7890-abcd-ef1234567890"
@@ -27565,8 +27539,6 @@
                         "share": {
                           "id": "d1e2f3a4-b5c6-7890-abcd-ef1234567890"
                         },
-                        "shareProto": "NFS",
-                        "shareSize": 100,
                         "size": 1
                       },
                       "currentTasks": null,
@@ -27574,9 +27546,6 @@
                       "resourceStatus": "READY",
                       "targetSpec": {
                         "description": "Daily backup snapshot",
-                        "location": {
-                          "region": "GRA1"
-                        },
                         "name": "my-share-snapshot",
                         "share": {
                           "id": "d1e2f3a4-b5c6-7890-abcd-ef1234567890"

--- a/internal/cmd/cloud_storage_file.go
+++ b/internal/cmd/cloud_storage_file.go
@@ -176,8 +176,8 @@ func initCloudStorageFileCommand(cloudCmd *cobra.Command) {
 		Run:   cloud.CreateShareSnapshot,
 		Args:  cobra.ExactArgs(1),
 	}
-	snapshotCreateCmd.Flags().StringVar(&cloud.ShareSnapshotSpec.Description, "description", "", "Snapshot description")
-	snapshotCreateCmd.Flags().StringVar(&cloud.ShareSnapshotSpec.Name, "name", "", "Snapshot name")
+	snapshotCreateCmd.Flags().StringVar(&cloud.ShareSnapshotSpec.TargetSpec.Description, "description", "", "Snapshot description")
+	snapshotCreateCmd.Flags().StringVar(&cloud.ShareSnapshotSpec.TargetSpec.Name, "name", "", "Snapshot name")
 	snapshotCmd.AddCommand(snapshotCreateCmd)
 
 	snapshotCmd.AddCommand(&cobra.Command{

--- a/internal/cmd/cloud_storage_file.go
+++ b/internal/cmd/cloud_storage_file.go
@@ -6,6 +6,7 @@ package cmd
 
 import (
 	"github.com/ovh/ovhcloud-cli/internal/assets"
+	"github.com/ovh/ovhcloud-cli/internal/flags"
 	"github.com/ovh/ovhcloud-cli/internal/services/cloud"
 	"github.com/spf13/cobra"
 )
@@ -16,7 +17,6 @@ func initCloudStorageFileCommand(cloudCmd *cobra.Command) {
 		Short: "Manage file storage shares in the given cloud project",
 	}
 	storageFileCmd.PersistentFlags().StringVar(&cloud.CloudProject, "cloud-project", "", "Cloud project ID")
-	storageFileCmd.PersistentFlags().StringVar(&cloud.ShareRegion, "region", "", "Region (skip region discovery if set)")
 
 	networkCmd := &cobra.Command{
 		Use:   "network",
@@ -178,7 +178,23 @@ func initCloudStorageFileCommand(cloudCmd *cobra.Command) {
 	}
 	snapshotCreateCmd.Flags().StringVar(&cloud.ShareSnapshotSpec.TargetSpec.Description, "description", "", "Snapshot description")
 	snapshotCreateCmd.Flags().StringVar(&cloud.ShareSnapshotSpec.TargetSpec.Name, "name", "", "Snapshot name")
+	snapshotCreateCmd.Flags().BoolVar(&flags.WaitForTask, "wait", false, "Wait for the snapshot to be ready before exiting")
+	addParameterFileFlags(snapshotCreateCmd, false, assets.CloudV2OpenapiSchema, "/publicCloud/project/{projectId}/storage/file/snapshot", "post", cloud.ShareSnapshotCreateExample, nil)
+	addInteractiveEditorFlag(snapshotCreateCmd)
+	markFlagsMutuallyExclusive(snapshotCreateCmd, "from-file", "editor")
 	snapshotCmd.AddCommand(snapshotCreateCmd)
+
+	snapshotEditCmd := &cobra.Command{
+		Use:   "edit <share_id> <snapshot_id>",
+		Short: "Edit a snapshot of the given share",
+		Run:   cloud.EditShareSnapshot,
+		Args:  cobra.ExactArgs(2),
+	}
+	snapshotEditCmd.Flags().StringVar(&cloud.ShareSnapshotEditSpec.TargetSpec.Description, "description", "", "Snapshot description")
+	snapshotEditCmd.Flags().StringVar(&cloud.ShareSnapshotEditSpec.TargetSpec.Name, "name", "", "Snapshot name")
+	snapshotEditCmd.Flags().BoolVar(&flags.WaitForTask, "wait", false, "Wait for the snapshot to be ready before exiting")
+	addInteractiveEditorFlag(snapshotEditCmd)
+	snapshotCmd.AddCommand(snapshotEditCmd)
 
 	snapshotCmd.AddCommand(&cobra.Command{
 		Use:   "delete <share_id> <snapshot_id>",

--- a/internal/services/cloud/cloud_storage_file.go
+++ b/internal/services/cloud/cloud_storage_file.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/ovh/ovhcloud-cli/internal/assets"
 	"github.com/ovh/ovhcloud-cli/internal/display"
-	filtersLib "github.com/ovh/ovhcloud-cli/internal/filters"
 	"github.com/ovh/ovhcloud-cli/internal/flags"
 	httpLib "github.com/ovh/ovhcloud-cli/internal/http"
 	"github.com/ovh/ovhcloud-cli/internal/services/common"
@@ -36,8 +35,14 @@ var (
 		"targetSpec.subnet.id subnetId",
 		"resourceStatus status",
 	}
-	shareSnapshotColumnsToDisplay = []string{"id", "name", "shareId", "size", "status"}
-	shareACLColumnsToDisplay      = []string{
+	shareSnapshotColumnsToDisplay = []string{
+		"id",
+		"targetSpec.name name",
+		"targetSpec.share.id shareId",
+		"targetSpec.location.region region",
+		"resourceStatus status",
+	}
+	shareACLColumnsToDisplay = []string{
 		"id",
 		"currentState.accessLevel accessLevel",
 		"currentState.accessTo accessTo",
@@ -99,8 +104,16 @@ var (
 	}
 
 	ShareSnapshotSpec struct {
-		Description string `json:"description,omitempty"`
-		Name        string `json:"name,omitempty"`
+		TargetSpec struct {
+			Description string `json:"description,omitempty"`
+			Name        string `json:"name,omitempty"`
+			Share       struct {
+				Id string `json:"id,omitempty"`
+			} `json:"share,omitzero"`
+			Location struct {
+				Region string `json:"region,omitempty"`
+			} `json:"location,omitzero"`
+		} `json:"targetSpec"`
 	}
 
 	ShareACLSpec struct {
@@ -311,6 +324,30 @@ func DeleteShare(_ *cobra.Command, args []string) {
 	display.OutputInfo(&flags.OutputFormatConfig, nil, "✅ Share %s deleted successfully", args[0])
 }
 
+func getShareRegionV2(projectID, shareID string) (string, error) {
+	var share map[string]any
+	endpoint := fmt.Sprintf("%s/%s", shareV2Endpoint(projectID), url.PathEscape(shareID))
+	if err := httpLib.Client.Get(endpoint, &share); err != nil {
+		return "", fmt.Errorf("failed to fetch share %s: %w", shareID, err)
+	}
+
+	for _, state := range []string{"targetSpec", "currentState"} {
+		stateValue, ok := share[state].(map[string]any)
+		if !ok {
+			continue
+		}
+		location, ok := stateValue["location"].(map[string]any)
+		if !ok {
+			continue
+		}
+		if region, ok := location["region"].(string); ok && region != "" {
+			return region, nil
+		}
+	}
+
+	return "", fmt.Errorf("share %s has no region", shareID)
+}
+
 // ACL commands
 
 func ListShareACLs(_ *cobra.Command, args []string) {
@@ -377,36 +414,31 @@ func DeleteShareACL(_ *cobra.Command, args []string) {
 // Snapshot commands
 
 func ListShareSnapshots(_ *cobra.Command, args []string) {
-	endpoint, _, err := findShare(args[0])
+	projectID, err := getConfiguredCloudProject()
 	if err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
-	var snapshots []map[string]any
-	if err := httpLib.Client.Get(endpoint+"/snapshot", &snapshots); err != nil {
-		display.OutputError(&flags.OutputFormatConfig, "failed to fetch share snapshots: %s", err)
-		return
-	}
-
-	snapshots, err = filtersLib.FilterLines(snapshots, flags.GenericFilters)
-	if err != nil {
-		display.OutputError(&flags.OutputFormatConfig, "failed to filter results: %s", err)
-		return
-	}
-
-	display.RenderTable(snapshots, shareSnapshotColumnsToDisplay, &flags.OutputFormatConfig)
+	filters := append([]string{}, flags.GenericFilters...)
+	filters = append(filters, fmt.Sprintf("targetSpec.share.id==%q", args[0]))
+	common.ManageListRequestNoExpand(
+		fmt.Sprintf("/v2/publicCloud/project/%s/storage/file/snapshot", projectID),
+		shareSnapshotColumnsToDisplay,
+		filters,
+	)
 }
 
 func GetShareSnapshot(_ *cobra.Command, args []string) {
-	endpoint, _, err := findShare(args[0])
+	projectID, err := getConfiguredCloudProject()
 	if err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
+	endpoint := fmt.Sprintf("/v2/publicCloud/project/%s/storage/file/snapshot/%s", projectID, url.PathEscape(args[1]))
 	var snapshot map[string]any
-	if err := httpLib.Client.Get(fmt.Sprintf("%s/snapshot/%s", endpoint, url.PathEscape(args[1])), &snapshot); err != nil {
+	if err := httpLib.Client.Get(endpoint, &snapshot); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "failed to fetch share snapshot: %s", err)
 		return
 	}
@@ -415,14 +447,22 @@ func GetShareSnapshot(_ *cobra.Command, args []string) {
 }
 
 func CreateShareSnapshot(_ *cobra.Command, args []string) {
-	endpoint, _, err := findShare(args[0])
+	projectID, err := getConfiguredCloudProject()
 	if err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
+	region, err := getShareRegionV2(projectID, args[0])
+	if err != nil {
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
+		return
+	}
+	ShareSnapshotSpec.TargetSpec.Share.Id = args[0]
+	ShareSnapshotSpec.TargetSpec.Location.Region = region
+	endpoint := fmt.Sprintf("/v2/publicCloud/project/%s/storage/file/snapshot", projectID)
 	var response map[string]any
-	if err := httpLib.Client.Post(endpoint+"/snapshot", ShareSnapshotSpec, &response); err != nil {
+	if err := httpLib.Client.Post(endpoint, ShareSnapshotSpec, &response); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "failed to create share snapshot: %s", err)
 		return
 	}
@@ -431,13 +471,14 @@ func CreateShareSnapshot(_ *cobra.Command, args []string) {
 }
 
 func DeleteShareSnapshot(_ *cobra.Command, args []string) {
-	endpoint, _, err := findShare(args[0])
+	projectID, err := getConfiguredCloudProject()
 	if err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
-	if err := httpLib.Client.Delete(fmt.Sprintf("%s/snapshot/%s", endpoint, url.PathEscape(args[1])), nil); err != nil {
+	endpoint := fmt.Sprintf("/v2/publicCloud/project/%s/storage/file/snapshot/%s", projectID, url.PathEscape(args[1]))
+	if err := httpLib.Client.Delete(endpoint, nil); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "failed to delete share snapshot: %s", err)
 		return
 	}

--- a/internal/services/cloud/cloud_storage_file.go
+++ b/internal/services/cloud/cloud_storage_file.go
@@ -37,7 +37,12 @@ var (
 		"resourceStatus status",
 	}
 	shareSnapshotColumnsToDisplay = []string{"id", "name", "shareId", "size", "status"}
-	shareACLColumnsToDisplay      = []string{"id", "accessLevel", "accessTo", "accessType", "status"}
+	shareACLColumnsToDisplay      = []string{
+		"id",
+		"currentState.accessLevel accessLevel",
+		"currentState.accessTo accessTo",
+		"resourceStatus status",
+	}
 
 	//go:embed templates/cloud_storage_file_share.tmpl
 	shareTemplate string
@@ -99,8 +104,10 @@ var (
 	}
 
 	ShareACLSpec struct {
-		AccessLevel string `json:"accessLevel,omitempty"`
-		AccessTo    string `json:"accessTo,omitempty"`
+		TargetSpec struct {
+			AccessLevel string `json:"accessLevel,omitempty"`
+			AccessTo    string `json:"accessTo,omitempty"`
+		} `json:"targetSpec"`
 	}
 
 	ShareRegion string
@@ -307,36 +314,26 @@ func DeleteShare(_ *cobra.Command, args []string) {
 // ACL commands
 
 func ListShareACLs(_ *cobra.Command, args []string) {
-	endpoint, _, err := findShare(args[0])
+	projectID, err := getConfiguredCloudProject()
 	if err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
-	var acls []map[string]any
-	if err := httpLib.Client.Get(endpoint+"/acl", &acls); err != nil {
-		display.OutputError(&flags.OutputFormatConfig, "failed to fetch share ACLs: %s", err)
-		return
-	}
-
-	acls, err = filtersLib.FilterLines(acls, flags.GenericFilters)
-	if err != nil {
-		display.OutputError(&flags.OutputFormatConfig, "failed to filter results: %s", err)
-		return
-	}
-
-	display.RenderTable(acls, shareACLColumnsToDisplay, &flags.OutputFormatConfig)
+	endpoint := fmt.Sprintf("%s/%s/acl", shareV2Endpoint(projectID), url.PathEscape(args[0]))
+	common.ManageListRequestNoExpand(endpoint, shareACLColumnsToDisplay, flags.GenericFilters)
 }
 
 func GetShareACL(_ *cobra.Command, args []string) {
-	endpoint, _, err := findShare(args[0])
+	projectID, err := getConfiguredCloudProject()
 	if err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
+	endpoint := fmt.Sprintf("%s/%s/acl/%s", shareV2Endpoint(projectID), url.PathEscape(args[0]), url.PathEscape(args[1]))
 	var acl map[string]any
-	if err := httpLib.Client.Get(fmt.Sprintf("%s/acl/%s", endpoint, url.PathEscape(args[1])), &acl); err != nil {
+	if err := httpLib.Client.Get(endpoint, &acl); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "failed to fetch share ACL: %s", err)
 		return
 	}
@@ -345,14 +342,15 @@ func GetShareACL(_ *cobra.Command, args []string) {
 }
 
 func CreateShareACL(_ *cobra.Command, args []string) {
-	endpoint, _, err := findShare(args[0])
+	projectID, err := getConfiguredCloudProject()
 	if err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
+	endpoint := fmt.Sprintf("%s/%s/acl", shareV2Endpoint(projectID), url.PathEscape(args[0]))
 	var response map[string]any
-	if err := httpLib.Client.Post(endpoint+"/acl", ShareACLSpec, &response); err != nil {
+	if err := httpLib.Client.Post(endpoint, ShareACLSpec, &response); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "failed to create share ACL: %s", err)
 		return
 	}
@@ -361,13 +359,14 @@ func CreateShareACL(_ *cobra.Command, args []string) {
 }
 
 func DeleteShareACL(_ *cobra.Command, args []string) {
-	endpoint, _, err := findShare(args[0])
+	projectID, err := getConfiguredCloudProject()
 	if err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
-	if err := httpLib.Client.Delete(fmt.Sprintf("%s/acl/%s", endpoint, url.PathEscape(args[1])), nil); err != nil {
+	endpoint := fmt.Sprintf("%s/%s/acl/%s", shareV2Endpoint(projectID), url.PathEscape(args[0]), url.PathEscape(args[1]))
+	if err := httpLib.Client.Delete(endpoint, nil); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "failed to delete share ACL: %s", err)
 		return
 	}

--- a/internal/services/cloud/cloud_storage_file.go
+++ b/internal/services/cloud/cloud_storage_file.go
@@ -37,12 +37,7 @@ var (
 		"resourceStatus status",
 	}
 	shareSnapshotColumnsToDisplay = []string{"id", "name", "shareId", "size", "status"}
-	shareACLColumnsToDisplay      = []string{
-		"id",
-		"currentState.accessLevel accessLevel",
-		"currentState.accessTo accessTo",
-		"resourceStatus status",
-	}
+	shareACLColumnsToDisplay      = []string{"id", "accessLevel", "accessTo", "accessType", "status"}
 
 	//go:embed templates/cloud_storage_file_share.tmpl
 	shareTemplate string
@@ -104,10 +99,8 @@ var (
 	}
 
 	ShareACLSpec struct {
-		TargetSpec struct {
-			AccessLevel string `json:"accessLevel,omitempty"`
-			AccessTo    string `json:"accessTo,omitempty"`
-		} `json:"targetSpec"`
+		AccessLevel string `json:"accessLevel,omitempty"`
+		AccessTo    string `json:"accessTo,omitempty"`
 	}
 
 	ShareRegion string
@@ -314,26 +307,36 @@ func DeleteShare(_ *cobra.Command, args []string) {
 // ACL commands
 
 func ListShareACLs(_ *cobra.Command, args []string) {
-	projectID, err := getConfiguredCloudProject()
+	endpoint, _, err := findShare(args[0])
 	if err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
-	endpoint := fmt.Sprintf("%s/%s/acl", shareV2Endpoint(projectID), url.PathEscape(args[0]))
-	common.ManageListRequestNoExpand(endpoint, shareACLColumnsToDisplay, flags.GenericFilters)
+	var acls []map[string]any
+	if err := httpLib.Client.Get(endpoint+"/acl", &acls); err != nil {
+		display.OutputError(&flags.OutputFormatConfig, "failed to fetch share ACLs: %s", err)
+		return
+	}
+
+	acls, err = filtersLib.FilterLines(acls, flags.GenericFilters)
+	if err != nil {
+		display.OutputError(&flags.OutputFormatConfig, "failed to filter results: %s", err)
+		return
+	}
+
+	display.RenderTable(acls, shareACLColumnsToDisplay, &flags.OutputFormatConfig)
 }
 
 func GetShareACL(_ *cobra.Command, args []string) {
-	projectID, err := getConfiguredCloudProject()
+	endpoint, _, err := findShare(args[0])
 	if err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
-	endpoint := fmt.Sprintf("%s/%s/acl/%s", shareV2Endpoint(projectID), url.PathEscape(args[0]), url.PathEscape(args[1]))
 	var acl map[string]any
-	if err := httpLib.Client.Get(endpoint, &acl); err != nil {
+	if err := httpLib.Client.Get(fmt.Sprintf("%s/acl/%s", endpoint, url.PathEscape(args[1])), &acl); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "failed to fetch share ACL: %s", err)
 		return
 	}
@@ -342,15 +345,14 @@ func GetShareACL(_ *cobra.Command, args []string) {
 }
 
 func CreateShareACL(_ *cobra.Command, args []string) {
-	projectID, err := getConfiguredCloudProject()
+	endpoint, _, err := findShare(args[0])
 	if err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
-	endpoint := fmt.Sprintf("%s/%s/acl", shareV2Endpoint(projectID), url.PathEscape(args[0]))
 	var response map[string]any
-	if err := httpLib.Client.Post(endpoint, ShareACLSpec, &response); err != nil {
+	if err := httpLib.Client.Post(endpoint+"/acl", ShareACLSpec, &response); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "failed to create share ACL: %s", err)
 		return
 	}
@@ -359,14 +361,13 @@ func CreateShareACL(_ *cobra.Command, args []string) {
 }
 
 func DeleteShareACL(_ *cobra.Command, args []string) {
-	projectID, err := getConfiguredCloudProject()
+	endpoint, _, err := findShare(args[0])
 	if err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
-	endpoint := fmt.Sprintf("%s/%s/acl/%s", shareV2Endpoint(projectID), url.PathEscape(args[0]), url.PathEscape(args[1]))
-	if err := httpLib.Client.Delete(endpoint, nil); err != nil {
+	if err := httpLib.Client.Delete(fmt.Sprintf("%s/acl/%s", endpoint, url.PathEscape(args[1])), nil); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "failed to delete share ACL: %s", err)
 		return
 	}

--- a/internal/services/cloud/cloud_storage_file.go
+++ b/internal/services/cloud/cloud_storage_file.go
@@ -39,7 +39,6 @@ var (
 		"id",
 		"targetSpec.name name",
 		"targetSpec.share.id shareId",
-		"targetSpec.location.region region",
 		"resourceStatus status",
 	}
 	shareACLColumnsToDisplay = []string{
@@ -60,6 +59,9 @@ var (
 
 	//go:embed parameter-samples/storage-file-share-network-create.json
 	ShareNetworkCreateExample string
+
+	//go:embed parameter-samples/storage-file-share-snapshot-create.json
+	ShareSnapshotCreateExample string
 
 	ShareSpec struct {
 		TargetSpec struct {
@@ -110,10 +112,14 @@ var (
 			Share       struct {
 				Id string `json:"id,omitempty"`
 			} `json:"share,omitzero"`
-			Location struct {
-				Region string `json:"region,omitempty"`
-			} `json:"location,omitzero"`
 		} `json:"targetSpec"`
+	}
+
+	ShareSnapshotEditSpec struct {
+		TargetSpec struct {
+			Description string `json:"description,omitempty"`
+			Name        string `json:"name,omitempty"`
+		} `json:"targetSpec,omitzero"`
 	}
 
 	ShareACLSpec struct {
@@ -122,8 +128,6 @@ var (
 			AccessTo    string `json:"accessTo,omitempty"`
 		} `json:"targetSpec"`
 	}
-
-	ShareRegion string
 )
 
 func shareV2Endpoint(projectID string) string {
@@ -134,39 +138,8 @@ func shareNetworkV2Endpoint(projectID string) string {
 	return fmt.Sprintf("/v2/publicCloud/project/%s/storage/file/network", projectID)
 }
 
-// getShareRegions returns a single-element slice if --region is set,
-// otherwise discovers all regions with the share feature available.
-func getShareRegions(projectID string) ([]any, error) {
-	if ShareRegion != "" {
-		return []any{ShareRegion}, nil
-	}
-	return getCloudRegionsWithFeatureAvailable(projectID, "share")
-}
-
-// findShare searches for a share across all regions and returns its endpoint and data.
-func findShare(shareID string) (string, map[string]any, error) {
-	projectID, err := getConfiguredCloudProject()
-	if err != nil {
-		return "", nil, err
-	}
-
-	regions, err := getShareRegions(projectID)
-	if err != nil {
-		return "", nil, fmt.Errorf("failed to fetch regions with share feature available: %w", err)
-	}
-
-	for _, region := range regions {
-		var (
-			share    map[string]any
-			endpoint = fmt.Sprintf("/v1/cloud/project/%s/region/%s/share/%s",
-				projectID, url.PathEscape(region.(string)), url.PathEscape(shareID))
-		)
-		if err := httpLib.Client.Get(endpoint, &share); err == nil {
-			return endpoint, share, nil
-		}
-	}
-
-	return "", nil, fmt.Errorf("no share found with ID %s", shareID)
+func shareSnapshotV2Endpoint(projectID string) string {
+	return fmt.Sprintf("/v2/publicCloud/project/%s/storage/file/snapshot", projectID)
 }
 
 func ListShares(_ *cobra.Command, _ []string) {
@@ -324,30 +297,6 @@ func DeleteShare(_ *cobra.Command, args []string) {
 	display.OutputInfo(&flags.OutputFormatConfig, nil, "✅ Share %s deleted successfully", args[0])
 }
 
-func getShareRegionV2(projectID, shareID string) (string, error) {
-	var share map[string]any
-	endpoint := fmt.Sprintf("%s/%s", shareV2Endpoint(projectID), url.PathEscape(shareID))
-	if err := httpLib.Client.Get(endpoint, &share); err != nil {
-		return "", fmt.Errorf("failed to fetch share %s: %w", shareID, err)
-	}
-
-	for _, state := range []string{"targetSpec", "currentState"} {
-		stateValue, ok := share[state].(map[string]any)
-		if !ok {
-			continue
-		}
-		location, ok := stateValue["location"].(map[string]any)
-		if !ok {
-			continue
-		}
-		if region, ok := location["region"].(string); ok && region != "" {
-			return region, nil
-		}
-	}
-
-	return "", fmt.Errorf("share %s has no region", shareID)
-}
-
 // ACL commands
 
 func ListShareACLs(_ *cobra.Command, args []string) {
@@ -413,6 +362,49 @@ func DeleteShareACL(_ *cobra.Command, args []string) {
 
 // Snapshot commands
 
+// shareSnapshotParentID returns the identifier of the share a snapshot was
+// taken from. The parent share is set at creation and never changes, so
+// targetSpec is authoritative and is also the only one available while the
+// snapshot is still being created.
+func shareSnapshotParentID(snapshot map[string]any) string {
+	for _, state := range []string{"targetSpec", "currentState"} {
+		stateValue, ok := snapshot[state].(map[string]any)
+		if !ok {
+			continue
+		}
+		share, ok := stateValue["share"].(map[string]any)
+		if !ok {
+			continue
+		}
+		if id, ok := share["id"].(string); ok && id != "" {
+			return id
+		}
+	}
+
+	return ""
+}
+
+// fetchShareSnapshot fetches a snapshot and checks that it really belongs to
+// the given share. Snapshot routes are project scoped in the v2 API, so
+// without this check any snapshot of the project would be reachable (and
+// deletable) through any share ID.
+func fetchShareSnapshot(projectID, shareID, snapshotID string) (map[string]any, error) {
+	var snapshot map[string]any
+	endpoint := fmt.Sprintf("%s/%s", shareSnapshotV2Endpoint(projectID), url.PathEscape(snapshotID))
+	if err := httpLib.Client.Get(endpoint, &snapshot); err != nil {
+		return nil, fmt.Errorf("failed to fetch share snapshot: %w", err)
+	}
+
+	switch parent := shareSnapshotParentID(snapshot); parent {
+	case shareID:
+		return snapshot, nil
+	case "":
+		return nil, fmt.Errorf("failed to determine the parent share of snapshot %s", snapshotID)
+	default:
+		return nil, fmt.Errorf("snapshot %s belongs to share %s, not to share %s", snapshotID, parent, shareID)
+	}
+}
+
 func ListShareSnapshots(_ *cobra.Command, args []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
@@ -422,11 +414,7 @@ func ListShareSnapshots(_ *cobra.Command, args []string) {
 
 	filters := append([]string{}, flags.GenericFilters...)
 	filters = append(filters, fmt.Sprintf("targetSpec.share.id==%q", args[0]))
-	common.ManageListRequestNoExpand(
-		fmt.Sprintf("/v2/publicCloud/project/%s/storage/file/snapshot", projectID),
-		shareSnapshotColumnsToDisplay,
-		filters,
-	)
+	common.ManageListRequestNoExpand(shareSnapshotV2Endpoint(projectID), shareSnapshotColumnsToDisplay, filters)
 }
 
 func GetShareSnapshot(_ *cobra.Command, args []string) {
@@ -436,38 +424,89 @@ func GetShareSnapshot(_ *cobra.Command, args []string) {
 		return
 	}
 
-	endpoint := fmt.Sprintf("/v2/publicCloud/project/%s/storage/file/snapshot/%s", projectID, url.PathEscape(args[1]))
-	var snapshot map[string]any
-	if err := httpLib.Client.Get(endpoint, &snapshot); err != nil {
-		display.OutputError(&flags.OutputFormatConfig, "failed to fetch share snapshot: %s", err)
+	snapshot, err := fetchShareSnapshot(projectID, args[0], args[1])
+	if err != nil {
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
 	display.OutputObject(snapshot, args[1], shareSnapshotTemplate, &flags.OutputFormatConfig)
 }
 
-func CreateShareSnapshot(_ *cobra.Command, args []string) {
+func CreateShareSnapshot(cmd *cobra.Command, args []string) {
 	projectID, err := getConfiguredCloudProject()
 	if err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
 
-	region, err := getShareRegionV2(projectID, args[0])
+	ShareSnapshotSpec.TargetSpec.Share.Id = args[0]
+	endpoint := shareSnapshotV2Endpoint(projectID)
+	snapshot, err := common.CreateResource(
+		cmd,
+		"/publicCloud/project/{projectId}/storage/file/snapshot",
+		endpoint,
+		ShareSnapshotCreateExample,
+		ShareSnapshotSpec,
+		assets.CloudV2OpenapiSchema,
+		[]string{"targetSpec.share.id"},
+	)
 	if err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "%s", err)
 		return
 	}
-	ShareSnapshotSpec.TargetSpec.Share.Id = args[0]
-	ShareSnapshotSpec.TargetSpec.Location.Region = region
-	endpoint := fmt.Sprintf("/v2/publicCloud/project/%s/storage/file/snapshot", projectID)
-	var response map[string]any
-	if err := httpLib.Client.Post(endpoint, ShareSnapshotSpec, &response); err != nil {
-		display.OutputError(&flags.OutputFormatConfig, "failed to create share snapshot: %s", err)
+
+	snapshotID, _ := snapshot["id"].(string)
+
+	if !flags.WaitForTask {
+		display.OutputInfo(&flags.OutputFormatConfig, snapshot, "✅ Snapshot creation started successfully for share %s (id: %s)", args[0], snapshotID)
 		return
 	}
 
-	display.OutputInfo(&flags.OutputFormatConfig, response, "✅ Snapshot created successfully for share %s (id: %s)", args[0], response["id"])
+	ready, err := waitForCloudResourceReady(fmt.Sprintf("%s/%s", endpoint, url.PathEscape(snapshotID)), 10*time.Minute)
+	if err != nil {
+		display.OutputError(&flags.OutputFormatConfig, "failed to wait for snapshot creation: %s", err)
+		return
+	}
+
+	display.OutputInfo(&flags.OutputFormatConfig, ready, "✅ Snapshot %s created successfully for share %s", snapshotID, args[0])
+}
+
+func EditShareSnapshot(cmd *cobra.Command, args []string) {
+	projectID, err := getConfiguredCloudProject()
+	if err != nil {
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
+		return
+	}
+
+	if _, err := fetchShareSnapshot(projectID, args[0], args[1]); err != nil {
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
+		return
+	}
+
+	endpoint := fmt.Sprintf("%s/%s", shareSnapshotV2Endpoint(projectID), url.PathEscape(args[1]))
+	if err := common.EditResource(
+		cmd,
+		"/publicCloud/project/{projectId}/storage/file/snapshot/{snapshotId}",
+		endpoint,
+		ShareSnapshotEditSpec,
+		assets.CloudV2OpenapiSchema,
+	); err != nil {
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
+		return
+	}
+
+	if !flags.WaitForTask {
+		return
+	}
+
+	ready, err := waitForCloudResourceReady(endpoint, 10*time.Minute)
+	if err != nil {
+		display.OutputError(&flags.OutputFormatConfig, "failed to wait for snapshot to be ready: %s", err)
+		return
+	}
+
+	display.OutputInfo(&flags.OutputFormatConfig, ready, "✅ Snapshot %s is now ready", args[1])
 }
 
 func DeleteShareSnapshot(_ *cobra.Command, args []string) {
@@ -477,11 +516,16 @@ func DeleteShareSnapshot(_ *cobra.Command, args []string) {
 		return
 	}
 
-	endpoint := fmt.Sprintf("/v2/publicCloud/project/%s/storage/file/snapshot/%s", projectID, url.PathEscape(args[1]))
+	if _, err := fetchShareSnapshot(projectID, args[0], args[1]); err != nil {
+		display.OutputError(&flags.OutputFormatConfig, "%s", err)
+		return
+	}
+
+	endpoint := fmt.Sprintf("%s/%s", shareSnapshotV2Endpoint(projectID), url.PathEscape(args[1]))
 	if err := httpLib.Client.Delete(endpoint, nil); err != nil {
 		display.OutputError(&flags.OutputFormatConfig, "failed to delete share snapshot: %s", err)
 		return
 	}
 
-	display.OutputInfo(&flags.OutputFormatConfig, nil, "✅ Snapshot %s deleted successfully from share %s", args[1], args[0])
+	display.OutputInfo(&flags.OutputFormatConfig, nil, "✅ Snapshot %s of share %s is being deleted", args[1], args[0])
 }

--- a/internal/services/cloud/parameter-samples/storage-file-share-snapshot-create.json
+++ b/internal/services/cloud/parameter-samples/storage-file-share-snapshot-create.json
@@ -1,0 +1,9 @@
+{
+  "targetSpec": {
+    "name": "my-share-snapshot",
+    "description": "My file share snapshot",
+    "share": {
+      "id": "00000000-0000-0000-0000-000000000000"
+    }
+  }
+}

--- a/internal/services/cloud/templates/cloud_storage_file_share_snapshot.tmpl
+++ b/internal/services/cloud/templates/cloud_storage_file_share_snapshot.tmpl
@@ -5,12 +5,12 @@ _{{index .Result "description"}}_
 
 ## General information
 
-**Name**:           {{index .Result "name"}}
-**Share ID**:       {{index .Result "shareId"}}
-**Share protocol**: {{index .Result "shareProtocol"}}
-**Share size**:     {{index .Result "shareSize"}}GB
-**Size**:           {{index .Result "size"}}GB
-**Status**:         {{index .Result "status"}}
+**Name**:           {{index .Result "currentState" "name"}}
+**Share ID**:       {{index .Result "currentState" "share" "id"}}
+**Share protocol**: {{index .Result "currentState" "shareProto"}}
+**Share size**:     {{index .Result "currentState" "shareSize"}}GB
+**Size**:           {{index .Result "currentState" "snapshotSize"}}GB
+**Status**:         {{index .Result "resourceStatus"}}
 **Created at**:     {{index .Result "createdAt"}}
 
 💡 Use option -o json or -o yaml to get the raw output with all information

--- a/internal/services/cloud/templates/cloud_storage_file_share_snapshot.tmpl
+++ b/internal/services/cloud/templates/cloud_storage_file_share_snapshot.tmpl
@@ -1,16 +1,15 @@
 🚀 Share Snapshot {{.ServiceName}}
 =======
+{{$state := index .Result "targetSpec"}}{{with index .Result "currentState"}}{{$state = .}}{{end}}
+{{with index $state "description"}}_{{.}}_
 
-_{{index .Result "description"}}_
+{{end}}## General information
 
-## General information
-
-**Name**:           {{index .Result "currentState" "name"}}
-**Share ID**:       {{index .Result "currentState" "share" "id"}}
-**Share protocol**: {{index .Result "currentState" "shareProto"}}
-**Share size**:     {{index .Result "currentState" "shareSize"}}GB
-**Size**:           {{index .Result "currentState" "snapshotSize"}}GB
-**Status**:         {{index .Result "resourceStatus"}}
-**Created at**:     {{index .Result "createdAt"}}
+{{with index $state "name"}}**Name**:       {{.}}
+{{end}}**Share ID**:   {{index $state "share" "id"}}
+**Status**:     {{index .Result "resourceStatus"}}
+{{with index .Result "currentState"}}**Region**:     {{index . "location" "region"}}
+**Size**:       {{index . "size"}}GB
+{{end}}**Created at**: {{index .Result "createdAt"}}
 
 💡 Use option -o json or -o yaml to get the raw output with all information


### PR DESCRIPTION
# Description

Migrates the file storage share snapshot commands to APIv2
(`/v2/publicCloud/project/{projectId}/storage/file/snapshot`) and aligns the embedded
`cloud_v2.json` schema with the published APIv2 schema.

Snapshot routes are project scoped in v2 (they are no longer nested under a share), so:

- The parent share is now referenced through `targetSpec.share.id`, and `snapshot list`
  filters the project-wide listing on it.
- `get`, `edit` and `delete` check that the requested snapshot really belongs to the share
  given on the command line, so a snapshot cannot be read or deleted through an unrelated
  share ID.
- The listing columns only read `targetSpec` and the root `resourceStatus`, so a snapshot
  that is still being created — and therefore has no `currentState` yet — is listed like
  any other one instead of aborting the whole listing.
- A snapshot inherits the region of its parent share: `targetSpec` has no `location`, so the
  extra `GET` on the share that was only there to resolve the region is gone.

Schema alignment (`internal/assets/api-schemas/cloud_v2.json`):

- `FileStorageSnapshotCurrentState`: `snapshotSize` renamed to `size`, `shareProto` and
  `shareSize` removed (they are not part of the contract).
- `FileStorageSnapshotTargetSpec`: `location` removed, `share` is the only required field.
- Request/response examples updated accordingly.

Command changes:

- `snapshot create` now goes through the shared creation helper, so it supports `--from-file`,
  `--init-file` and `--editor`, validates the payload client-side, and accepts `--wait`.
  Creation is asynchronous, so the default output now reports that creation *started*.
- `snapshot edit <share_id> <snapshot_id>` is added (`PUT`, name and description), with
  `--editor` and `--wait`.
- `snapshot delete` reports that the snapshot *is being deleted*, matching its asynchronous
  behavior.
- The `--region` persistent flag is removed: it only fed the v1 region discovery, which no
  longer exists now that every file storage route is project scoped.

The detail template only referenced fields that do not exist in the API and crashed on a
snapshot whose `currentState` is still null (right after creation); it now renders the real
fields and degrades gracefully.

Also removes 17 stale `doc/ovhcloud_cloud_storage-file_*.md` files left over from the
`storage-file` -> `storage file` command rename, and regenerates `doc/`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Improvement (improvement of existing commands)
- [x] Breaking change (fix or feature that can break a current behavior)
- [x] Documentation update

Breaking change: the `--region` flag of `ovhcloud cloud storage file` is removed.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have commented my code
- [x] I ran `go mod tidy`
- [ ] I have added tests that prove my fix is effective or that my feature works